### PR TITLE
ID cc clients using UUID by default instead of topology hostname

### DIFF
--- a/src/go/api/soh/app.go
+++ b/src/go/api/soh/app.go
@@ -383,6 +383,10 @@ func (this *SOH) getFlows(ctx context.Context, exp *types.Experiment) {
 
 		opts := []mm.C2Option{mm.C2NS(exp.Metadata.Name), mm.C2VM(hostname), mm.C2Command("query-flows.sh")}
 
+		if this.md.useUUIDForC2Active(hostname) {
+			opts = append(opts, mm.C2IDClientsByUUID())
+		}
+
 		id, err = mm.ExecC2Command(opts...)
 		if err != nil {
 			if errors.Is(err, mm.ErrC2ClientNotActive) {

--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -739,6 +739,10 @@ func (this *SOH) waitForCPULoad(ctx context.Context, ns string) {
 
 			opts := []mm.C2Option{mm.C2NS(ns), mm.C2VM(host), mm.C2Command(exec)}
 
+			if this.md.useUUIDForC2Active(host) {
+				opts = append(opts, mm.C2IDClientsByUUID())
+			}
+
 			id, err := mm.ExecC2Command(opts...)
 			if err != nil {
 				wg.AddError(fmt.Errorf("executing command '%s': %w", exec, err), map[string]interface{}{"host": host})
@@ -1096,9 +1100,13 @@ func (this SOH) portTest(ctx context.Context, wg *mm.ErrGroup, ns string, node i
 }
 
 func (this SOH) newParallelCommand(ns, host, exec string) *mm.C2ParallelCommand {
-	return &mm.C2ParallelCommand{
-		Options: []mm.C2Option{mm.C2NS(ns), mm.C2VM(host), mm.C2Command(exec), mm.C2Timeout(this.md.c2Timeout)},
+	opts := []mm.C2Option{mm.C2NS(ns), mm.C2VM(host), mm.C2Command(exec), mm.C2Timeout(this.md.c2Timeout)}
+
+	if this.md.useUUIDForC2Active(host) {
+		opts = append(opts, mm.C2IDClientsByUUID())
 	}
+
+	return &mm.C2ParallelCommand{Options: opts}
 }
 
 func injectICMPAllowRules(nodes []ifaces.NodeSpec) error {

--- a/src/go/internal/mm/option.go
+++ b/src/go/internal/mm/option.go
@@ -144,6 +144,7 @@ type c2Options struct {
 	skipActiveClientCheck bool
 
 	responseType C2ResponseType
+	idByUUID     bool
 }
 
 func NewC2Options(opts ...C2Option) c2Options {
@@ -228,6 +229,12 @@ func C2ResponseTypeStdout() C2Option {
 func C2ResponseTypeStderr() C2Option {
 	return func(o *c2Options) {
 		o.responseType = C2ResponseStderr
+	}
+}
+
+func C2IDClientsByUUID() C2Option {
+	return func(o *c2Options) {
+		o.idByUUID = true
 	}
 }
 

--- a/src/go/web/log.go
+++ b/src/go/web/log.go
@@ -81,7 +81,7 @@ func PublishLogs(ctx context.Context, phenix, minimega string) {
 					}
 
 					phenixBody = map[string]interface{}{
-						"source":    "gophenix",
+						"source":    "phenix",
 						"timestamp": parts[1],
 						"epoch":     ts.Unix(),
 						"level":     parts[2],
@@ -97,7 +97,7 @@ func PublishLogs(ctx context.Context, phenix, minimega string) {
 
 				broker.Broadcast(
 					nil,
-					broker.NewResource("log", "gophenix", "update"),
+					broker.NewResource("log", "phenix", "update"),
 					marshalled,
 				)
 			case LOG_MINIMEGA:


### PR DESCRIPTION
Added an option to ID clients by hostname, defaulting to false, which
means by default clients will be identified by their UUID when checking
to see if C2 is active for a client.