### PR TITLE
Fix spelling on vyatta config template

### DIFF
--- a/src/go/tmpl/templates/vyatta.tmpl
+++ b/src/go/tmpl/templates/vyatta.tmpl
@@ -176,7 +176,7 @@ system {
 {{ if $ntpAddr }}
     ntp {
         server {{ $ntpAddr }} {
-            perfer
+            prefer
         }
     }
 {{ end }}


### PR DESCRIPTION
Corrected spelling error that prevented injected ntp settings from taking effect at boot