### PR TITLE
Add support for secure UI

### DIFF
--- a/src/go/cmd/ui.go
+++ b/src/go/cmd/ui.go
@@ -51,6 +51,7 @@ func newUiCmd() *cobra.Command {
 			opts := []web.ServerOption{
 				web.ServeOnEndpoint(viper.GetString("ui.listen-endpoint")),
 				web.ServeWithJWTKey(viper.GetString("ui.jwt-signing-key")),
+				web.ServeWithTLS(viper.GetString("ui.tls-key"), viper.GetString("ui.tls-cert")),
 				web.ServePhenixLogs(viper.GetString("ui.logs.phenix-path")),
 				web.ServeMinimegaLogs(viper.GetString("ui.logs.minimega-path")),
 			}
@@ -76,7 +77,9 @@ func newUiCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("listen-endpoint", "e", "0.0.0.0:3000", "endpoint to listen on")
-	cmd.Flags().StringP("jwt-signing-key", "k", "", "secret key used to sign JWT for authentication")
+	cmd.Flags().StringP("jwt-signing-key", "k", "", "Secret key used to sign JWT for authentication")
+	cmd.Flags().String("tls-key", "", "path to TLS key file")
+	cmd.Flags().String("tls-cert", "", "path to TLS cert file")
 	cmd.Flags().Bool("unbundled", false, "serve local public files instead of bundled")
 	cmd.Flags().String("log-level", "info", "log level for UI logs")
 	cmd.Flags().Bool("log-verbose", true, "write UI logs to STDERR")
@@ -85,6 +88,8 @@ func newUiCmd() *cobra.Command {
 
 	viper.BindPFlag("ui.listen-endpoint", cmd.Flags().Lookup("listen-endpoint"))
 	viper.BindPFlag("ui.jwt-signing-key", cmd.Flags().Lookup("jwt-signing-key"))
+	viper.BindPFlag("ui.tls-key", cmd.Flags().Lookup("tls-key"))
+	viper.BindPFlag("ui.tls-cert", cmd.Flags().Lookup("tls-cert"))
 	viper.BindPFlag("ui.log-level", cmd.Flags().Lookup("log-level"))
 	viper.BindPFlag("ui.log-verbose", cmd.Flags().Lookup("log-verbose"))
 	viper.BindPFlag("ui.logs.phenix-path", cmd.Flags().Lookup("logs.phenix-path"))
@@ -92,6 +97,8 @@ func newUiCmd() *cobra.Command {
 
 	viper.BindEnv("ui.listen-endpoint")
 	viper.BindEnv("ui.jwt-signing-key")
+	viper.BindEnv("ui.tls-key")
+	viper.BindEnv("ui.tls-cert")
 	viper.BindEnv("ui.log-level")
 	viper.BindEnv("ui.log-verbose")
 	viper.BindEnv("ui.logs.phenix-path")

--- a/src/go/web/broker/client.go
+++ b/src/go/web/broker/client.go
@@ -60,8 +60,6 @@ type Client struct {
 }
 
 func NewClient(role rbac.Role, conn *websocket.Conn) *Client {
-	log.Debug("[gophenix] new WS client created")
-
 	return &Client{
 		role:    role,
 		conn:    conn,
@@ -87,12 +85,10 @@ func (this *Client) stop() {
 	close(this.done)
 
 	if err := this.conn.WriteMessage(websocket.CloseMessage, []byte{}); err != nil {
-		log.Error("closing client connection: %v", err)
+		log.Warn("closing client connection: %v", err)
 	}
 
 	this.conn.Close()
-
-	log.Debug("[gophenix] WS client destroyed")
 }
 
 func (this *Client) read() {

--- a/src/go/web/option.go
+++ b/src/go/web/option.go
@@ -10,6 +10,9 @@ type serverOptions struct {
 	users     []string
 	allowCORS bool
 
+	tlsKeyPath string
+	tlsCrtPath string
+
 	logMiddleware string
 
 	publishLogs  bool
@@ -21,9 +24,8 @@ type serverOptions struct {
 
 func newServerOptions(opts ...ServerOption) serverOptions {
 	o := serverOptions{
-		endpoint:  ":3000",
-		users:     []string{"admin@foo.com:foobar:Global Admin"},
-		allowCORS: true, // TODO: default to false
+		endpoint: ":3000",
+		users:    []string{"admin@foo.com:foobar:Global Admin"},
 	}
 
 	for _, opt := range opts {
@@ -35,6 +37,18 @@ func newServerOptions(opts ...ServerOption) serverOptions {
 	}
 
 	return o
+}
+
+func (this serverOptions) tlsEnabled() bool {
+	if this.tlsKeyPath == "" {
+		return false
+	}
+
+	if this.tlsCrtPath == "" {
+		return false
+	}
+
+	return true
 }
 
 func ServeOnEndpoint(e string) ServerOption {
@@ -58,6 +72,13 @@ func ServeWithUsers(u string) ServerOption {
 func ServeWithCORS(c bool) ServerOption {
 	return func(o *serverOptions) {
 		o.allowCORS = c
+	}
+}
+
+func ServeWithTLS(k, c string) ServerOption {
+	return func(o *serverOptions) {
+		o.tlsKeyPath = k
+		o.tlsCrtPath = c
 	}
 }
 

--- a/src/go/web/server.go
+++ b/src/go/web/server.go
@@ -212,7 +212,11 @@ func Start(opts ...ServerOption) error {
 
 	go PublishLogs(context.Background(), o.phenixLogs, o.minimegaLogs)
 
-	log.Info("Starting HTTP server on %s", o.endpoint)
-
-	return http.ListenAndServe(o.endpoint, router)
+	if o.tlsEnabled() {
+		log.Info("Starting HTTPS server on %s", o.endpoint)
+		return http.ListenAndServeTLS(o.endpoint, o.tlsCrtPath, o.tlsKeyPath, router)
+	} else {
+		log.Info("Starting HTTP server on %s", o.endpoint)
+		return http.ListenAndServe(o.endpoint, router)
+	}
 }


### PR DESCRIPTION
Use the `--tls-key` and `--tls-cert` options now present for the `phenix ui` subcommand to secure the UI with the provided TLS certificate.