### PR TITLE
Fix mistake during merge conflict resolution

### DIFF
--- a/src/js/src/components/StoppedExperiment.vue
+++ b/src/js/src/components/StoppedExperiment.vue
@@ -90,7 +90,8 @@
             backend-sorting
             :default-sort-direction="table.defaultSortDirection"
             default-sort="name"
-            @sort="onSort">
+            @sort="onSort"
+            ref="vmTable">
               <template slot="empty">
                 <section class="section">
                   <div class="content has-text-white has-text-centered">


### PR DESCRIPTION
While using GitHub's editor for merge conflict resolution, I deleted something that enabled the multiSelect checkboxes to work.  This fixes the broken multiSelect checkboxes for the stopped view that I broke during merge conflict resolution.