### PR TITLE
Add support for building Kali image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN VER=${PHENIX_VERSION} COMMIT=${PHENIX_COMMIT} make bin/phenix
 RUN wget https://github.com/glattercj/vmdb2/releases/download/v1.0/vmdb2 -P bin/ \
   && chmod +x bin/vmdb2
 
-RUN git clone --branch main https://github.com/activeshadow/phenix-apps.git /phenix-apps
+RUN git clone --branch main https://github.com/sandia-minimega/phenix-apps.git /phenix-apps
 
 WORKDIR /phenix-apps/src/go
 
@@ -52,7 +52,7 @@ ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt update \
-  && apt install -y cpio git locales nano python3-pip systemd-container vim vmdb2 \
+  && apt install -y cpio debootstrap git locales nano python3-pip systemd-container vim vmdb2 \
   && locale-gen en_US.UTF-8 \
   && apt clean \
   && rm -rf /var/lib/apt/lists/* \
@@ -65,7 +65,10 @@ COPY --from=gobuilder /phenix/bin/phenix   /usr/local/bin/phenix
 COPY --from=gobuilder /phenix/bin/vmdb2    /usr/bin/vmdb2
 COPY --from=gobuilder /go/bin/phenix-app-* /usr/local/bin
 
-RUN python3 -m pip install "git+https://github.com/activeshadow/phenix-apps.git@main#egg=phenix-apps&subdirectory=src/python"
+RUN python3 -m pip install "git+https://github.com/sandia-minimega/phenix-apps.git@main#egg=phenix-apps&subdirectory=src/python"
+
+RUN wget -O kali.deb http://http.kali.org/kali/pool/main/k/kali-archive-keyring/kali-archive-keyring_2020.2_all.deb \
+	&& dpkg -i kali.deb && rm kali.deb
 
 RUN echo "root:t00r" | chpasswd
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,11 +6,6 @@ x-common: &common
     options:
       max-file: "5"
       max-size: "10m"
-x-minimega-bin-volume:
-  &minimega-bin-volume
-  type: bind
-  source: ./minimega-overlays
-  target: /usr/local/share/minimega/overlays
 services:
   phenix:
     build:
@@ -37,10 +32,9 @@ services:
       - /sys:/sys
       - /phenix:/phenix
       - /etc/phenix:/etc/phenix
-      - /tmp/minimega:/tmp/minimega
+      - /tmp:/tmp
       - /var/log/phenix:/var/log/phenix
       - /etc/localtime:/etc/localtime:ro
-      - *minimega-bin-volume
     depends_on:
       - minimega
     healthcheck:
@@ -76,7 +70,6 @@ services:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /root/.ssh:/root/.ssh:ro
       - /etc/localtime:/etc/localtime:ro
-      - *minimega-bin-volume
     healthcheck:
       test: minimega -e version
 networks:

--- a/docker/minimega/minimega.service
+++ b/docker/minimega/minimega.service
@@ -11,10 +11,6 @@ Environment="MM_DEGREE=2"
 Environment="MM_CONTEXT=minimega"
 Environment="MM_LOGLEVEL=info"
 Environment="MM_LOGFILE=/var/log/minimega.log"
-ExecStartPre=-/bin/mkdir -p /usr/local/share/minimega/overlays/miniccc/opt/minimega/bin
-ExecStartPre=-/bin/mkdir -p /usr/local/share/minimega/overlays/protonuke/opt/minimega/bin
-ExecStartPre=-/bin/cp /opt/minimega/bin/miniccc /usr/local/share/minimega/overlays/miniccc/opt/minimega/bin
-ExecStartPre=-/bin/cp /opt/minimega/bin/protonuke /usr/local/share/minimega/overlays/protonuke/opt/minimega/bin
 ExecStart=/usr/bin/minimega \
   -force \
   -nostdin \

--- a/src/go/api/config/default/kali.yml
+++ b/src/go/api/config/default/kali.yml
@@ -1,0 +1,86 @@
+apiVersion: phenix.sandia.gov/v1
+kind: Image
+metadata:
+  name: kali
+spec:
+  compress: true
+  deb_append: ' --components=main,contrib,non-free'
+  format: qcow2
+  mirror: http://http.kali.org/kali
+  overlays: null
+  packages:
+  - initramfs-tools
+  - net-tools
+  - isc-dhcp-client
+  - openssh-server
+  - init
+  - iputils-ping
+  - vim
+  - less
+  - netbase
+  - curl
+  - ifupdown
+  - dbus
+  - linux-image-amd64
+  - linux-headers-amd64
+  - xserver-xorg
+  - kali-desktop-xfce
+  ramdisk: false
+  release: kali
+  script_order:
+  - POSTBUILD_APT_CLEANUP
+  - POSTBUILD_NO_ROOT_PASSWD
+  - POSTBUILD_PHENIX_HOSTNAME
+  - POSTBUILD_PHENIX_BASE
+  scripts:
+    POSTBUILD_APT_CLEANUP: |
+      apt clean || apt-get clean || echo "unable to clean apt cache"
+    POSTBUILD_NO_ROOT_PASSWD: |
+      sed -i 's/nullok_secure/nullok/' /etc/pam.d/common-auth
+      sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+      sed -i 's/#PermitEmptyPasswords no/PermitEmptyPasswords yes/' /etc/ssh/sshd_config
+      sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+      sed -i 's/PermitEmptyPasswords no/PermitEmptyPasswords yes/' /etc/ssh/sshd_config
+      passwd -d root
+    POSTBUILD_PHENIX_BASE: |
+      cat > /etc/systemd/system/phenix.service <<EOF
+      [Unit]
+      Description=phenix startup service
+      After=network.target systemd-hostnamed.service
+      [Service]
+      Environment=LD_LIBRARY_PATH=/usr/local/lib
+      ExecStart=/usr/local/bin/phenix-start.sh
+      RemainAfterExit=true
+      StandardOutput=journal
+      Type=oneshot
+      [Install]
+      WantedBy=multi-user.target
+      EOF
+      mkdir -p /etc/systemd/system/multi-user.target.wants
+      ln -s /etc/systemd/system/phenix.service /etc/systemd/system/multi-user.target.wants/phenix.service
+      mkdir -p /usr/local/bin
+      cat > /usr/local/bin/phenix-start.sh <<EOF
+      #!/bin/bash
+      for file in /etc/phenix/startup/*; do
+      echo \$file
+      bash \$file
+      done
+      EOF
+      chmod +x /usr/local/bin/phenix-start.sh
+      mkdir -p /etc/phenix/startup
+    POSTBUILD_PHENIX_HOSTNAME: |
+      echo "phenix" > /etc/hostname
+      sed -i 's/127.0.1.1 .*/127.0.1.1 phenix/' /etc/hosts
+      cat > /etc/motd <<EOF
+
+      ██████╗ ██╗  ██╗███████╗███╗  ██╗██╗██╗  ██╗
+      ██╔══██╗██║  ██║██╔════╝████╗ ██║██║╚██╗██╔╝
+      ██████╔╝███████║█████╗  ██╔██╗██║██║ ╚███╔╝
+      ██╔═══╝ ██╔══██║██╔══╝  ██║╚████║██║ ██╔██╗
+      ██║     ██║  ██║███████╗██║ ╚███║██║██╔╝╚██╗
+      ╚═╝     ╚═╝  ╚═╝╚══════╝╚═╝  ╚══╝╚═╝╚═╝  ╚═╝
+
+      EOF
+      echo "\nBuilt with phenix image on $(date)\n\n" >> /etc/motd
+  size: 10G
+  variant: minbase

--- a/src/go/api/config/default/minirouter.yml
+++ b/src/go/api/config/default/minirouter.yml
@@ -1,0 +1,107 @@
+apiVersion: phenix.sandia.gov/v1
+kind: Image
+metadata:
+  name: minirouter
+spec:
+  compress: false
+  deb_append: ' --components=main,restricted,universe,multiverse'
+  format: qcow2
+  include_miniccc: true
+  mirror: http://us.archive.ubuntu.com/ubuntu/
+  overlays: null
+  packages:
+  - bird
+  - curl
+  - dbus
+  - dnsmasq
+  - dnsutils
+  - ethtool
+  - ifupdown
+  - init
+  - initramfs-tools
+  - iptables
+  - iputils-ping
+  - isc-dhcp-client
+  - less
+  - linux-headers-generic
+  - linux-image-generic
+  - net-tools
+  - netbase
+  - netcat-openbsd
+  - openssh-server
+  - tcpdump
+  - telnet
+  - traceroute
+  - wget
+  - vim
+  ramdisk: false
+  release: focal
+  script_order:
+  - POSTBUILD_APT_CLEANUP
+  - POSTBUILD_NO_ROOT_PASSWD
+  - POSTBUILD_DISABLE_SERVICES
+  - POSTBUILD_ENABLE_IPFORWARDING
+  - POSTBUILD_PHENIX_HOSTNAME
+  - POSTBUILD_PHENIX_BASE
+  scripts:
+    POSTBUILD_APT_CLEANUP: |
+      apt clean || apt-get clean || echo "unable to clean apt cache"
+    POSTBUILD_NO_ROOT_PASSWD: |
+      sed -i 's/nullok_secure/nullok/' /etc/pam.d/common-auth
+      sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+      sed -i 's/#PermitEmptyPasswords no/PermitEmptyPasswords yes/' /etc/ssh/sshd_config
+      sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+      sed -i 's/PermitEmptyPasswords no/PermitEmptyPasswords yes/' /etc/ssh/sshd_config
+      passwd -d root
+    POSTBUILD_DISABLE_SERVICES: |
+      rm /etc/systemd/system/multi-user.target.wants/systemd-resolved.service
+      rm /etc/systemd/system/multi-user.target.wants/dnsmasq.service
+      rm /etc/systemd/system/multi-user.target.wants/bird.service
+      rm /etc/systemd/system/multi-user.target.wants/bird6.service
+    POSTBUILD_ENABLE_IPFORWARDING: |
+      cat > /etc/sysctl.d/local.conf <<EOF
+      net.ipv4.ip_forward = 1
+      net.ipv6.conf.all.forwarding = 1
+      EOF
+    POSTBUILD_PHENIX_HOSTNAME: |
+      echo "phenix" > /etc/hostname
+      sed -i 's/127.0.1.1 .*/127.0.1.1 phenix/' /etc/hosts
+      cat > /etc/motd <<EOF
+
+      ██████╗ ██╗  ██╗███████╗███╗  ██╗██╗██╗  ██╗
+      ██╔══██╗██║  ██║██╔════╝████╗ ██║██║╚██╗██╔╝
+      ██████╔╝███████║█████╗  ██╔██╗██║██║ ╚███╔╝
+      ██╔═══╝ ██╔══██║██╔══╝  ██║╚████║██║ ██╔██╗
+      ██║     ██║  ██║███████╗██║ ╚███║██║██╔╝╚██╗
+      ╚═╝     ╚═╝  ╚═╝╚══════╝╚═╝  ╚══╝╚═╝╚═╝  ╚═╝
+
+      EOF
+      echo "\nBuilt with love using phenix image on $(date)\n\n" >> /etc/motd
+    POSTBUILD_PHENIX_BASE: |
+      cat > /etc/systemd/system/phenix.service <<EOF
+      [Unit]
+      Description=phenix startup service
+      After=network.target systemd-hostnamed.service
+      [Service]
+      Environment=LD_LIBRARY_PATH=/usr/local/lib
+      ExecStart=/usr/local/bin/phenix-start.sh
+      RemainAfterExit=true
+      StandardOutput=journal
+      Type=oneshot
+      [Install]
+      WantedBy=multi-user.target
+      EOF
+      mkdir -p /etc/systemd/system/multi-user.target.wants
+      ln -s /etc/systemd/system/phenix.service /etc/systemd/system/multi-user.target.wants/phenix.service
+      mkdir -p /usr/local/bin
+      cat > /usr/local/bin/phenix-start.sh <<EOF
+      #!/bin/bash
+      for file in /etc/phenix/startup/*; do
+        echo \$file
+        bash \$file
+      done
+      EOF
+      chmod +x /usr/local/bin/phenix-start.sh
+      mkdir -p /etc/phenix/startup
+  size: 5G
+  variant: minbase

--- a/src/go/cmd/image.go
+++ b/src/go/cmd/image.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -273,7 +272,7 @@ func newImageBuildCmd() *cobra.Command {
 				verbosity = verbosity | image.V_VVVERBOSE
 			}
 
-			ctx := context.Background()
+			ctx := util.WarningContext(nil)
 
 			if err := image.Build(ctx, name, verbosity, cache, dryrun, output); err != nil {
 				err := util.HumanizeError(err, "Unable to build the "+name+" image")
@@ -456,40 +455,65 @@ func newImageUpdateCmd() *cobra.Command {
 func newImageInjectMinicccCmd() *cobra.Command {
 	desc := `Inject the miniccc agent into a disk image
 
-	Used to add the miniccc agent and relevant boot scripts into an existing
-	disk image. The disk operating system is guessed based on the provided
-	agent's extension. When specifying the path to the disk to modify, the
-	partition to inject into can optionally be included at the end of the path
-	using a colon (for example, /phenix/images/foo.qc2:2). If not specified,
-	partition 1 will be assumed.
-
-	In a Windows disk image, the miniccc agent and the PowerShell script to run
-	the miniccc agent will be injected into C:\miniccc, and a scheduler command
-	will be placed into the Windows StartUp directory.
-
-	In a Linux disk image, the miniccc agent will be injected into
-	/usr/local/bin and the service file and symlinks will be injected into the
-	appropriate locations, depending on which init system is being used. For
-	systemd, they will be injected into /etc/systemd/system, and for sysinitv
-	they will be injected into /etc/init.d and /etc/rc5.d.`
+	This subcommand has been DEPRECATED. Please use inject-miniexe instead.`
 
 	cmd := &cobra.Command{
 		Use:   "inject-miniccc <path to miniccc> <path to disk>",
-		Short: "Inject the miniccc agent into a disk image",
+		Short: "Inject the miniccc agent into a disk image (DEPRECATED)",
+		Long:  desc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("inject-miniccc has been deprecated - please use inject-miniexe instead")
+		},
+	}
+
+	return cmd
+}
+
+func newImageInjectMiniExeCmd() *cobra.Command {
+	desc := `Inject a minimega executable into a disk image
+
+	Used to add a minimega executable (miniccc, protonuke, or minirouter) and
+	relevant boot scripts into an existing disk image. The disk operating system
+	is guessed based on the provided agent's extension. When specifying the path
+	to the disk to modify, the partition to inject into can optionally be included
+	at the end of the path using a colon (for example, /phenix/images/foo.qc2:2).
+	If not specified, partition 1 will be assumed.
+
+	In a Windows disk image, the minimega executable will be injected into
+	C:\[miniccc,protonuke]. A scheduler command will be placed into the Windows
+	Startup directory for miniccc, but not for protonuke, since protonuke's
+	command line arguments are dynamic. Users or apps wishing to leverage
+	protonuke on Windows hosts need to inject their own scheduler command in the
+	Windows Startup directory or use miniccc to start protonuke.
+
+	In a Linux disk image, the minimega executable will be injected into
+	/usr/local/bin and the service file and symlinks will be injected into the
+	appropriate locations, depending on which init system is being used. For
+	systemd, they will be injected into /etc/systemd/system, and for sysinitv they
+	will be injected into /etc/init.d and /etc/rc5.d. The protonuke service will
+	only start if a file is present at /etc/default/protonuke, and that file
+	should contain a single line setting the PROTONUKE_ARGS variable to a set of
+	protonuke command line arguments. The minirouter service expects the miniccc
+	service to be injected, and injecting minirouter will automatically cause
+	miniccc to be injected as well.`
+
+	cmd := &cobra.Command{
+		Use:   "inject-miniexe <path to exe> <path to disk>",
+		Short: "Inject a minimega executable into a disk image",
 		Long:  desc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
-				return fmt.Errorf("The path to miniccc and the disk is required")
+				return fmt.Errorf("The path to the minimega executable and the disk is required")
 			}
 
 			var (
-				agent = args[0]
-				disk  = args[1]
-				init  = MustGetString(cmd.Flags(), "init-system")
+				exe  = args[0]
+				disk = args[1]
+				init = MustGetString(cmd.Flags(), "init-system")
 			)
 
-			if err := image.InjectMiniccc(agent, disk, init); err != nil {
-				err := util.HumanizeError(err, "Unable to inject miniccc into the "+disk+" image")
+			if err := image.InjectMiniExe(exe, disk, init); err != nil {
+				err := util.HumanizeError(err, "Unable to inject "+exe+" into the "+disk+" image")
 				return err.Humanized()
 			}
 
@@ -514,6 +538,7 @@ func init() {
 	imageCmd.AddCommand(newImageRemoveCmd())
 	imageCmd.AddCommand(newImageUpdateCmd())
 	imageCmd.AddCommand(newImageInjectMinicccCmd())
+	imageCmd.AddCommand(newImageInjectMiniExeCmd())
 
 	rootCmd.AddCommand(imageCmd)
 }

--- a/src/go/tmpl/templates/minirouter/minirouter.init
+++ b/src/go/tmpl/templates/minirouter/minirouter.init
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides: minirouter startup
+# Required-Start:	$syslog $local_fs 
+# Required-Stop:	$syslog $local_fs 
+# Default-Start:	5
+# Default-Stop:		0 1 6
+# Short-Description: minirouter Agent
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+PROG=minirouter
+PIDFILE=/var/run/$PROG.pid
+DESC="minirouter Agent"
+
+start() {
+	log_daemon_msg "Starting $DESC" "$PROG"
+	start_daemon -p $PIDFILE /usr/local/bin/$PROG -miniccc /usr/local/bin/miniccc
+
+	if [ $? -ne 0 ]; then
+		log_end_msg 1
+		exit 1
+	fi
+
+	if [ $? -eq 0 ]; then
+		log_end_msg 0
+	fi
+
+	exit 0
+}
+
+stop() {
+	log_daemon_msg "Stopping $DESC" "$PROG"
+	killproc -p $PIDFILE
+
+	if [ $? -ne 0 ]; then
+		log_end_msg 1
+		exit 1
+	fi
+
+	if [ $? -eq 0 ]; then
+		log_end_msg 0
+	fi
+
+	exit 0
+}
+
+force_reload() {
+	stop
+	start
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	force-reload)
+		force_reload
+		;;
+	restart)
+		stop
+		start
+		;;
+	*)
+		echo "$Usage: $prog {start|stop|force-reload|restart}"
+		exit 2
+esac

--- a/src/go/tmpl/templates/minirouter/minirouter.service
+++ b/src/go/tmpl/templates/minirouter/minirouter.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=minirouter Agent
+
+[Service]
+ExecStart=/usr/local/bin/minirouter -miniccc /usr/local/bin/miniccc
+
+[Install]
+WantedBy=multi-user.target

--- a/src/go/tmpl/templates/protonuke/protonuke.init
+++ b/src/go/tmpl/templates/protonuke/protonuke.init
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides: protonuke startup
+# Required-Start:	$syslog $local_fs 
+# Required-Stop:	$syslog $local_fs 
+# Default-Start:	5
+# Default-Stop:		0 1 6
+# Short-Description: protonuke Agent
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+PROG=protonuke
+PIDFILE=/var/run/$PROG.pid
+DESC="protonuke Agent"
+
+start() {
+	log_daemon_msg "Starting $DESC" "$PROG"
+
+	if [ -f /etc/default/protonuke ]; then
+		. /etc/default/protonuke
+	else
+		log_daemon_msg "Failed to start $PROG - missing /etc/default/protonuke file"
+		log_end_msg 1
+		exit 1
+	fi
+
+	start_daemon -p $PIDFILE /usr/local/bin/$PROG $PROTONUKE_ARGS
+
+	if [ $? -ne 0 ]; then
+		log_end_msg 1
+		exit 1
+	fi
+
+	if [ $? -eq 0 ]; then
+		log_end_msg 0
+	fi
+
+	exit 0
+}
+
+stop() {
+	log_daemon_msg "Stopping $DESC" "$PROG"
+	killproc -p $PIDFILE
+
+	if [ $? -ne 0 ]; then
+		log_end_msg 1
+		exit 1
+	fi
+
+	if [ $? -eq 0 ]; then
+		log_end_msg 0
+	fi
+
+	exit 0
+}
+
+force_reload() {
+	stop
+	start
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	force-reload)
+		force_reload
+		;;
+	restart)
+		stop
+		start
+		;;
+	*)
+		echo "$Usage: $prog {start|stop|force-reload|restart}"
+		exit 2
+esac

--- a/src/go/tmpl/templates/protonuke/protonuke.service
+++ b/src/go/tmpl/templates/protonuke/protonuke.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=protonuke Agent
+
+[Service]
+ConditionPathExists=/etc/default/protonuke
+EnvironmentFile=/etc/default/protonuke
+ExecStart=/usr/local/bin/protonuke ${PROTONUKE_ARGS}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
* Added default image config for Kali
* Updated Dockerfile to include Kali Archive keyring

This commit also includes some updates to image building in general.

* Print deprecation warning for inject_miniccc and inject_protonuke
* Added inject-miniexe subcommand for miniccc, protonuke, and minirouter
* Deprecated inject-miniccc in favor of inject-miniexe

closes #31