### PR TITLE
Search experiment files for running/stopped views

### DIFF
--- a/src/go/api/experiment/experiment.go
+++ b/src/go/api/experiment/experiment.go
@@ -675,12 +675,13 @@ func Delete(name string) error {
 	return errors
 }
 
-func Files(name string) ([]string, error) {
-	return file.GetExperimentFileNames(name)
+func Files(name, filter string) (file.ExperimentFiles, error) {
+
+	return file.GetExperimentFileNames(name, filter)
 }
 
 func File(name, fileName string) ([]byte, error) {
-	files, err := file.GetExperimentFileNames(name)
+	files, err := file.GetExperimentFileNames(name, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting list of experiment files: %w", err)
 	}
@@ -692,12 +693,12 @@ func File(name, fileName string) ([]byte, error) {
 	}
 
 	for _, f := range files {
-		if fileName == f {
+		if fileName == f.Name {
 			headnode, _ := os.Hostname()
 
-			file.CopyFile(headnode, fmt.Sprintf("/%s/files/%s", name, f), nil)
+			file.CopyFile(headnode, fmt.Sprintf("/%s/files/%s", name, f.Name), nil)
 
-			path := fmt.Sprintf("%s/images/%s/files/%s", common.PhenixBase, name, f)
+			path := fmt.Sprintf("%s/images/%s/files/%s", common.PhenixBase, name, f.Name)
 
 			data, err := ioutil.ReadFile(path)
 			if err != nil {

--- a/src/go/internal/file/search.go
+++ b/src/go/internal/file/search.go
@@ -1,0 +1,498 @@
+package file
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/activeshadow/libminimega/minilog"
+)
+
+var (
+	dateRe                     = regexp.MustCompile(`[<>=][ ]?\d{4}[-](?:[^\n]+)?`)
+	sizeRe                     = regexp.MustCompile(`[<>=][ ]?\d+[ ]?(?:kb|mb|gb)?`)
+	categoryRe                 = regexp.MustCompile(`^(?:packet|elf|vm)`)
+	comparisonOps              = regexp.MustCompile(`[<>=]{1,2}`)
+	fileSizeSpec               = regexp.MustCompile(`(?:kb|mb|gb)`)
+	boolOps                    = regexp.MustCompile(`^(?:and|or|not)$`)
+	groups                     = regexp.MustCompile(`(?:[(][^ ])|(?:[^ ][)])`)
+	keywordEscape              = regexp.MustCompile(`['"]([^'"]+)['"]`)
+	defaultSearchFields        = []string{"Name", "Category"}
+	spaceReplacement    string = "-sp-32-sp-"
+)
+
+type Stack struct {
+	s []interface{}
+}
+
+func (s *Stack) Push(item interface{}) {
+	s.s = append(s.s, item)
+
+}
+
+func (s *Stack) Pop() interface{} {
+	if s.IsEmpty() {
+		return nil
+	}
+
+	lastItem := s.s[len(s.s)-1]
+	s.s = s.s[:len(s.s)-1]
+
+	return lastItem
+
+}
+
+func (s *Stack) IsEmpty() bool {
+	return len(s.s) == 0
+
+}
+
+type ExpressionTree struct {
+	left         *ExpressionTree
+	right        *ExpressionTree
+	term         string
+	searchFields []string
+}
+
+func (node *ExpressionTree) PrintTree() {
+
+	if node == nil {
+		return
+	}
+
+	node.left.PrintTree()
+	node.right.PrintTree()
+
+}
+
+func BuildTree(searchFilter string) *ExpressionTree {
+
+	if len(searchFilter) == 0 {
+		return nil
+	}
+
+	// Adjust any parentheses so that they are
+	// space delimited
+	if groups.MatchString(searchFilter) {
+		searchFilter = strings.ReplaceAll(searchFilter, "(", "( ")
+		searchFilter = strings.ReplaceAll(searchFilter, ")", " )")
+	}
+
+	searchString := strings.ToLower(searchFilter)
+
+	// Add any placeholder spaces
+
+	// The date string will be a special case as we
+	// to replace the 1st space and the 2nd space with
+	// different placeholders
+	if dateRe.MatchString(searchString) {
+		original := dateRe.FindAllStringSubmatch(searchString, -1)[0][0]
+
+		replacement := strings.Replace(original, " ", spaceReplacement, 1)
+		replacement = strings.ReplaceAll(replacement, " ", "_")
+		searchString = strings.ReplaceAll(searchString, original, replacement)
+
+	}
+
+	searchString = addPlaceholderSpaces(searchString, sizeRe)
+	searchString = addPlaceholderSpaces(searchString, categoryRe)
+
+	stringParts := strings.Split(searchString, " ")
+
+	// If no operators were found, assume a default
+	// operator of "and"
+	match := false
+	for _, part := range stringParts {
+		if boolOps.MatchString(part) {
+			match = true
+			break
+		}
+
+	}
+
+	if !match {
+		tmp := strings.Join(stringParts, " and ")
+		stringParts = strings.Split(tmp, " ")
+	}
+
+	postFix, err := postfix(stringParts)
+	log.Debug("Postfix:%v", postFix)
+
+	if err != nil {
+		return nil
+	}
+
+	// If the only term that was passed in
+	// is a boolean operator, then skip
+	// building the tree
+	if len(postFix) == 1 {
+		if boolOps.MatchString(postFix[0]) {
+			return nil
+		}
+	}
+
+	expressionTree, err := createTree(postFix)
+
+	if err != nil {
+		return nil
+	}
+
+	return expressionTree
+
+}
+
+func (node *ExpressionTree) Evaluate(experimentFile *ExperimentFile) bool {
+
+	if node == nil {
+		return false
+	}
+
+	if node.left == nil && node.right == nil {
+		return node.match(experimentFile)
+
+	}
+
+	rightSide := false
+	if node.right != nil {
+		rightSide = node.right.Evaluate(experimentFile)
+	}
+
+	leftSide := false
+	if node.left != nil {
+		leftSide = node.left.Evaluate(experimentFile)
+	}
+
+	switch node.term {
+	case "and":
+		return rightSide && leftSide
+
+	case "or":
+		return rightSide || leftSide
+
+	case "not":
+		return !rightSide
+	}
+
+	return false
+
+}
+
+// Shunting yard algorithm by Edsger Dijkstra
+// for putting search terms and operators into
+// postfix notation
+func postfix(terms []string) ([]string, error) {
+
+	var output []string
+	opStack := new(Stack)
+
+	for _, term := range terms {
+
+		if len(term) == 0 {
+			continue
+		}
+
+		if boolOps.MatchString(term) || term == "(" {
+			opStack.Push(term)
+
+		} else if term == ")" {
+			token := ""
+			for token != "(" {
+				if tmpToken, ok := opStack.Pop().(string); !ok {
+					return output, fmt.Errorf("Error: type assertion parsing token")
+				} else {
+					token = tmpToken
+				}
+
+				if token != "(" {
+					output = append(output, token)
+				}
+
+			}
+
+		} else {
+
+			output = append(output, term)
+
+		}
+
+	}
+
+	for !opStack.IsEmpty() {
+
+		if token, ok := opStack.Pop().(string); !ok {
+			return output, fmt.Errorf("Error: type assertion parsing token")
+		} else {
+			output = append(output, token)
+		}
+
+	}
+
+	return output, nil
+
+}
+
+func createTree(postFix []string) (*ExpressionTree, error) {
+
+	stack := new(Stack)
+
+	for _, term := range postFix {
+
+		if boolOps.MatchString(term) {
+			opTree := new(ExpressionTree)
+			opTree.term = term
+
+			if t1, ok := stack.Pop().(*ExpressionTree); !ok {
+				return nil, fmt.Errorf("Error: type assertion parsing token")
+			} else {
+				opTree.right = t1
+			}
+
+			if !stack.IsEmpty() && term != "not" {
+
+				if t2, ok := stack.Pop().(*ExpressionTree); !ok {
+					return nil, fmt.Errorf("Error: type assertion parsing token")
+				} else {
+					opTree.left = t2
+				}
+
+			}
+
+			stack.Push(opTree)
+
+		} else {
+
+			operand := new(ExpressionTree)
+			if keywordEscape.MatchString(term) {
+				operand.term = keywordEscape.FindAllStringSubmatch(term, -1)[0][1]
+				operand.searchFields = defaultSearchFields
+			} else {
+				operand.term = term
+
+				// Replace any space placeholders to return
+				// the correct search fields
+				operand.term = strings.ReplaceAll(operand.term, spaceReplacement, "")
+
+				operand.searchFields = getSearchFields(operand.term)
+
+			}
+
+			stack.Push(operand)
+
+		}
+
+	}
+
+	if expressionTree, ok := stack.Pop().(*ExpressionTree); !ok {
+		return nil, fmt.Errorf("Error: type assertion parsing token")
+	} else {
+		return expressionTree, nil
+	}
+
+}
+
+func getSearchFields(term string) []string {
+
+	if dateRe.MatchString(term) {
+		return []string{"Date"}
+
+	} else if sizeRe.MatchString(term) {
+		return []string{"Size"}
+
+	} else if categoryRe.MatchString(term) {
+		return []string{"Category"}
+
+	} else {
+		return defaultSearchFields
+
+	}
+
+}
+
+func (node *ExpressionTree) match(file *ExperimentFile) bool {
+
+	for _, field := range node.searchFields {
+		switch field {
+		case "Date":
+			{
+				var (
+					compOp  string
+					newTerm string
+					layout  string
+				)
+
+				// Try to determine the date format
+				switch numHyphens := strings.Count(node.term, "-"); numHyphens {
+				case 1:
+					layout = "2006-01"
+
+				case 2:
+					switch numColons := strings.Count(node.term, ":"); numColons {
+					case 0:
+						layout = "2006-01-02"
+						if strings.Contains(node.term, "_") {
+							layout = "2006-01-02_15"
+						}
+					case 1:
+						layout = "2006-01-02_15:04"
+					case 2:
+						layout = "2006-01-02_15:04:05"
+					}
+
+				}
+
+				if comparisonOps.MatchString(node.term) {
+					compOp = comparisonOps.FindAllStringSubmatch(node.term, -1)[0][0]
+					newTerm = comparisonOps.ReplaceAllString(node.term, "")
+				}
+
+				// Make sure a valid comparison operator was found
+				if len(compOp) == 0 {
+					return false
+				}
+
+				t, err := time.Parse(layout, newTerm)
+				if err != nil {
+					return false
+				}
+
+				switch compOp {
+				case "<":
+					return file.DateTime.Before(t)
+				case ">":
+					return file.DateTime.After(t)
+				case "=":
+					return dateTimeEqual(file.DateTime, t, layout)
+				case ">=":
+					return file.DateTime.After(t) || dateTimeEqual(file.DateTime, t, layout)
+				case "<=":
+					return file.DateTime.Before(t) || dateTimeEqual(file.DateTime, t, layout)
+
+				}
+
+			}
+		case "Size":
+			{
+				var (
+					compOp   string
+					newTerm  string
+					fileSize interface{}
+					err      error
+				)
+
+				if comparisonOps.MatchString(node.term) {
+					compOp = comparisonOps.FindAllStringSubmatch(node.term, -1)[0][0]
+					newTerm = comparisonOps.ReplaceAllString(node.term, "")
+				}
+
+				// Make sure a valid comparison operator was found
+				if len(compOp) == 0 {
+					return false
+				}
+
+				if fileSizeSpec.MatchString(node.term) {
+					spec := fileSizeSpec.FindAllStringSubmatch(newTerm, -1)[0][0]
+					newTerm = fileSizeSpec.ReplaceAllString(newTerm, "")
+
+					fileSize, err = strconv.Atoi(newTerm)
+					if err != nil {
+						return false
+					}
+
+					switch spec {
+					case "kb":
+						fileSize = fileSize.(int) * int(math.Pow10(3))
+					case "mb":
+						fileSize = fileSize.(int) * int(math.Pow10(6))
+					case "gb":
+						fileSize = fileSize.(int) * int(math.Pow10(9))
+					}
+
+				}
+
+				// Check if fileSize has already been converted to an int
+				if _, ok := fileSize.(int); !ok {
+
+					fileSize, err = strconv.Atoi(newTerm)
+					if err != nil {
+						return false
+					}
+
+				}
+
+				switch compOp {
+				case "<":
+					return file.Size < fileSize.(int)
+				case ">":
+					return file.Size > fileSize.(int)
+				case "=":
+					return file.Size == fileSize.(int)
+				case ">=":
+					return file.Size > fileSize.(int) || file.Size == fileSize.(int)
+				case "<=":
+					return file.Size < fileSize.(int) || file.Size == fileSize.(int)
+
+				}
+
+			}
+		case "Category":
+			{
+				match := strings.Contains(strings.ToLower(file.Category), node.term)
+				if match {
+					return match
+				}
+
+				continue
+			}
+		case "Name":
+			{
+				match := strings.Contains(strings.ToLower(file.Name), node.term)
+				if match {
+					return match
+				}
+
+				continue
+			}
+
+		}
+	}
+
+	return false
+}
+
+func dateTimeEqual(t, t1 time.Time, layout string) bool {
+
+	switch layout {
+	case "2006-01":
+		return t.Year() == t1.Year() && t.Month() == t1.Month()
+	case "2006-01-02":
+		return t.Year() == t1.Year() && t.Month() == t1.Month() && t.Day() == t1.Day()
+	case "2006-01-02_15":
+		yearMonthDay := t.Year() == t1.Year() && t.Month() == t1.Month() && t.Day() == t1.Day()
+		return yearMonthDay && t.Hour() == t1.Hour()
+	case "2006-01-02_15:04":
+		yearMonthDay := t.Year() == t1.Year() && t.Month() == t1.Month() && t.Day() == t1.Day()
+		return yearMonthDay && t.Hour() == t1.Hour() && t.Minute() == t1.Minute()
+	case "2006-01-02_15:04:05":
+		yearMonthDay := t.Year() == t1.Year() && t.Month() == t1.Month() && t.Day() == t1.Day()
+		return yearMonthDay && t.Hour() == t1.Hour() && t.Minute() == t1.Minute() && t.Second() == t1.Second()
+	}
+
+	return false
+
+}
+
+func addPlaceholderSpaces(searchString string, pattern *regexp.Regexp) string {
+
+	// Replace spaces with the replacement string
+	if pattern.MatchString(searchString) {
+		extracted := pattern.FindAllStringSubmatch(searchString, -1)[0][0]
+		replacement := strings.ReplaceAll(extracted, " ", spaceReplacement)
+		return strings.ReplaceAll(searchString, extracted, replacement)
+
+	}
+
+	return searchString
+}

--- a/src/go/internal/file/types.go
+++ b/src/go/internal/file/types.go
@@ -1,5 +1,11 @@
 package file
 
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
 type ImageKind int
 type CopyStatus func(float64)
 
@@ -14,4 +20,86 @@ type ImageDetails struct {
 	Name     string
 	FullPath string
 	Size     int
+}
+
+type ExperimentFile struct {
+	Name     string
+	Date     string
+	Size     int
+	Category string
+
+	// Internal use to aid in sorting
+	DateTime time.Time
+}
+
+type ExperimentFiles []ExperimentFile
+
+func (this ExperimentFiles) SortByName(asc bool) {
+	sort.Slice(this, func(i, j int) bool {
+		if asc {
+			return strings.ToLower(this[i].Name) < strings.ToLower(this[j].Name)
+		}
+
+		return strings.ToLower(this[i].Name) > strings.ToLower(this[j].Name)
+	})
+}
+
+func (this ExperimentFiles) SortByDate(asc bool) {
+	sort.Slice(this, func(i, j int) bool {
+		if asc {
+			return this[i].DateTime.Before(this[j].DateTime)
+		}
+
+		return this[i].DateTime.After(this[j].DateTime)
+	})
+}
+
+func (this ExperimentFiles) SortBySize(asc bool) {
+	sort.Slice(this, func(i, j int) bool {
+		if asc {
+			return this[i].Size < this[j].Size
+		}
+
+		return this[i].Size > this[j].Size
+	})
+}
+
+func (this ExperimentFiles) SortByCategory(asc bool) {
+	sort.Slice(this, func(i, j int) bool {
+		if asc {
+			return strings.ToLower(this[i].Category) < strings.ToLower(this[j].Category)
+		}
+
+		return strings.ToLower(this[i].Category) > strings.ToLower(this[j].Category)
+	})
+}
+
+func (this ExperimentFiles) SortBy(col string, asc bool) {
+	switch col {
+	case "name":
+		this.SortByName(asc)
+	case "date":
+		this.SortByDate(asc)
+	case "size":
+		this.SortBySize(asc)
+	case "category":
+		this.SortByCategory(asc)
+	}
+}
+
+func (this ExperimentFiles) Paginate(page, size int) ExperimentFiles {
+	var (
+		start = (page - 1) * size
+		end   = start + size
+	)
+
+	if start >= len(this) {
+		return ExperimentFiles{}
+	}
+
+	if end > len(this) {
+		end = len(this)
+	}
+
+	return this[start:end]
 }

--- a/src/go/web/handlers.go
+++ b/src/go/web/handlers.go
@@ -798,10 +798,16 @@ func GetExperimentFiles(w http.ResponseWriter, r *http.Request) {
 	log.Debug("GetExperimentFiles HTTP handler called")
 
 	var (
-		ctx  = r.Context()
-		role = ctx.Value("role").(rbac.Role)
-		vars = mux.Vars(r)
-		name = vars["name"]
+		ctx          = r.Context()
+		role         = ctx.Value("role").(rbac.Role)
+		vars         = mux.Vars(r)
+		name         = vars["name"]
+		query        = r.URL.Query()
+		sortCol      = query.Get("sortCol")
+		sortDir      = query.Get("sortDir")
+		pageNum      = query.Get("pageNum")
+		perPage      = query.Get("perPage")
+		clientFilter = query.Get("filter")
 	)
 
 	if !role.Allowed("experiments/files", "list", name) {
@@ -810,14 +816,30 @@ func GetExperimentFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	files, err := experiment.Files(name)
+	files, err := experiment.Files(name, clientFilter)
 	if err != nil {
 		log.Error("getting list of files for experiment %s - %v", name, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	body, err := marshaler.Marshal(&proto.FileList{Files: files})
+	experimentFilesTotal := len(files)
+
+	if sortCol != "" && sortDir != "" {
+		files.SortBy(sortCol, sortDir == "asc")
+	}
+
+	if pageNum != "" && perPage != "" {
+		n, _ := strconv.Atoi(pageNum)
+		s, _ := strconv.Atoi(perPage)
+
+		files = files.Paginate(n, s)
+	}
+
+	experimentFileList := util.ExperimentFileListToProtobuf(files)
+	experimentFileList.Total = uint32(experimentFilesTotal)
+
+	body, err := marshaler.Marshal(experimentFileList)
 	if err != nil {
 		log.Error("marshaling file list for experiment %s - %v", name, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/src/go/web/proto/experiment.proto
+++ b/src/go/web/proto/experiment.proto
@@ -93,3 +93,15 @@ message UpdateScheduleRequest {
 message AppList {
 	repeated string applications = 1;
 }
+
+message ExperimentFile {
+	string name = 1;
+	string date = 2;
+	uint32 size = 3;
+	string category = 4;
+}
+
+message ExperimentFileList {
+	repeated ExperimentFile files = 1;
+	uint32 total = 2;
+}

--- a/src/go/web/util/protobuf.go
+++ b/src/go/web/util/protobuf.go
@@ -3,6 +3,7 @@ package util
 import (
 	"sort"
 
+	"phenix/internal/file"
 	"phenix/internal/mm"
 	"phenix/types"
 	"phenix/web/cache"
@@ -173,4 +174,20 @@ func UserToProtobuf(u rbac.User) *proto.User {
 	}
 
 	return user
+}
+
+func ExperimentFileListToProtobuf(experimentFiles []file.ExperimentFile) *proto.ExperimentFileList {
+	var protoExperimentFiles []*proto.ExperimentFile
+
+	for _, experimentFile := range experimentFiles {
+		protoExperimentFiles = append(protoExperimentFiles,
+			&proto.ExperimentFile{
+				Name:     experimentFile.Name,
+				Date:     experimentFile.Date,
+				Size:     uint32(experimentFile.Size),
+				Category: experimentFile.Category,
+			})
+	}
+
+	return &proto.ExperimentFileList{Files: protoExperimentFiles}
 }

--- a/src/js/src/components/StoppedExperiment.vue
+++ b/src/js/src/components/StoppedExperiment.vue
@@ -39,7 +39,7 @@
     <b-field v-if="experimentUser() || experimentViewer()" position="is-right">
       <b-autocomplete
         v-model="searchName"
-        placeholder="Find a VM"
+        :placeholder="searchPlaceholder"
         icon="search"
         :data="searchHistory"
         @typing="searchVMs"
@@ -74,7 +74,7 @@
       </p>  
     </b-field>
     <div style="margin-top: -4em;">
-      <b-tabs @change="updateFiles">
+      <b-tabs @input="tabsSwitched()" v-model="activeTab">
         <b-tab-item label="Table">
           <b-table
             :key="table.key"
@@ -206,32 +206,52 @@
           </b-field>
         </b-tab-item>
         <b-tab-item label="Files">
-          <template v-if="files && !files.length">
-            <section class="hero is-light is-bold is-large">
-              <div class="hero-body">
-                <div class="container" style="text-align: center">
-                  <h1 class="title">
-                    There are no files available.
-                  </h1>
-                </div>
-              </div>
-            </section>
-          </template>
-          <template v-else>
-            <ul class="fa-ul" style="list-style:none">
-              <li v-for="( f, index ) in files" :key="index">
-                <font-awesome-icon class="fa-li" icon="file-download" />
-                <a :href="'/api/v1/experiments/'
+          <b-table            
+            :data="files"
+            :paginated="filesTable.isPaginated  && filesPaginationNeeded"
+            backend-pagination
+            :total="filesTable.total"
+            :per-page="filesTable.perPage"
+            :current-page.sync="filesTable.currentPage"  
+            @page-change="onFilesPageChange"   
+            :pagination-simple="filesTable.isPaginationSimple"
+            :pagination-size="filesTable.paginationSize"  
+            backend-sorting
+            :default-sort-direction="filesTable.defaultSortDirection"
+            default-sort="date"
+            @sort="onFilesSort">
+            <template slot="empty">
+                <section class="section">
+                  <div class="content has-text-white has-text-centered">
+                    No Files Are Available!
+                  </div>
+                </section>
+            </template>
+            <template slot-scope="props">
+                <b-table-column field="name" label="Name" sortable centered>                  
+                          {{ props.row.name }}                      
+                </b-table-column>
+                <b-table-column field="date" label="Date" sortable centered>                  
+                          {{ props.row.date }}                      
+                </b-table-column>
+                <b-table-column field="size" label="Size" sortable centered>                  
+                          {{ props.row.size }}                      
+                </b-table-column>
+                 <b-table-column field="category" label="Category" sortable centered>                  
+                          {{ props.row.category }}                      
+                </b-table-column>
+                <b-table-column field="download" label="Download" centered>   
+                        <a :href="'/api/v1/experiments/'
                           + experiment.name 
                           + '/files/' 
-                          + f 
+                          + props.row.name
                           + '?token=' 
-                          + $store.state.token" target="_blank">
-                  {{ f }}
-                </a>
-              </li>
-            </ul>
-          </template>
+                          + $store.state.token" target="_blank"> 
+                          <b-icon icon="file-download" size="is-small"></b-icon>                       
+                          </a>                      
+                </b-table-column>
+            </template>
+          </b-table>
         </b-tab-item>
       </b-tabs>
     </div>
@@ -295,6 +315,13 @@
         }
 
         return true;
+      },
+      filesPaginationNeeded () {
+        if ( this.filesTable.total <= this.filesTable.perPage ) {
+          return  false;
+        }
+
+        return true;
       }
     },
 
@@ -316,7 +343,13 @@
           term  = '';
         }
         this.searchName = term;
-        this.updateExperiment();
+        if (this.activeTab == 0){
+          this.updateExperiment();
+          return
+        }
+        
+        this.updateFiles()
+        
       },250),
 
       bootDecorator ( dnb ) {
@@ -326,6 +359,16 @@
           return 'boot';
         }
       },
+
+      onFilesPageChange  ( page ) {
+        this.filesTable.currentPage = page;
+        this.updateFiles();
+      },
+      onFilesSort  ( column, order ) {
+        this.filesTable.sortColumn = column;
+        this.filesTable.defaultSortDirection = order;
+        this.updateFiles();
+      }, 
 
       handler ( event ) {
         event.data.split( /\r?\n/ ).forEach( m => {
@@ -479,16 +522,53 @@
         );
       },
       
-      updateFiles () {
-        this.files = [];
+      tabsSwitched() {
 
-        this.$http.get( 'experiments/' + this.$route.params.id + '/files' ).then(
+        // Clear search history and 
+        // search filter when switching tabs
+        this.searchHistory = []
+        this.searchName = ""
+
+        
+        if (this.activeTab == 0){
+          this.searchPlaceholder = "Find a VM"         
+          this.updateExperiment()          
+        }
+        else {
+          this.searchPlaceholder = "Find a File" 
+          this.updateFiles()         
+        }
+
+      },
+
+      updateFiles () {               
+
+        let params = '?filter=' + this.searchName
+        params = params + '&sortCol=' + this.filesTable.sortColumn
+        params = params + '&sortDir=' + this.filesTable.defaultSortDirection
+        params = params + '&pageNum=' + this.filesTable.currentPage
+        params = params + '&perPage=' + this.filesTable.perPage
+
+        this.$http.get( 'experiments/' + this.$route.params.id + '/files' + params ).then(
           response => {
             response.json().then(
-              state => {
-                for ( let i = 0; i < state.files.length; i++ ){
-                  this.files.push( state.files[ i ] );
+              state => {                             
+                this.files = state.files
+                this.filesTable.total = state.total
+
+                // Format the file sizes
+                for(let i = 0; i<this.files.length;i++){
+                  this.files[i].size = this.formatFileSize(this.files[i].size)
                 }
+
+                // Only add successful searches to the search history
+                if (this.files.length > 0) {
+                if (this.searchHistory > this.searchHistoryLength) {
+                  this.searchHistory.pop()
+                }
+                this.searchHistory.push(this.searchName.trim())
+                this.searchHistory = this.getUniqueItems(this.searchHistory)
+              }
                 
                 this.isWaiting = false;
               }
@@ -965,6 +1045,18 @@
         
         return Object.keys(arrayHash).sort();
 
+      },
+      
+      formatFileSize(fileSize){
+        if(fileSize < Math.pow(10,3)){
+          return fileSize.toFixed(2) + ' B'
+        } else if(fileSize >= Math.pow(10,3) && fileSize < Math.pow(10,6)){
+          return (fileSize/Math.pow(10,3)).toFixed(2) + ' KB'
+        } else if (fileSize >= Math.pow(10,6) && fileSize < Math.pow(10,9)){
+          return (fileSize/Math.pow(10,6)).toFixed(2) + ' MB'
+        } else if (fileSize >= Math.pow(10,9)) {
+          return (fileSize/Math.pow(10,9)).toFixed(2) + ' GB'
+        }
       }
     },
 
@@ -978,6 +1070,16 @@
           isPaginationSimple: true,
           paginationSize: 'is-small',
           defaultSortDirection: 'asc'
+        },
+        filesTable: {          
+          isPaginated: true,
+          isPaginationSimple: true,
+          currentPage: 1,
+          perPage: 10,          
+          total:  0,
+          sortColumn: 'date',          
+          paginationSize: 'is-small',
+          defaultSortDirection: 'desc'
         },
         expModal: {
           active: false,
@@ -996,8 +1098,10 @@
         algorithm: null,
         dnb: false,
         isWaiting: true,
-        searchHistory: [],
-        searchHistoryLength:10 
+        searchHistory: [],        
+        searchHistoryLength:10,
+        searchPlaceholder:"Find a VM",
+        activeTab:0
       }
     }
   }


### PR DESCRIPTION
Added the list of experiment files to a Buefy table to facilitate searching/sorting/paging for the running and stopped experiment views.  This PR satisfies issue #57 .  Here are a few screenshots to give an overview of the searching.  

This screenshot show the list of fields added to the table.  The `Date` column is the default sort column.  Sorting, searching, and pagination is done on the server.  The screenshot also show an example search for files greater than 100 MB using the search term `>= 100 MB`  When searching the file size, the following size abbreviations can be used `KB,MB,GB`.
![searchExperimentFiles_Table_Stopped_Size_Search](https://user-images.githubusercontent.com/75450207/119287767-2968c800-bc15-11eb-804a-f3e02f6b5176.JPG)

Here is another screenshot showing a date/time search.   The `Size` and `Date` columns are searched using the following comparison operators `< > = <= >=`.  Currently, in order to search the `Date` column, the search term must be in the following format `YYYY-MM-DD HH:MM:SS`.  The minimum information to search a date is `YYYY-MM`
![searchExperimentFiles_Table_Stopped_DateTime_Search](https://user-images.githubusercontent.com/75450207/119288169-07bc1080-bc16-11eb-95cf-40e204b53f8f.JPG)

Here is an example of combining search terms using the `and` operator.  The following logical operators are supported `and or not`
![searchExperimentFiles_Table_Stopped_CombinedSearch](https://user-images.githubusercontent.com/75450207/119288695-0f2fe980-bc17-11eb-9fb4-ab0e853064d1.JPG)

Finally, the `Category` column is a little redundant as it is derived from file extensions.  This screenshot shows the `Category` column being searched for VM snapshots using the search term `vm` 
![searchExperimentFiles_Table_Stopped_Category_Search](https://user-images.githubusercontent.com/75450207/119289405-8d40c000-bc18-11eb-866c-ef036edd97d4.JPG)








