### PR TITLE
Sort the list of disks

### DIFF
--- a/src/go/web/handlers.go
+++ b/src/go/web/handlers.go
@@ -2597,6 +2597,8 @@ func GetDisks(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	sort.Strings(allowed)
+
 	body, err := marshaler.Marshal(&proto.DiskList{Disks: allowed})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Sort the list of disks in dropdowns when selecting a backing image for a VM prior to experiment start or when deploying a VM