### PR TITLE
Update vmdb template

### DIFF
--- a/src/go/tmpl/templates/vmdb.tmpl
+++ b/src/go/tmpl/templates/vmdb.tmpl
@@ -31,18 +31,15 @@ steps:
       - {{ $overlay }}
       {{- end }}
   {{- end }}
+  - fstab: root
+  - grub: bios
+    tag: root
+  - mount-virtual-filesystems: root
   {{- if .Scripts }}
   - chroot: root
     shell: |
 {{ .PostBuild }}
   {{- end }}
-  - fstab: root
-  - grub: bios
-    tag: root
   {{- if .Ramdisk }}
   - ramdisk: root
   {{- end }}
-  - shell: |
-      echo Disk usage of this installation:
-      du -sh "$ROOT"
-    root-fs: root


### PR DESCRIPTION
Add `mount-virtual-filesystems` to support running services (e.g., docker) inside chroot during build. Moved fstab and grub earlier to avoid conflict with virtual filesystem mounts.