### PR TITLE
Add support for custom reachability tests in SoH app

### DIFF
--- a/src/go/api/soh/app.go
+++ b/src/go/api/soh/app.go
@@ -137,7 +137,7 @@ func (this *SOH) PostStart(ctx context.Context, exp *types.Experiment) error {
 
 	if err := this.runChecks(ctx, exp, true); err != nil {
 		if this.md.ExitOnError {
-			return err
+			return fmt.Errorf("running initial SoH checks: %w", err)
 		}
 
 		fmt.Printf("Error running initial SoH checks: %v\n", err)
@@ -214,7 +214,7 @@ func (this *SOH) runChecks(ctx context.Context, exp *types.Experiment, initial b
 
 				printer.Printf("  Waiting for IP %s on host %s to be set...\n", cidr, host)
 
-				isNetworkingConfigured(ctx, wg, ns, node, iface)
+				this.isNetworkingConfigured(ctx, wg, ns, node, iface)
 			}
 		}
 	}
@@ -277,6 +277,10 @@ func (this *SOH) runChecks(ctx context.Context, exp *types.Experiment, initial b
 	}
 
 	exp.Status.SetAppStatus("soh", appStatus)
+
+	if len(wg.Errors) > 0 {
+		return fmt.Errorf("errors encountered in state of health app")
+	}
 
 	return nil
 }

--- a/src/go/api/soh/types.go
+++ b/src/go/api/soh/types.go
@@ -92,17 +92,27 @@ type elasticServer struct {
 	VLAN      string `mapstructure:"vlan"`
 }
 
+type customReachability struct {
+	Src    string        `mapstructure:"src"`
+	Dst    string        `mapstructure:"dst"`
+	Proto  string        `mapstructure:"proto"`
+	Port   int           `mapstructure:"port"`
+	Wait   time.Duration `mapstructure:"wait"`
+	Packet string        `mapstructure:"udpPacketBase64"`
+}
+
 type sohMetadata struct {
-	AppProfileKey     string              `mapstructure:"appMetadataProfileKey"`
-	C2Timeout         string              `mapstructure:"c2Timeout"`
-	ExitOnError       bool                `mapstructure:"exitOnError"`
-	HostListeners     map[string][]string `mapstructure:"hostListeners"`
-	HostProcesses     map[string][]string `mapstructure:"hostProcesses"`
-	InjectICMPAllow   bool                `mapstructure:"injectICMPAllow"`
-	PacketCapture     packetCapture       `mapstructure:"packetCapture"`
-	Reachability      string              `mapstructure:"testReachability"`
-	SkipNetworkConfig bool                `mapstructure:"skipInitialNetworkConfigTests"`
-	SkipHosts         []string            `mapstructure:"skipHosts"`
+	AppProfileKey      string               `mapstructure:"appMetadataProfileKey"`
+	C2Timeout          string               `mapstructure:"c2Timeout"`
+	ExitOnError        bool                 `mapstructure:"exitOnError"`
+	HostListeners      map[string][]string  `mapstructure:"hostListeners"`
+	HostProcesses      map[string][]string  `mapstructure:"hostProcesses"`
+	InjectICMPAllow    bool                 `mapstructure:"injectICMPAllow"`
+	PacketCapture      packetCapture        `mapstructure:"packetCapture"`
+	Reachability       string               `mapstructure:"testReachability"`
+	CustomReachability []customReachability `mapstructure:"testCustomReachability"`
+	SkipNetworkConfig  bool                 `mapstructure:"skipInitialNetworkConfigTests"`
+	SkipHosts          []string             `mapstructure:"skipHosts"`
 
 	// set after parsing
 	c2Timeout time.Duration

--- a/src/go/internal/mm/c2.go
+++ b/src/go/internal/mm/c2.go
@@ -68,9 +68,11 @@ func ScheduleC2ParallelCommand(ctx context.Context, cmd *C2ParallelCommand) {
 			id string
 		)
 
+		timeout := time.After(o.timeout)
+
 		for {
 			select {
-			case <-time.After(o.timeout):
+			case <-timeout:
 				cmd.Wait.AddError(fmt.Errorf("timeout waiting for C2 to be active: %w", ErrC2ClientNotActive), cmd.Meta)
 				return
 			default:

--- a/src/go/internal/mm/minimega.go
+++ b/src/go/internal/mm/minimega.go
@@ -717,7 +717,11 @@ func (this Minimega) ExecC2Command(opts ...C2Option) (string, error) {
 		return "", fmt.Errorf("setting host filter to %s: %w", o.vm, err)
 	}
 
-	cmd.Command = fmt.Sprintf("cc exec %s", o.command)
+	if o.testConn != "" {
+		cmd.Command = fmt.Sprintf("cc test-conn %s", o.testConn)
+	} else {
+		cmd.Command = fmt.Sprintf("cc exec %s", o.command)
+	}
 
 	data, err := mmcli.SingleDataResponse(mmcli.Run(cmd))
 	if err != nil {

--- a/src/go/internal/mm/option.go
+++ b/src/go/internal/mm/option.go
@@ -122,6 +122,8 @@ type c2Options struct {
 	command   string
 	commandID string
 
+	testConn string
+
 	timeout time.Duration
 
 	skipActiveClientCheck bool
@@ -161,6 +163,12 @@ func C2Command(c string) C2Option {
 func C2CommandID(i string) C2Option {
 	return func(o *c2Options) {
 		o.commandID = i
+	}
+}
+
+func C2TestConn(t string) C2Option {
+	return func(o *c2Options) {
+		o.testConn = t
 	}
 }
 

--- a/src/go/types/version/v1/network.go
+++ b/src/go/types/version/v1/network.go
@@ -405,10 +405,20 @@ func (this Rule) Protocol() string {
 }
 
 func (this Rule) Source() ifaces.NodeNetworkRulesetRuleAddrPort {
+	// fun times... https://glucn.medium.com/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
+	if this.SourceF == nil {
+		return nil
+	}
+
 	return this.SourceF
 }
 
 func (this Rule) Destination() ifaces.NodeNetworkRulesetRuleAddrPort {
+	// fun times... https://glucn.medium.com/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
+	if this.DestinationF == nil {
+		return nil
+	}
+
 	return this.DestinationF
 }
 

--- a/src/js/src/components/Experiments.vue
+++ b/src/js/src/components/Experiments.vue
@@ -93,7 +93,7 @@
       <div style="margin-top: -1em;">
         <b-table
           :data="filteredExperiments"
-          :paginated="table.isPaginated && paginationNeeded"
+          :paginated="table.isPaginated"
           :per-page="table.perPage"
           :current-page.sync="table.currentPage"
           :pagination-simple="table.isPaginationSimple"
@@ -174,7 +174,7 @@
         <br>
         <b-field v-if="paginationNeeded" grouped position="is-right">
           <div class="control is-flex">
-            <b-switch v-model="table.isPaginated" size="is-small" type="is-light">Paginate</b-switch>
+            <b-switch v-model="table.isPaginated" size="is-small" type="is-light" @input="changePaginate()">Paginate</b-switch>
           </div>
         </b-field>
       </div>
@@ -226,14 +226,19 @@
       },
 
       paginationNeeded () {
-        var experiments = this.experiments;
-        if ( experiments.length <= 10 ) {
+        var user = localStorage.getItem( 'user' );
+
+        if ( localStorage.getItem( user + '.lastPaginate' ) ) {
+          this.table.isPaginated = localStorage.getItem( user + '.lastPaginate' )  == 'true';
+        }
+
+        if ( this.experiments.length <= 10 ) {
+          this.table.isPaginated = false;
           return false;
         } else {
           return true;
         }
-      }      
-      
+      }
     },
     
     methods: { 
@@ -415,6 +420,11 @@
       
       experimentUser () {
         return [ 'Global Admin', 'Experiment Admin', 'Experiment User' ].includes( this.$store.getters.role );
+      },
+
+      changePaginate () {
+        var user = localStorage.getItem( 'user' );
+        localStorage.setItem( user + '.lastPaginate', this.table.isPaginated );
       },
       
       updating: function( status ) {
@@ -723,7 +733,7 @@
     data () {
       return {
         table: {
-          isPaginated: true,
+          isPaginated: false,
           perPage: 10,
           currentPage: 1,
           isPaginationSimple: true,

--- a/src/js/src/components/Hosts.vue
+++ b/src/js/src/components/Hosts.vue
@@ -10,7 +10,7 @@ available for experiments, the number of VMs, and host uptime.
     <hr>
     <b-table
       :data="hosts"
-      :paginated="table.isPaginated && paginationNeeded"
+      :paginated="table.isPaginated"
       :per-page="table.perPage"
       :current-page.sync="table.currentPage"
       :pagination-simple="table.isPaginationSimple"
@@ -59,7 +59,7 @@ available for experiments, the number of VMs, and host uptime.
     <br>
     <b-field v-if="paginationNeeded" grouped position="is-right">
       <div class="control is-flex">
-        <b-switch v-model="table.isPaginated" size="is-small" type="is-light">Paginate</b-switch>
+        <b-switch v-model="table.isPaginated" size="is-small" type="is-light" @input="changePaginate()">Paginate</b-switch>
       </div>
     </b-field>
     <b-loading :is-full-page="true" :active.sync="isWaiting" :can-cancel="false"></b-loading>
@@ -109,6 +109,11 @@ available for experiments, the number of VMs, and host uptime.
         }, 10000 )
       },
 
+      changePaginate () {
+        var user = localStorage.getItem( 'user' );
+        localStorage.setItem( user + '.lastPaginate', this.table.isPaginated );
+      },
+
       decorator ( sum, len ) {
         let actual = sum / len;
         if ( actual < .65 ) {
@@ -131,7 +136,14 @@ available for experiments, the number of VMs, and host uptime.
     
     computed: {
       paginationNeeded () {
+        var user = localStorage.getItem( 'user' );
+
+        if ( localStorage.getItem( user + '.lastPaginate' ) ) {
+          this.table.isPaginated = localStorage.getItem( user + '.lastPaginate' )  == 'true';
+        }
+
         if ( this.hosts.length <= 10 ) {
+          this.table.isPaginated = false;
           return false;
         } else {
           return true;
@@ -142,7 +154,7 @@ available for experiments, the number of VMs, and host uptime.
     data () {
       return {
         table: {
-          isPaginated: true,
+          isPaginated: false,
           perPage: 10,
           currentPage: 1,
           isPaginationSimple: true,

--- a/src/js/src/components/Users.vue
+++ b/src/js/src/components/Users.vue
@@ -87,7 +87,7 @@
       <div>
         <b-table
           :data="users"
-          :paginated="table.isPaginated && paginationNeeded"
+          :paginated="table.isPaginated"
           :per-page="table.perPage"
           :current-page.sync="table.currentPage"
           :pagination-simple="table.isPaginationSimple"
@@ -125,9 +125,10 @@
             </b-table-column>
           </template>
         </b-table>
+        <br>
         <b-field v-if="paginationNeeded" grouped position="is-right">
           <div class="control is-flex">
-            <b-switch v-model="table.isPaginated" size="is-small" type="is-light">Paginate</b-switch>
+            <b-switch v-model="table.isPaginated" size="is-small" type="is-light" @input="changePaginate()">Paginate</b-switch>
           </div>
         </b-field>
       </div>
@@ -150,7 +151,14 @@
 
     computed: {
       paginationNeeded () {
+        var user = localStorage.getItem( 'user' );
+
+        if ( localStorage.getItem( user + '.lastPaginate' ) ) {
+          this.table.isPaginated = localStorage.getItem( user + '.lastPaginate' )  == 'true';
+        }
+
         if ( this.users.length <= 10 ) {
+          this.table.isPaginated = false;
           return false;
         } else {
           return true;
@@ -260,6 +268,11 @@
       
       experimentUser () {
         return [ 'Global Admin', 'Experiment Admin', 'Experiment User' ].includes( this.$store.getters.role );
+      },
+
+      changePaginate () {
+        var user = localStorage.getItem( 'user' );
+        localStorage.setItem( user + '.lastPaginate', this.table.isPaginated );
       },
 
       createUser () {
@@ -494,7 +507,7 @@
       return {
         table: {
           striped: true,
-          isPaginated: true,
+          isPaginated: false,
           isPaginationSimple: true,
           paginationSize: 'is-small',
           defaultSortDirection: 'asc',


### PR DESCRIPTION
Support configuration of TCP and UDP reachability tests in addition to
the ICMP-based reachability testing SoH already supports.

For UDP tests, a valid UDP payload that will trigger a UDP response must
be provided as a Base64-encoded string.

Note that this commit relies on new features recently added to minimega
that haven't been merged into the default minimega branch yet. The
minimega code required is in the activeshadow/minimega@tcp-conn-test
branch.