### PR TITLE
Update ntp_windows script to work with Win10

### DIFF
--- a/src/go/tmpl/templates/ntp_windows.tmpl
+++ b/src/go/tmpl/templates/ntp_windows.tmpl
@@ -32,6 +32,7 @@ Phenix-SetNTPStatus('running')
 
 echo "Starting NTP..."
 
+Set-Service -Name w32time -StartupType Automatic
 net start w32time
 Start-Sleep -s 5
 
@@ -61,9 +62,16 @@ Do {
     echo "Get NTP server status"
 
     $output = w32tm /monitor /computers:{{ . }} # get the output of the w32tm monitor action
-    $str = $output[2].Split(' ')[1] # get the third line of the output and split it, to get the stratum number
-    $num = [convert]::ToInt32($str, 10) # convert the stratum number to an integer
 
+    # find stratum number in output
+    ForEach ($line in $output) {
+        if ($line -ilike "*stratum*") {
+            $str = $line.Split(' ')[-1]
+            break
+        }
+    }
+
+    $num = [convert]::ToInt32($str, 10) # convert the stratum number to an integer
     echo "Stratum: $num"
 } Until ($num -gt 0) # when the NTP server is not ready the stratum number will be 0, anything higher than that should mean its ready
 


### PR DESCRIPTION
Windows 10 has a slightly different output format when calling the `w32tm /monitor` command. This update makes the windows ntp script more flexible in getting the current `Stratum` value so it works with Win7 or Win10