### PR TITLE
Added functions to start/stop packet captures via subnet

### DIFF
--- a/src/go/util/printer/printer.go
+++ b/src/go/util/printer/printer.go
@@ -231,3 +231,14 @@ func PrintTableOfVLANRanges(writer io.Writer, info map[string][2]int) {
 
 	table.Render()
 }
+
+func PrintTableOfSubnetCaptures(writer io.Writer, captures []mm.Capture) {
+	table := tablewriter.NewWriter(writer)
+	table.SetHeader([]string{"Name", "Interface Index", "File Path"})
+
+	for _, capture := range captures {
+		table.Append([]string{capture.VM, strconv.Itoa(capture.Interface), capture.Filepath})
+	}
+
+	table.Render()
+}

--- a/src/go/web/proto/vm.proto
+++ b/src/go/web/proto/vm.proto
@@ -85,3 +85,12 @@ message MemorySnapshotResponse {
 	string disk = 1;
 	VM vm = 2;
 }
+
+message CaptureSubnetRequest {
+  string subnet = 1;
+  repeated string vms = 2;
+}
+
+message VMNameList {
+  repeated string vms = 1;
+}

--- a/src/go/web/server.go
+++ b/src/go/web/server.go
@@ -130,6 +130,8 @@ func Start(opts ...ServerOption) error {
 	api.HandleFunc("/experiments/{name}/schedule", GetExperimentSchedule).Methods("GET", "OPTIONS")
 	api.HandleFunc("/experiments/{name}/schedule", ScheduleExperiment).Methods("POST", "OPTIONS")
 	api.HandleFunc("/experiments/{name}/captures", GetExperimentCaptures).Methods("GET", "OPTIONS")
+	api.HandleFunc("/experiments/{exp}/captureSubnet", StartCaptureSubnet).Methods("POST", "OPTIONS")
+	api.HandleFunc("/experiments/{exp}/stopCaptureSubnet", StopCaptureSubnet).Methods("POST", "OPTIONS")
 	api.HandleFunc("/experiments/{name}/files", GetExperimentFiles).Methods("GET", "OPTIONS")
 	api.HandleFunc("/experiments/{name}/files/{filename}", GetExperimentFile).Methods("GET", "OPTIONS")
 	api.Handle("/experiments/{name}/scorch/components/{run}/{loop}/{stage}/{cmp}", weberror.ErrorHandler(scorch.GetComponentOutput)).Methods("GET", "OPTIONS")


### PR DESCRIPTION
This PR applies to #44.  Functions were added to both the Web UI and command line to enable starting/stopping packet captures via an ipv4 subnet.  

**Current Known Limitations:** Since the minimega capture cli does not currently allow packet captures to be stopped for a specific VM interface, when stopping packet captures for a subnet, all packet captures are stopped for all VMs with an interface in the specified subnet.  This is not the ideal behavior.  An issue has been submitted to the minimega respository https://github.com/sandia-minimega/minimega/issues/1447

**Web UI Examples**
Using the recently merged PR #41 (extended Web UI search), the search bar can be used to specify an ipv4 subnet.  When a valid ipv4 subnet is entered, the `play` button adjacent to the IPv4 label will be enabled.
![capture_start_enable](https://user-images.githubusercontent.com/75450207/118309402-35d57e00-b4bb-11eb-874b-785e206cddbf.JPG)

Once there are valid captures, the `stop` button adjacent to the `play` button will be enabled.
![show_capture_stop_button](https://user-images.githubusercontent.com/75450207/118309769-b8f6d400-b4bb-11eb-9a59-d0fe94eed97c.JPG)

To stop all packet captures for all subnets, the term `capturing` can be entered in the search bar.
![stop_all_subnets](https://user-images.githubusercontent.com/75450207/118310062-1b4fd480-b4bc-11eb-9419-608ea80514b7.png)

There were also command line equivalents added.  An optional filter can be specified on the command line that has the same syntax/keywords as the search terms entered in the Web UI search bar.

