### PR TITLE
Support custom, host-based user tests via scripts

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -61,7 +61,7 @@ RUN groupadd --gid $USER_UID $USERNAME \
 
 RUN apt update && apt install -y curl gnupg2 make protobuf-compiler wget xz-utils
 
-ENV GOLANG_VERSION 1.14.6
+ENV GOLANG_VERSION 1.16.5
 
 RUN wget -O go.tgz https://golang.org/dl/go\${GOLANG_VERSION}.linux-amd64.tar.gz \
   && tar -C /usr/local -xzf go.tgz && rm go.tgz

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN npm install \
   && npm run build
 
 
-FROM golang:1.14 AS gobuilder
+FROM golang:1.16.5 AS gobuilder
 
 RUN apt update \
   && apt install -y protobuf-compiler xz-utils

--- a/src/go/api/soh/app.go
+++ b/src/go/api/soh/app.go
@@ -137,7 +137,7 @@ func (this *SOH) PostStart(ctx context.Context, exp *types.Experiment) error {
 
 	if err := this.runChecks(ctx, exp, true); err != nil {
 		if this.md.ExitOnError {
-			return err
+			return fmt.Errorf("running initial SoH checks: %w", err)
 		}
 
 		fmt.Printf("Error running initial SoH checks: %v\n", err)
@@ -214,7 +214,7 @@ func (this *SOH) runChecks(ctx context.Context, exp *types.Experiment, initial b
 
 				printer.Printf("  Waiting for IP %s on host %s to be set...\n", cidr, host)
 
-				isNetworkingConfigured(ctx, wg, ns, node, iface)
+				this.isNetworkingConfigured(ctx, wg, ns, node, iface)
 			}
 		}
 	}
@@ -277,6 +277,10 @@ func (this *SOH) runChecks(ctx context.Context, exp *types.Experiment, initial b
 	}
 
 	exp.Status.SetAppStatus("soh", appStatus)
+
+	if len(wg.Errors) > 0 {
+		return fmt.Errorf("errors encountered in state of health app")
+	}
 
 	return nil
 }

--- a/src/go/api/soh/app.go
+++ b/src/go/api/soh/app.go
@@ -317,6 +317,7 @@ func (this *SOH) runChecks(ctx context.Context, exp *types.Experiment, initial b
 	this.waitForReachabilityTest(ctx, ns)
 	this.waitForProcTest(ctx, ns)
 	this.waitForPortTest(ctx, ns)
+	this.waitForCustomTest(ctx, ns)
 	this.waitForCPULoad(ctx, ns)
 
 	if !initial {
@@ -381,9 +382,9 @@ func (this *SOH) getFlows(ctx context.Context, exp *types.Experiment) {
 		}
 	}
 
-	opts := []mm.C2Option{mm.C2NS(exp.Metadata.Name), mm.C2CommandID(id)}
+	opts := []mm.C2Option{mm.C2NS(exp.Metadata.Name), mm.C2Context(ctx), mm.C2CommandID(id)}
 
-	resp, err := mm.WaitForC2Response(ctx, opts...)
+	resp, err := mm.WaitForC2Response(opts...)
 	if err != nil {
 		fmt.Printf("error getting response for command 'query-flows.sh': %v\n", err)
 		return

--- a/src/go/api/soh/types.go
+++ b/src/go/api/soh/types.go
@@ -92,17 +92,27 @@ type elasticServer struct {
 	VLAN      string `mapstructure:"vlan"`
 }
 
+type customReachability struct {
+	Src    string        `mapstructure:"src"`
+	Dst    string        `mapstructure:"dst"`
+	Proto  string        `mapstructure:"proto"`
+	Port   int           `mapstructure:"port"`
+	Wait   time.Duration `mapstructure:"wait"`
+	Packet string        `mapstructure:"udpPacketBase64"`
+}
+
 type sohMetadata struct {
-	AppProfileKey     string              `mapstructure:"appMetadataProfileKey"`
-	C2Timeout         string              `mapstructure:"c2Timeout"`
-	ExitOnError       bool                `mapstructure:"exitOnError"`
-	HostListeners     map[string][]string `mapstructure:"hostListeners"`
-	HostProcesses     map[string][]string `mapstructure:"hostProcesses"`
-	InjectICMPAllow   bool                `mapstructure:"injectICMPAllow"`
-	PacketCapture     packetCapture       `mapstructure:"packetCapture"`
-	Reachability      string              `mapstructure:"testReachability"`
-	SkipNetworkConfig bool                `mapstructure:"skipInitialNetworkConfigTests"`
-	SkipHosts         []string            `mapstructure:"skipHosts"`
+	AppProfileKey      string               `mapstructure:"appMetadataProfileKey"`
+	C2Timeout          string               `mapstructure:"c2Timeout"`
+	ExitOnError        bool                 `mapstructure:"exitOnError"`
+	HostListeners      map[string][]string  `mapstructure:"hostListeners"`
+	HostProcesses      map[string][]string  `mapstructure:"hostProcesses"`
+	InjectICMPAllow    bool                 `mapstructure:"injectICMPAllow"`
+	PacketCapture      packetCapture        `mapstructure:"packetCapture"`
+	Reachability       string               `mapstructure:"testReachability"`
+	CustomReachability []customReachability `mapstructure:"testCustomReachability"`
+	SkipNetworkConfig  bool                 `mapstructure:"skipInitialNetworkConfigTests"`
+	SkipHosts          []string             `mapstructure:"skipHosts"`
 
 	// set after parsing
 	c2Timeout time.Duration

--- a/src/go/api/soh/types.go
+++ b/src/go/api/soh/types.go
@@ -58,12 +58,19 @@ type Listener struct {
 	Error     string `json:"error" mapstructure:"error" structs:"error"`
 }
 
+type CustomTest struct {
+	Test      string `json:"test" mapstructure:"test" structs:"test"`
+	Timestamp string `json:"timestamp" mapstructure:"timestamp" structs:"timestamp"`
+	Error     string `json:"error" mapstructure:"error" structs:"error"`
+}
+
 type HostState struct {
 	Hostname     string         `json:"hostname" mapstructure:"hostname" structs:"hostname"`
 	CPULoad      string         `json:"cpuLoad" mapstructure:"cpuLoad" structs:"cpuLoad"`
 	Reachability []Reachability `json:"reachability,omitempty" mapstructure:"reachability,omitempty" structs:"reachability,omitempty"`
 	Processes    []Process      `json:"processes,omitempty" mapstructure:"processes,omitempty" structs:"processes,omitempty"`
 	Listeners    []Listener     `json:"listeners,omitempty" mapstructure:"listeners,omitempty" structs:"listeners,omitempty"`
+	CustomTests  []CustomTest   `json:"customTest,omitempty" mapstructure:"customTest,omitempty" structs:"customTest,omitempty"`
 }
 
 type flowsStruct struct {
@@ -101,18 +108,27 @@ type customReachability struct {
 	Packet string        `mapstructure:"udpPacketBase64"`
 }
 
+type customHostTest struct {
+	Name       string `mapstructure:"name"`
+	TestScript string `mapstructure:"testScript"`
+	Executor   string `mapstructure:"executor"`
+	TestStdout string `mapstructure:"testStdout"`
+	TestStderr string `mapstructure:"testStderr"`
+}
+
 type sohMetadata struct {
-	AppProfileKey      string               `mapstructure:"appMetadataProfileKey"`
-	C2Timeout          string               `mapstructure:"c2Timeout"`
-	ExitOnError        bool                 `mapstructure:"exitOnError"`
-	HostListeners      map[string][]string  `mapstructure:"hostListeners"`
-	HostProcesses      map[string][]string  `mapstructure:"hostProcesses"`
-	InjectICMPAllow    bool                 `mapstructure:"injectICMPAllow"`
-	PacketCapture      packetCapture        `mapstructure:"packetCapture"`
-	Reachability       string               `mapstructure:"testReachability"`
-	CustomReachability []customReachability `mapstructure:"testCustomReachability"`
-	SkipNetworkConfig  bool                 `mapstructure:"skipInitialNetworkConfigTests"`
-	SkipHosts          []string             `mapstructure:"skipHosts"`
+	AppProfileKey      string                      `mapstructure:"appMetadataProfileKey"`
+	C2Timeout          string                      `mapstructure:"c2Timeout"`
+	ExitOnError        bool                        `mapstructure:"exitOnError"`
+	HostListeners      map[string][]string         `mapstructure:"hostListeners"`
+	HostProcesses      map[string][]string         `mapstructure:"hostProcesses"`
+	CustomHostTests    map[string][]customHostTest `mapstructure:"hostCustomTests"`
+	InjectICMPAllow    bool                        `mapstructure:"injectICMPAllow"`
+	PacketCapture      packetCapture               `mapstructure:"packetCapture"`
+	Reachability       string                      `mapstructure:"testReachability"`
+	CustomReachability []customReachability        `mapstructure:"testCustomReachability"`
+	SkipNetworkConfig  bool                        `mapstructure:"skipInitialNetworkConfigTests"`
+	SkipHosts          []string                    `mapstructure:"skipHosts"`
 
 	// set after parsing
 	c2Timeout time.Duration
@@ -156,10 +172,11 @@ func (this *sohMetadata) init() error {
 }
 
 type sohProfile struct {
-	C2Timeout string   `mapstructure:"c2Timeout"`
-	Processes []string `mapstructure:"processes"`
-	Listeners []string `mapstructure:"listeners"`
-	Captures  []string `mapstructure:"captureInterfaces"`
+	C2Timeout   string           `mapstructure:"c2Timeout"`
+	Processes   []string         `mapstructure:"processes"`
+	Listeners   []string         `mapstructure:"listeners"`
+	CustomTests []customHostTest `mapstructure:"customTests"`
+	Captures    []string         `mapstructure:"captureInterfaces"`
 
 	// set after parsing
 	c2Timeout time.Duration

--- a/src/go/app/user.go
+++ b/src/go/app/user.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -97,14 +96,6 @@ func (this UserApp) shellOut(ctx context.Context, action Action, exp *types.Expe
 		return fmt.Errorf("marshaling experiment to JSON: %w", err)
 	}
 
-	var logFile string
-
-	if dir := filepath.Dir(common.LogFile); dir == "/var/log/phenix" {
-		logFile = dir + "/phenix-apps.log"
-	} else {
-		logFile = dir + "/.phenix-apps.log"
-	}
-
 	opts := []shell.Option{
 		shell.Command(cmdName),
 		shell.Args(string(action)),
@@ -112,7 +103,7 @@ func (this UserApp) shellOut(ctx context.Context, action Action, exp *types.Expe
 		shell.Env(
 			"PHENIX_DIR="+common.PhenixBase,
 			"PHENIX_LOG_LEVEL="+util.GetEnv("PHENIX_LOG_LEVEL", "DEBUG"),
-			"PHENIX_LOG_FILE="+util.GetEnv("PHENIX_LOG_FILE", logFile),
+			"PHENIX_LOG_FILE="+util.GetEnv("PHENIX_LOG_FILE", common.LogFile),
 			"PHENIX_DRYRUN="+strconv.FormatBool(this.options.DryRun),
 		),
 	}

--- a/src/go/cmd/root.go
+++ b/src/go/cmd/root.go
@@ -37,18 +37,18 @@ var rootCmd = &cobra.Command{
 			errOut   = viper.GetBool("log.error-stderr")
 		)
 
-		common.LogFile = errFile
+		common.ErrorFile = errFile
 
 		if err := store.Init(store.Endpoint(endpoint)); err != nil {
 			return fmt.Errorf("initializing storage: %w", err)
 		}
 
 		if err := util.InitFatalLogWriter(errFile, errOut); err != nil {
-			return fmt.Errorf("Unable to initialize fatal log writer: %w", err)
+			return fmt.Errorf("unable to initialize fatal log writer: %w", err)
 		}
 
 		if err := config.Init(); err != nil {
-			return fmt.Errorf("Unable to initialize default configs: %w", err)
+			return fmt.Errorf("unable to initialize default configs: %w", err)
 		}
 
 		return nil
@@ -84,11 +84,15 @@ func init() {
 		os.MkdirAll("/etc/phenix", 0755)
 		os.MkdirAll("/var/log/phenix", 0755)
 
-		rootCmd.PersistentFlags().StringVar(&storeEndpoint, "store.endpoint", fmt.Sprintf("bolt:///etc/phenix/store.bdb"), "endpoint for storage service")
+		rootCmd.PersistentFlags().StringVar(&storeEndpoint, "store.endpoint", "bolt:///etc/phenix/store.bdb", "endpoint for storage service")
 		rootCmd.PersistentFlags().StringVar(&errFile, "log.error-file", "/var/log/phenix/error.log", "log fatal errors to file")
+
+		common.LogFile = "/var/log/phenix/phenix.log"
 	} else {
 		rootCmd.PersistentFlags().StringVar(&storeEndpoint, "store.endpoint", fmt.Sprintf("bolt://%s/.phenix.bdb", home), "endpoint for storage service")
 		rootCmd.PersistentFlags().StringVar(&errFile, "log.error-file", fmt.Sprintf("%s/.phenix.err", home), "log fatal errors to file")
+
+		common.LogFile = fmt.Sprintf("%s/.phenix.log", home)
 	}
 
 	viper.BindPFlags(rootCmd.PersistentFlags())

--- a/src/go/cmd/ui.go
+++ b/src/go/cmd/ui.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"phenix/internal/common"
 	"phenix/util"
 	"phenix/web"
 
@@ -39,6 +40,7 @@ func newUiCmd() *cobra.Command {
 				}
 
 				log.AddLogger("file", logfile, level, false)
+				common.LogFile = path
 			}
 
 			opts := []web.ServerOption{

--- a/src/go/internal/common/common.go
+++ b/src/go/internal/common/common.go
@@ -8,7 +8,8 @@ var (
 	PhenixBase   = "/phenix"
 	MinimegaBase = "/tmp/minimega"
 
-	LogFile = "/var/log/phenix"
+	LogFile   = "/var/log/phenix/phenix.log"
+	ErrorFile = "/var/log/phenix/error.log"
 
 	HostnameSuffixes string
 )

--- a/src/go/internal/mm/c2.go
+++ b/src/go/internal/mm/c2.go
@@ -68,9 +68,11 @@ func ScheduleC2ParallelCommand(ctx context.Context, cmd *C2ParallelCommand) {
 			id string
 		)
 
+		timeout := time.After(o.timeout)
+
 		for {
 			select {
-			case <-time.After(o.timeout):
+			case <-timeout:
 				cmd.Wait.AddError(fmt.Errorf("timeout waiting for C2 to be active: %w", ErrC2ClientNotActive), cmd.Meta)
 				return
 			default:

--- a/src/go/internal/mm/minimega.go
+++ b/src/go/internal/mm/minimega.go
@@ -717,7 +717,11 @@ func (this Minimega) ExecC2Command(opts ...C2Option) (string, error) {
 		return "", fmt.Errorf("setting host filter to %s: %w", o.vm, err)
 	}
 
-	cmd.Command = fmt.Sprintf("cc exec %s", o.command)
+	if o.testConn != "" {
+		cmd.Command = fmt.Sprintf("cc test-conn %s", o.testConn)
+	} else {
+		cmd.Command = fmt.Sprintf("cc exec %s", o.command)
+	}
 
 	data, err := mmcli.SingleDataResponse(mmcli.Run(cmd))
 	if err != nil {

--- a/src/go/internal/mm/minimega.go
+++ b/src/go/internal/mm/minimega.go
@@ -115,7 +115,7 @@ func (this Minimega) GetVMInfo(opts ...Option) VMs {
 
 	cmd := mmcli.NewNamespacedCommand(o.ns)
 	cmd.Command = "vm info"
-	cmd.Columns = []string{"host", "name", "state", "uptime", "vlan", "tap", "memory", "vcpus", "disks", "tags"}
+	cmd.Columns = []string{"host", "name", "state", "uptime", "vlan", "tap", "ip", "memory", "vcpus", "disks", "tags"}
 
 	if o.vm != "" {
 		cmd.Filters = []string{"name=" + o.vm}
@@ -135,7 +135,6 @@ func (this Minimega) GetVMInfo(opts ...Option) VMs {
 		s := row["vlan"]
 		s = strings.TrimPrefix(s, "[")
 		s = strings.TrimSuffix(s, "]")
-		s = strings.TrimSpace(s)
 
 		if s != "" {
 			vm.Networks = strings.Split(s, ", ")
@@ -144,16 +143,22 @@ func (this Minimega) GetVMInfo(opts ...Option) VMs {
 		s = row["tap"]
 		s = strings.TrimPrefix(s, "[")
 		s = strings.TrimSuffix(s, "]")
-		s = strings.TrimSpace(s)
 
 		if s != "" {
 			vm.Taps = strings.Split(s, ", ")
 		}
 
+		s = row["ip"]
+		s = strings.TrimPrefix(s, "[")
+		s = strings.TrimSuffix(s, "]")
+
+		if s != "" {
+			vm.IPv4 = strings.Split(s, ", ")
+		}
+
 		s = row["tags"]
 		s = strings.TrimPrefix(s, "{")
 		s = strings.TrimSuffix(s, "}")
-		s = strings.TrimSpace(s)
 
 		if s != "" {
 			vm.Tags = strings.Split(s, ",")

--- a/src/go/internal/mm/mm.go
+++ b/src/go/internal/mm/mm.go
@@ -1,7 +1,5 @@
 package mm
 
-import "context"
-
 var DefaultMM MM = new(Minimega)
 
 type MM interface {
@@ -36,6 +34,7 @@ type MM interface {
 
 	IsC2ClientActive(...C2Option) error
 	ExecC2Command(...C2Option) (string, error)
-	WaitForC2Response(context.Context, ...C2Option) (string, error)
+	GetC2Response(...C2Option) (string, error)
+	WaitForC2Response(...C2Option) (string, error)
 	ClearC2Responses(...C2Option) error
 }

--- a/src/go/internal/mm/mmcli/client.go
+++ b/src/go/internal/mm/mmcli/client.go
@@ -94,6 +94,10 @@ func SingleResponse(responses chan *miniclient.Response) (string, error) {
 		}
 	}
 
+	if resp == nil {
+		return "", err
+	}
+
 	return *resp, err
 }
 

--- a/src/go/internal/mm/option.go
+++ b/src/go/internal/mm/option.go
@@ -122,6 +122,8 @@ type c2Options struct {
 	command   string
 	commandID string
 
+	testConn string
+
 	timeout time.Duration
 
 	skipActiveClientCheck bool
@@ -161,6 +163,12 @@ func C2Command(c string) C2Option {
 func C2CommandID(i string) C2Option {
 	return func(o *c2Options) {
 		o.commandID = i
+	}
+}
+
+func C2TestConn(t string) C2Option {
+	return func(o *c2Options) {
+		o.testConn = t
 	}
 }
 

--- a/src/go/internal/mm/package.go
+++ b/src/go/internal/mm/package.go
@@ -1,7 +1,5 @@
 package mm
 
-import "context"
-
 func ReadScriptFromFile(filename string) error {
 	return DefaultMM.ReadScriptFromFile(filename)
 }
@@ -102,8 +100,12 @@ func ExecC2Command(opts ...C2Option) (string, error) {
 	return DefaultMM.ExecC2Command(opts...)
 }
 
-func WaitForC2Response(ctx context.Context, opts ...C2Option) (string, error) {
-	return DefaultMM.WaitForC2Response(ctx, opts...)
+func GetC2Response(opts ...C2Option) (string, error) {
+	return DefaultMM.GetC2Response(opts...)
+}
+
+func WaitForC2Response(opts ...C2Option) (string, error) {
+	return DefaultMM.WaitForC2Response(opts...)
 }
 
 func ClearC2Responses(opts ...C2Option) error {

--- a/src/go/internal/mm/types.go
+++ b/src/go/internal/mm/types.go
@@ -227,6 +227,9 @@ type VM struct {
 
 	// Used internally to track state of VM in minimega.
 	State string `json:"-"`
+
+	// Used internally to check for active CC agent.
+	UUID string `json:"-"`
 }
 
 type Captures struct {

--- a/src/go/tmpl/templates/linux_interfaces.tmpl
+++ b/src/go/tmpl/templates/linux_interfaces.tmpl
@@ -6,10 +6,14 @@ service NetworkManager stop
 # Check if ip command exists
 if command -v 'ip' &>/dev/null; then
     {{ range $idx, $iface := .Network.Interfaces }}
-        {{ if ne $iface.Proto "dhcp" }}
     dev=$(ip -oneline -4 link show | grep -iv 'LOOPBACK' | awk 'NR=={{ addInt $idx 1 }} {split($2, devname, ":"); print devname[1]}')
     ip link set dev "$dev" down
     ip addr flush dev "$dev"
+
+        {{ if eq $iface.Proto "dhcp" }}
+    ip link set dev "$dev" up
+    dhclient "$dev"
+        {{ else }}
     ip addr add {{ $iface.Address }}/{{ $iface.Mask }} dev "$dev"
     ip link set dev "$dev" up
             {{ if ne $iface.Gateway "" }}
@@ -20,9 +24,13 @@ if command -v 'ip' &>/dev/null; then
 else
     # Fallback to ifconfig
     {{ range $idx, $iface := .Network.Interfaces }}
-        {{ if ne $iface.Proto "dhcp" }}
     dev=$(ifconfig -s -a | grep -ivE '^lo|Iface' | awk 'NR=={{ addInt $idx 1 }} { print $1 }')
     ifconfig "$dev" down
+
+        {{ if eq $iface.Proto "dhcp" }}
+    ifconfig "$dev" up
+    dhclient "$dev"
+        {{ else }}
     ifconfig "$dev" {{ $iface.Address }} netmask {{ cidrToMask (print $iface.Address "/" $iface.Mask) }}
     ifconfig "$dev" up
             {{ if ne $iface.Gateway "" }}

--- a/src/go/types/version/v1/network.go
+++ b/src/go/types/version/v1/network.go
@@ -405,10 +405,20 @@ func (this Rule) Protocol() string {
 }
 
 func (this Rule) Source() ifaces.NodeNetworkRulesetRuleAddrPort {
+	// fun times... https://glucn.medium.com/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
+	if this.SourceF == nil {
+		return nil
+	}
+
 	return this.SourceF
 }
 
 func (this Rule) Destination() ifaces.NodeNetworkRulesetRuleAddrPort {
+	// fun times... https://glucn.medium.com/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
+	if this.DestinationF == nil {
+		return nil
+	}
+
 	return this.DestinationF
 }
 

--- a/src/go/web/handlers.go
+++ b/src/go/web/handlers.go
@@ -2650,6 +2650,7 @@ func GetLogs(w http.ResponseWriter, r *http.Request) {
 	type LogLine struct {
 		Source    string `json:"source"`
 		Timestamp string `json:"timestamp"`
+		Epoch     int64  `json:"epoch"`
 		Level     string `json:"level"`
 		Log       string `json:"log"`
 
@@ -2724,7 +2725,7 @@ func GetLogs(w http.ResponseWriter, r *http.Request) {
 						continue
 					}
 
-					if time.Now().Sub(ts) > since {
+					if time.Since(ts) > since {
 						continue
 					}
 
@@ -2735,6 +2736,7 @@ func GetLogs(w http.ResponseWriter, r *http.Request) {
 					body = &LogLine{
 						Source:    name,
 						Timestamp: parts[1],
+						Epoch:     ts.Unix(),
 						Level:     parts[2],
 						Log:       parts[3],
 

--- a/src/go/web/log.go
+++ b/src/go/web/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"regexp"
+	"time"
 
 	"phenix/web/broker"
 
@@ -74,9 +75,15 @@ func PublishLogs(ctx context.Context, phenix, minimega string) {
 			switch l.kind {
 			case LOG_PHENIX:
 				if len(parts) == 4 {
+					ts, err := time.ParseInLocation("2006/01/02 15:04:05", parts[1], time.Local)
+					if err != nil {
+						continue
+					}
+
 					phenixBody = map[string]interface{}{
 						"source":    "gophenix",
 						"timestamp": parts[1],
+						"epoch":     ts.Unix(),
 						"level":     parts[2],
 						"log":       parts[3],
 					}
@@ -95,9 +102,15 @@ func PublishLogs(ctx context.Context, phenix, minimega string) {
 				)
 			case LOG_MINIMEGA:
 				if len(parts) == 4 {
+					ts, err := time.ParseInLocation("2006/01/02 15:04:05", parts[1], time.Local)
+					if err != nil {
+						continue
+					}
+
 					mmBody = map[string]interface{}{
 						"source":    "minimega",
 						"timestamp": parts[1],
+						"epoch":     ts.Unix(),
 						"level":     parts[2],
 						"log":       parts[3],
 					}

--- a/src/js/src/components/Experiments.vue
+++ b/src/js/src/components/Experiments.vue
@@ -93,7 +93,7 @@
       <div style="margin-top: -1em;">
         <b-table
           :data="filteredExperiments"
-          :paginated="table.isPaginated && paginationNeeded"
+          :paginated="table.isPaginated"
           :per-page="table.perPage"
           :current-page.sync="table.currentPage"
           :pagination-simple="table.isPaginationSimple"
@@ -174,7 +174,7 @@
         <br>
         <b-field v-if="paginationNeeded" grouped position="is-right">
           <div class="control is-flex">
-            <b-switch v-model="table.isPaginated" size="is-small" type="is-light">Paginate</b-switch>
+            <b-switch v-model="table.isPaginated" size="is-small" type="is-light" @input="changePaginate()">Paginate</b-switch>
           </div>
         </b-field>
       </div>
@@ -226,14 +226,19 @@
       },
 
       paginationNeeded () {
-        var experiments = this.experiments;
-        if ( experiments.length <= 10 ) {
+        var user = localStorage.getItem( 'user' );
+
+        if ( localStorage.getItem( user + '.lastPaginate' ) ) {
+          this.table.isPaginated = localStorage.getItem( user + '.lastPaginate' )  == 'true';
+        }
+
+        if ( this.experiments.length <= 10 ) {
+          this.table.isPaginated = false;
           return false;
         } else {
           return true;
         }
-      }      
-      
+      }
     },
     
     methods: { 
@@ -415,6 +420,11 @@
       
       experimentUser () {
         return [ 'Global Admin', 'Experiment Admin', 'Experiment User' ].includes( this.$store.getters.role );
+      },
+
+      changePaginate () {
+        var user = localStorage.getItem( 'user' );
+        localStorage.setItem( user + '.lastPaginate', this.table.isPaginated );
       },
       
       updating: function( status ) {
@@ -723,7 +733,7 @@
     data () {
       return {
         table: {
-          isPaginated: true,
+          isPaginated: false,
           perPage: 10,
           currentPage: 1,
           isPaginationSimple: true,

--- a/src/js/src/components/Hosts.vue
+++ b/src/js/src/components/Hosts.vue
@@ -10,7 +10,7 @@ available for experiments, the number of VMs, and host uptime.
     <hr>
     <b-table
       :data="hosts"
-      :paginated="table.isPaginated && paginationNeeded"
+      :paginated="table.isPaginated"
       :per-page="table.perPage"
       :current-page.sync="table.currentPage"
       :pagination-simple="table.isPaginationSimple"
@@ -59,7 +59,7 @@ available for experiments, the number of VMs, and host uptime.
     <br>
     <b-field v-if="paginationNeeded" grouped position="is-right">
       <div class="control is-flex">
-        <b-switch v-model="table.isPaginated" size="is-small" type="is-light">Paginate</b-switch>
+        <b-switch v-model="table.isPaginated" size="is-small" type="is-light" @input="changePaginate()">Paginate</b-switch>
       </div>
     </b-field>
     <b-loading :is-full-page="true" :active.sync="isWaiting" :can-cancel="false"></b-loading>
@@ -109,6 +109,11 @@ available for experiments, the number of VMs, and host uptime.
         }, 10000 )
       },
 
+      changePaginate () {
+        var user = localStorage.getItem( 'user' );
+        localStorage.setItem( user + '.lastPaginate', this.table.isPaginated );
+      },
+
       decorator ( sum, len ) {
         let actual = sum / len;
         if ( actual < .65 ) {
@@ -131,7 +136,14 @@ available for experiments, the number of VMs, and host uptime.
     
     computed: {
       paginationNeeded () {
+        var user = localStorage.getItem( 'user' );
+
+        if ( localStorage.getItem( user + '.lastPaginate' ) ) {
+          this.table.isPaginated = localStorage.getItem( user + '.lastPaginate' )  == 'true';
+        }
+
         if ( this.hosts.length <= 10 ) {
+          this.table.isPaginated = false;
           return false;
         } else {
           return true;
@@ -142,7 +154,7 @@ available for experiments, the number of VMs, and host uptime.
     data () {
       return {
         table: {
-          isPaginated: true,
+          isPaginated: false,
           perPage: 10,
           currentPage: 1,
           isPaginationSimple: true,

--- a/src/js/src/components/StateOfHealth.vue
+++ b/src/js/src/components/StateOfHealth.vue
@@ -651,7 +651,13 @@ export default {
         .on( 'click', this.clicked )
         .call( this.drag( simulation ) );
 
-      node.append( "title" ).text( d => d.label );
+      const label = g.selectAll( "text" )
+        .data( nodes )
+        .join( "text" )
+          .text( d => d.label )
+          .style( "text-anchor", "start" )
+          .style( "fill", "whitesmoke" )
+          .style( "font-size", "6px" );
 
       simulation.on( "tick", () => {
         link
@@ -662,7 +668,11 @@ export default {
 
         node
           .attr( "cx", d => d.x )
-          .attr( "cy", d => d.y) ;
+          .attr( "cy", d => d.y );
+
+        label
+          .attr( "x", d => d.x + 4 )
+          .attr( "y", d => d.y + 8 );
       });
     },
 
@@ -672,7 +682,7 @@ export default {
       }
 
       let circle = d3.select( e.target );
-
+      
       circle
         .transition()
         .attr( "r", 15 )

--- a/src/js/src/components/Users.vue
+++ b/src/js/src/components/Users.vue
@@ -87,7 +87,7 @@
       <div>
         <b-table
           :data="users"
-          :paginated="table.isPaginated && paginationNeeded"
+          :paginated="table.isPaginated"
           :per-page="table.perPage"
           :current-page.sync="table.currentPage"
           :pagination-simple="table.isPaginationSimple"
@@ -125,9 +125,10 @@
             </b-table-column>
           </template>
         </b-table>
+        <br>
         <b-field v-if="paginationNeeded" grouped position="is-right">
           <div class="control is-flex">
-            <b-switch v-model="table.isPaginated" size="is-small" type="is-light">Paginate</b-switch>
+            <b-switch v-model="table.isPaginated" size="is-small" type="is-light" @input="changePaginate()">Paginate</b-switch>
           </div>
         </b-field>
       </div>
@@ -150,7 +151,14 @@
 
     computed: {
       paginationNeeded () {
+        var user = localStorage.getItem( 'user' );
+
+        if ( localStorage.getItem( user + '.lastPaginate' ) ) {
+          this.table.isPaginated = localStorage.getItem( user + '.lastPaginate' )  == 'true';
+        }
+
         if ( this.users.length <= 10 ) {
+          this.table.isPaginated = false;
           return false;
         } else {
           return true;
@@ -260,6 +268,11 @@
       
       experimentUser () {
         return [ 'Global Admin', 'Experiment Admin', 'Experiment User' ].includes( this.$store.getters.role );
+      },
+
+      changePaginate () {
+        var user = localStorage.getItem( 'user' );
+        localStorage.setItem( user + '.lastPaginate', this.table.isPaginated );
       },
 
       createUser () {
@@ -494,7 +507,7 @@
       return {
         table: {
           striped: true,
-          isPaginated: true,
+          isPaginated: false,
           isPaginationSimple: true,
           paginationSize: 'is-small',
           defaultSortDirection: 'asc',


### PR DESCRIPTION
Users can specify a script to run per host, with the option of comparing
STDOUT or STDERR output from the script to an expected outcome.

This works on both Linux and Windows VMs.