### PR TITLE
Allow for assigning VLAN alias to VLAN ID mappings in UI

### DIFF
--- a/src/go/web/server.go
+++ b/src/go/web/server.go
@@ -122,6 +122,7 @@ func Start(opts ...ServerOption) error {
 	api.Handle("/experiments/builder", weberror.ErrorHandler(CreateExperimentFromBuilder)).Methods("POST", "OPTIONS")
 	api.Handle("/experiments/builder", weberror.ErrorHandler(UpdateExperimentFromBuilder)).Methods("PUT", "OPTIONS")
 	api.Handle("/experiments/{name}", weberror.ErrorHandler(GetExperiment)).Methods("GET", "OPTIONS")
+	api.Handle("/experiments/{name}", weberror.ErrorHandler(UpdateExperiment)).Methods("PATCH", "OPTIONS")
 	api.HandleFunc("/experiments/{name}", DeleteExperiment).Methods("DELETE", "OPTIONS")
 	api.Handle("/experiments/{name}/apps", weberror.ErrorHandler(GetExperimentApps)).Methods("GET", "OPTIONS")
 	api.HandleFunc("/experiments/{name}/start", StartExperiment).Methods("POST", "OPTIONS")


### PR DESCRIPTION
It will be possible to assign a VLAN ID to a VLAN alias within an existing experiment in the Stopped Component.