### PR TITLE
Ubuntu18.04.6:Files tab date column populated

### DIFF
--- a/src/go/internal/file/file.go
+++ b/src/go/internal/file/file.go
@@ -342,8 +342,8 @@ func fillInFileDates(expName string, expFiles map[string]ExperimentFile) {
 
 	// First get file listings from mesh, then from headnode.
 	commands := []string{
-		"mesh send all shell /usr/bin/ls -alht --full-time " + dirPath,
-		"shell /usr/bin/ls -alht --full-time " + dirPath,
+		"mesh send all shell ls -alht --full-time " + dirPath,
+		"shell ls -alht --full-time " + dirPath,
 	}
 
 	cmd := mmcli.NewCommand()


### PR DESCRIPTION
This fixes the **[UI] Ubuntu 18.04.6 Files Tab Date Column Empty** issue.  The problem was a hardcoded absolute path to the `ls` command.  Since the location of the `ls` command can vary by Linux distribution, the absolute path reference was removed.  The minimega shell command will call `exec.LookPath` to find the absolute path to a command as long as the command is listed in the PATH environment variable.   The screenshot below shows that the issue has been fixed.
![date_column_18 04_populated](https://user-images.githubusercontent.com/75450207/165663844-9f02a583-50e7-4570-8483-d78bffee4f19.JPG)


