### PR TITLE
vrouter minirouter: always commit changes

### DIFF
--- a/src/go/app/vrouter.go
+++ b/src/go/app/vrouter.go
@@ -217,6 +217,8 @@ func (Vrouter) PostStart(ctx context.Context, exp *types.Experiment) error {
 					return fmt.Errorf("configuring interface for router %s: %w", node.General().Hostname(), err)
 				}
 			}
+			
+			commit = true
 		}
 
 		for _, route := range node.Network().Routes() {


### PR DESCRIPTION
Even if there are no firewall rules set, commit minirouter settings so that IP address and routing rules take effect. Otherwise, minirouter does not work unless there are firewall rules defined in the scenario.