### PR TITLE
Update Windows startup process to add a registry entry when done

### DIFF
--- a/src/go/app/ntp.go
+++ b/src/go/app/ntp.go
@@ -92,7 +92,7 @@ func (NTP) PreStart(ctx context.Context, exp *types.Experiment) error {
 				return fmt.Errorf("generating Windows NTP script: %w", err)
 			}
 
-			node.AddInject(ntpFile, "ntp.ps1", "0755", "")
+			node.AddInject(ntpFile, "/phenix/startup/25-ntp.ps1", "0755", "")
 		}
 	}
 

--- a/src/go/app/startup.go
+++ b/src/go/app/startup.go
@@ -101,11 +101,21 @@ func (this Startup) PreStart(ctx context.Context, exp *types.Experiment) error {
 
 			node.AddInject(
 				startupFile,
-				"/phenix/startup/startup.ps1",
+				"/phenix/startup/20-startup.ps1",
 				"0755", "",
 			)
 
 			if incl, ok := node.GetAnnotation("includes-phenix-startup"); !ok || incl == "false" || incl == false {
+				node.AddInject(
+					startupDir+"/phenix-startup.ps1",
+					"/phenix/phenix-startup.ps1",
+					"0755", "",
+				)
+
+				if err := tmpl.RestoreAsset(startupDir, "phenix-startup.ps1"); err != nil {
+					return fmt.Errorf("restoring phenix startup script: %w", err)
+				}
+
 				node.AddInject(
 					startupDir+"/startup-scheduler.cmd",
 					"ProgramData/Microsoft/Windows/Start Menu/Programs/Startup/startup_scheduler.cmd",
@@ -157,7 +167,7 @@ func (Startup) PostStart(ctx context.Context, exp *types.Experiment) error {
 					mm.C2NS(exp.Metadata.Name),
 					mm.C2VM(node.General().Hostname()),
 					mm.C2SkipActiveClientCheck(true),
-					mm.C2Command(`powershell.exe -noprofile -executionpolicy bypass -file /startup.ps1`),
+					mm.C2Command(`powershell.exe -noprofile -executionpolicy bypass -file /phenix/phenix-startup.ps1`),
 				)
 
 				if err != nil {

--- a/src/go/tmpl/templates/ntp_windows.tmpl
+++ b/src/go/tmpl/templates/ntp_windows.tmpl
@@ -1,11 +1,50 @@
+function Phenix-SetNTPStatus($status) {
+    echo "Marking phenix ntp as $status in registry..."
+
+    If (-NOT (Test-Path 'HKLM:\Software\phenix')) {
+        New-Item -Path 'HKLM:\Software\phenix' -Force | Out-Null
+    }
+
+    New-ItemProperty -Path 'HKLM:\Software\phenix' -Name 'ntp' -Value $status -PropertyType String -Force | Out-Null
+}
+
+function Phenix-NTPComplete {
+    $key = Get-Item -LiteralPath 'HKLM:\Software\phenix' -ErrorAction SilentlyContinue
+
+    if ($key) {
+        $val = $key.GetValue('ntp')
+
+        if ($val) {
+          return $val -eq 'done'
+        }
+
+        return $false
+    }
+
+    return $false
+}
+
+if (Phenix-NTPComplete) {
+    exit
+}
+
+Phenix-SetNTPStatus('running')
+
 echo "Starting NTP..."
+
 net start w32time
 Start-Sleep -s 5
+
 echo "Configuring timezone to 'UTC'..."
+
 tzutil /s "UTC"
+
 echo "Configuring NTP..."
+
 w32tm /config /manualpeerlist:"{{ . }}" /syncfromflags:manual /reliable:YES /update
+
 echo "Restart NTP for the changes to take affect..."
+
 net stop w32time
 Start-Sleep -s 2
 net start w32time
@@ -15,18 +54,28 @@ net start w32time
 # server to settle and produce a valid stratum number.  Once a valid stratum is
 # received the NTP client can be restarted and forced to resync.
 echo "Wait for NTP server at {{ . }} then resync"
+
 Do {
     Start-Sleep -s 60
+
     echo "Get NTP server status"
+
     $output = w32tm /monitor /computers:{{ . }} # get the output of the w32tm monitor action
     $str = $output[2].Split(' ')[1] # get the third line of the output and split it, to get the stratum number
     $num = [convert]::ToInt32($str, 10) # convert the stratum number to an integer
+
     echo "Stratum: $num"
 } Until ($num -gt 0) # when the NTP server is not ready the stratum number will be 0, anything higher than that should mean its ready
+
 Start-Sleep -s 60
+
 net stop w32time
 Start-Sleep -s 2
 net start w32time
+
 echo "NTP Server ready, time to resync local NTP"
 w32tm /resync /force
+
+Phenix-SetNTPStatus('done')
+
 echo "Done..."

--- a/src/go/tmpl/templates/phenix-startup.ps1
+++ b/src/go/tmpl/templates/phenix-startup.ps1
@@ -1,0 +1,3 @@
+Get-ChildItem '/phenix/startup/*.ps1' | ForEach-Object {
+  & $_.FullName
+}

--- a/src/go/tmpl/templates/startup-scheduler.cmd
+++ b/src/go/tmpl/templates/startup-scheduler.cmd
@@ -1,2 +1,2 @@
-schtasks /create /tn "phenix-startup" /sc onlogon /rl highest /tr "powershell.exe -file C:\phenix\startup\startup.ps1 > C:\phenix\phenix-startup.log" /F
+schtasks /create /tn "phenix-startup" /sc onlogon /rl highest /tr "powershell.exe -file C:\phenix\phenix-startup.ps1 > C:\phenix\phenix-startup.log" /F
 schtasks /run /tn "phenix-startup"

--- a/src/go/tmpl/templates/windows_startup.tmpl
+++ b/src/go/tmpl/templates/windows_startup.tmpl
@@ -1,4 +1,37 @@
+function Phenix-SetStartupStatus($status) {
+    echo "Marking phenix startup as $status in registry..."
+
+    If (-NOT (Test-Path 'HKLM:\Software\phenix')) {
+        New-Item -Path 'HKLM:\Software\phenix' -Force | Out-Null
+    }
+
+    New-ItemProperty -Path 'HKLM:\Software\phenix' -Name 'startup' -Value $status -PropertyType String -Force | Out-Null
+}
+
+function Phenix-StartupComplete {
+    $key = Get-Item -LiteralPath 'HKLM:\Software\phenix' -ErrorAction SilentlyContinue
+
+    if ($key) {
+        $val = $key.GetValue('startup')
+
+        if ($val) {
+          return $val -eq 'done'
+        }
+
+        return $false
+    }
+
+    return $false
+}
+
+if (Phenix-StartupComplete) {
+    exit
+}
+
+Phenix-SetStartupStatus('running')
+
 Import-Module C:\Windows\System32\UIAutomation.0.8.7B3.NET35\UIAutomation.dll
+
 echo 'Configuring network interfaces...'
 $wmi = $null
 Do {
@@ -58,32 +91,34 @@ if (($host_name -eq "{{ .Node.General.Hostname }}") -or ("{{ .Node.General.Hostn
     $password = "{{ index .Metadata "domain_controller" "password" }}" | ConvertTo-SecureString -AsPlainText -Force
     $credential = New-Object System.Management.Automation.PSCredential($username,$password)
     $sysinfo = systeminfo /fo csv | ConvertFrom-Csv
+
     if ($sysinfo.Domain.contains($domain.ToUpper())) {
-        echo 'Deleting startup script...'
-        While (Test-Path C:\startup.ps1) {
-            Start-Sleep -m 500
-            Remove-Item $MyInvocation.InvocationName
-        }
+        echo 'Startup script complete!'
+        Phenix-SetStartupStatus('done')
         exit
     }
+
     echo 'Joining $domain domain'
     Add-Computer -DomainName $domain -Credential $credential
+
     echo 'Adding auto logon'
     $path = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"
     Set-ItemProperty -Path $path -Name DefaultUserName -Value $username
     Set-ItemProperty -Path $path -Name DefaultPassword -Value {{ index .Metadata "domain_controller" "password" }}
     Set-ItemProperty -Path $path -Name DefaultDomainName -Value $domain
     Set-ItemProperty -Path $path -Name AutoAdminLogon -Value 1
-{{ end }}
-    echo 'Startup script complete!'
-{{ if .Metadata.domain_controller }}
-    echo 'Domain joined..  Restarting...'
+
+    echo 'Domain joined. Restarting...'
     Restart-Computer
+{{ else }}
+    echo 'Startup script complete!'
+    Phenix-SetStartupStatus('done')
+    exit
 {{ end }}
 } else {
     echo 'Changing hostname'
     $computer_info = Get-WmiObject -Class Win32_ComputerSystem
     $computer_info.Rename("{{ .Node.General.Hostname }}")
-    echo 'Hostname changed.  Restarting...'
+    echo 'Hostname changed. Restarting...'
     Restart-Computer
 }


### PR DESCRIPTION
The following is an example of a function other scripts can use to know
if the phenix startup script has fully completed.

```
function Phenix-StartupComplete() {
    $key = Get-Item -LiteralPath 'HKLM:\Software\phenix' -ErrorAction SilentlyContinue

    if ($key) {
        $val = $key.GetValue('startup')

        if ($val) {
          return $val -eq 'done'
        }

        return $false
    }

    return $false
}
```

This commit also updates the scheduled task to run a script that will
execute all PowerShell scripts present in `C:\phenix\startup\*.ps1` on
each boot. This means any scripts placed in this directory must be
idempotent or self-delete.