### PR TITLE
Update startup app and tmpl to account for phenix-startup task in Windows

### DIFF
--- a/src/go/tmpl/templates/startup-scheduler.cmd
+++ b/src/go/tmpl/templates/startup-scheduler.cmd
@@ -1,2 +1,2 @@
-schtasks /create /tn "startup" /sc onlogon /rl highest /tr "powershell.exe -file C:\startup.ps1" /F
-schtasks /run /tn "startup"
+schtasks /create /tn "phenix-startup" /sc onlogon /rl highest /tr "powershell.exe -file C:\phenix\startup\startup.ps1 > C:\phenix\phenix-startup.log" /F
+schtasks /run /tn "phenix-startup"

--- a/src/go/tmpl/templates/windows_startup.tmpl
+++ b/src/go/tmpl/templates/windows_startup.tmpl
@@ -1,6 +1,10 @@
 Import-Module C:\Windows\System32\UIAutomation.0.8.7B3.NET35\UIAutomation.dll
 echo 'Configuring network interfaces...'
-$wmi = gwmi win32_NetworkAdapterConfiguration -Filter 'ipenabled = "true"' | sort -Property Description
+$wmi = $null
+Do {
+    Start-Sleep -Milliseconds 1000
+    $wmi = gwmi win32_NetworkAdapterConfiguration -Filter 'ipenabled = "true"' | sort -Property Description
+} While ($wmi -eq $null)
 {{ $length := len .Node.Network.Interfaces }}
 {{ range $idx, $iface := .Node.Network.Interfaces }}
     {{ $mask := $iface.NetworkMask }}
@@ -71,11 +75,7 @@ if (($host_name -eq "{{ .Node.General.Hostname }}") -or ("{{ .Node.General.Hostn
     Set-ItemProperty -Path $path -Name DefaultDomainName -Value $domain
     Set-ItemProperty -Path $path -Name AutoAdminLogon -Value 1
 {{ end }}
-    echo 'Deleting hostname script...'
-    While (Test-Path C:\startup.ps1) {
-        Start-Sleep -m 500
-        Remove-Item $MyInvocation.InvocationName
-    }
+    echo 'Startup script complete!'
 {{ if .Metadata.domain_controller }}
     echo 'Domain joined..  Restarting...'
     Restart-Computer


### PR DESCRIPTION
In an effort to be more consistent across images and to address issues
with using the `Startup` folder in newer versions of Windows to run
scripts at boot, this commit includes backwards-compatible updates to
support a scheduled task in Windows images to run Powershell scripts
present in C:\phenix\startup at boot.

Specifically, this commit updates injections created by the `Startup`
app for Windows VMs to place them in C:\phenix\startup instead of C:\.
It also updates the default Windows Scheduler script that gets placed in
the `Startup` folder to look for the `startup.ps1` script in
C:\phenix\startup.

Additionally, support for an annotation on Windows VMs in the topology
config named `includes-phenix-startup` that, when present, will prevent
the `Startup` app from adding the Windows Scheduler script to the
`Startup` folder and will instead assume that the Windows image being
used has been preconfigured with a script to run at boot that will
execute any scripts present in C:\phenix\startup.

An example of how to create such a Windows image using Packer looks like
the following:

First, create a script at the root of your Packer config directory
called `phenix-startup.ps1` that contains the following:

```
Get-ChildItem '/phenix/startup/*.ps1' | ForEach-Object {
  & $_.FullName
}
```

Then, add a few extra provisioners to your Packer build config.

```
"provisioners": [
  {
    "type": "file",
    "source": "phenix-startup.ps1",
    "destination": "/phenix/phenix-startup.ps1"
  },
  {
    "type": "windows-shell",
    "inline": "schtasks.exe /create /sc onstart /ru SYSTEM /tn phenix-startup /tr \"powershell.exe -ep bypass C:\\phenix\\phenix-startup.ps1 > C:\\phenix\\phenix-startup.log\" /f"
  }
]
```

Lastly, in your topology, annotate the Windows VM using the image like
so.

```
spec:
  topology:
    nodes:
    - type: VirtualMachine
      annotations:
        includes-phenix-startup: true
```