### PR TITLE
Enable using minimega C2 on Windows 10 VMs to run startup script

### DIFF
--- a/src/go/internal/mm/minimega.go
+++ b/src/go/internal/mm/minimega.go
@@ -682,6 +682,10 @@ func (Minimega) GetVLANs(opts ...Option) (map[string]int, error) {
 func (Minimega) IsC2ClientActive(opts ...C2Option) error {
 	o := NewC2Options(opts...)
 
+	if o.skipActiveClientCheck {
+		return nil
+	}
+
 	cmd := mmcli.NewNamespacedCommand(o.ns)
 	cmd.Command = "vm info"
 	cmd.Columns = []string{"cc_active"}
@@ -721,10 +725,10 @@ func (this Minimega) ExecC2Command(opts ...C2Option) (string, error) {
 
 	data, err := mmcli.SingleDataResponse(mmcli.Run(cmd))
 	if err != nil {
-		return "", fmt.Errorf("executing command %s: %w", o.command, err)
+		return "", fmt.Errorf("executing command '%s' on vm %s: %w", o.command, o.vm, err)
 	}
 
-	// This will the the ID for the cc exec command
+	// This will be the ID for the cc exec command
 	return fmt.Sprintf("%v", data), nil
 }
 

--- a/src/go/internal/mm/option.go
+++ b/src/go/internal/mm/option.go
@@ -123,6 +123,8 @@ type c2Options struct {
 	commandID string
 
 	timeout time.Duration
+
+	skipActiveClientCheck bool
 }
 
 func NewC2Options(opts ...C2Option) c2Options {
@@ -165,5 +167,11 @@ func C2CommandID(i string) C2Option {
 func C2Timeout(d time.Duration) C2Option {
 	return func(o *c2Options) {
 		o.timeout = d
+	}
+}
+
+func C2SkipActiveClientCheck(s bool) C2Option {
+	return func(o *c2Options) {
+		o.skipActiveClientCheck = s
 	}
 }

--- a/src/go/types/interfaces/topology.go
+++ b/src/go/types/interfaces/topology.go
@@ -13,6 +13,7 @@ type TopologySpec interface {
 }
 
 type NodeSpec interface {
+	Annotations() map[string]string
 	Labels() map[string]string
 	Type() string
 	General() NodeGeneral
@@ -33,6 +34,8 @@ type NodeSpec interface {
 	SetAdvanced(map[string]string)
 	AddAdvanced(string, string)
 	AddOverride(string, string)
+
+	GetAnnotation(string) (string, bool)
 }
 
 type NodeGeneral interface {

--- a/src/go/types/version/v0/node.go
+++ b/src/go/types/version/v0/node.go
@@ -10,12 +10,17 @@ import (
 )
 
 type Node struct {
-	LabelsF     map[string]string `json:"labels" yaml:"labels" structs:"labels" mapstructure:"labels"`
-	TypeF       string            `json:"type" yaml:"type" structs:"type" mapstructure:"type"`
-	GeneralF    *General          `json:"general" yaml:"general" structs:"general" mapstructure:"general"`
-	HardwareF   *Hardware         `json:"hardware" yaml:"hardware" structs:"hardware" mapstructure:"hardware"`
-	NetworkF    *Network          `json:"network" yaml:"network" structs:"network" mapstructure:"network"`
-	InjectionsF []*Injection      `json:"injections" yaml:"injections" structs:"injections" mapstructure:"injections"`
+	AnnotationsF map[string]string `json:"annotations" yaml:"annotations" structs:"annotations" mapstructure:"annotations"`
+	LabelsF      map[string]string `json:"labels" yaml:"labels" structs:"labels" mapstructure:"labels"`
+	TypeF        string            `json:"type" yaml:"type" structs:"type" mapstructure:"type"`
+	GeneralF     *General          `json:"general" yaml:"general" structs:"general" mapstructure:"general"`
+	HardwareF    *Hardware         `json:"hardware" yaml:"hardware" structs:"hardware" mapstructure:"hardware"`
+	NetworkF     *Network          `json:"network" yaml:"network" structs:"network" mapstructure:"network"`
+	InjectionsF  []*Injection      `json:"injections" yaml:"injections" structs:"injections" mapstructure:"injections"`
+}
+
+func (this Node) Annotations() map[string]string {
+	return this.AnnotationsF
 }
 
 func (this Node) Labels() map[string]string {
@@ -124,6 +129,20 @@ func (this *Node) AddInject(src, dst, perms, desc string) {
 func (Node) SetAdvanced(map[string]string) {}
 func (Node) AddAdvanced(string, string)    {}
 func (Node) AddOverride(string, string)    {}
+
+func (this Node) GetAnnotation(a string) (string, bool) {
+	if this.AnnotationsF == nil {
+		return "", false
+	}
+
+	for k := range this.AnnotationsF {
+		if k == a {
+			return this.AnnotationsF[k], true
+		}
+	}
+
+	return "", false
+}
 
 type General struct {
 	HostnameF    string `json:"hostname" yaml:"hostname" structs:"hostname" mapstructure:"hostname"`

--- a/src/go/types/version/v1/node.go
+++ b/src/go/types/version/v1/node.go
@@ -10,14 +10,19 @@ import (
 )
 
 type Node struct {
-	LabelsF     map[string]string `json:"labels" yaml:"labels" structs:"labels" mapstructure:"labels"`
-	TypeF       string            `json:"type" yaml:"type" structs:"type" mapstructure:"type"`
-	GeneralF    *General          `json:"general" yaml:"general" structs:"general" mapstructure:"general"`
-	HardwareF   *Hardware         `json:"hardware" yaml:"hardware" structs:"hardware" mapstructure:"hardware"`
-	NetworkF    *Network          `json:"network" yaml:"network" structs:"network" mapstructure:"network"`
-	InjectionsF []*Injection      `json:"injections" yaml:"injections" structs:"injections" mapstructure:"injections"`
-	AdvancedF   map[string]string `json:"advanced" yaml:"advanced" structs:"advanced" mapstructure:"advanced"`
-	OverridesF  map[string]string `json:"overrides" yaml:"overrides" structs:"overrides" mapstructure:"overrides"`
+	AnnotationsF map[string]string `json:"annotations" yaml:"annotations" structs:"annotations" mapstructure:"annotations"`
+	LabelsF      map[string]string `json:"labels" yaml:"labels" structs:"labels" mapstructure:"labels"`
+	TypeF        string            `json:"type" yaml:"type" structs:"type" mapstructure:"type"`
+	GeneralF     *General          `json:"general" yaml:"general" structs:"general" mapstructure:"general"`
+	HardwareF    *Hardware         `json:"hardware" yaml:"hardware" structs:"hardware" mapstructure:"hardware"`
+	NetworkF     *Network          `json:"network" yaml:"network" structs:"network" mapstructure:"network"`
+	InjectionsF  []*Injection      `json:"injections" yaml:"injections" structs:"injections" mapstructure:"injections"`
+	AdvancedF    map[string]string `json:"advanced" yaml:"advanced" structs:"advanced" mapstructure:"advanced"`
+	OverridesF   map[string]string `json:"overrides" yaml:"overrides" structs:"overrides" mapstructure:"overrides"`
+}
+
+func (this Node) Annotations() map[string]string {
+	return this.AnnotationsF
 }
 
 func (this Node) Labels() map[string]string {
@@ -164,6 +169,20 @@ func (this *Node) AddOverride(match, replace string) {
 	}
 
 	this.OverridesF[match] = replace
+}
+
+func (this Node) GetAnnotation(a string) (string, bool) {
+	if this.AnnotationsF == nil {
+		return "", false
+	}
+
+	for k := range this.AnnotationsF {
+		if k == a {
+			return this.AnnotationsF[k], true
+		}
+	}
+
+	return "", false
 }
 
 type General struct {


### PR DESCRIPTION
This obviously requires that the Windows 10 VM image be configured ahead
of time to run the miniccc agent at boot. Since the `image inject-miniexe`
subcommand uses the startup folder script technique to start the miniccc
agent, the miniccc agent and service must be added to Windows 10 images
in a different manner (e.g. a Packer config).