### PR TITLE
Support minirouter as router os_type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
+*.bdb
+*.code-workspace
+
 .devcontainer
 .vscode
-*.bdb
 
 bin
-
-docker/minimega-bin/miniccc
-docker/minimega-bin/protonuke

--- a/src/go/app/ntp.go
+++ b/src/go/app/ntp.go
@@ -34,8 +34,12 @@ func (this *NTP) Configure(ctx context.Context, exp *types.Experiment) error {
 			return fmt.Errorf("creating experiment ntp directory path: %w", err)
 		}
 
-		if node.Type() == "Router" {
-			node.AddInject(ntpFile, "/opt/vyatta/etc/ntp.conf", "", "")
+		if strings.EqualFold(node.Type(), "router") {
+			if strings.EqualFold(node.Hardware().OSType(), "minirouter") {
+				node.AddInject(ntpFile, "/etc/ntp.conf", "", "")
+			} else {
+				node.AddInject(ntpFile, "/opt/vyatta/etc/ntp.conf", "", "")
+			}
 		} else if node.Hardware().OSType() == "linux" {
 			node.AddInject(ntpFile, "/etc/ntp.conf", "", "")
 		} else if node.Hardware().OSType() == "windows" {

--- a/src/go/types/version/v1/network.go
+++ b/src/go/types/version/v1/network.go
@@ -48,6 +48,12 @@ func (this *Network) OSPF() ifaces.NodeNetworkOSPF {
 		return nil
 	}
 
+	// fun times... https://glucn.medium.com/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
+	// probably other places we need to do this too... :shrug:
+	if this.OSPFF == nil {
+		return nil
+	}
+
 	return this.OSPFF
 }
 

--- a/src/go/types/version/v1/schema.go
+++ b/src/go/types/version/v1/schema.go
@@ -171,6 +171,7 @@ components:
               - linux
               - rhel
               - centos
+              - minirouter
               default: linux
               example: windows
             drives:


### PR DESCRIPTION
When minirouter is specified as the os_type for nodes of type Router,
the minimega router commands are used to configure the VM instead of
injecting config files.

Currently supports configuring interface addresses, default gateways,
static routes, and OSPF routing. At some point it will be updated to
also support ACLs via iptables configurations.