### PR TITLE
Revert "Update vmdb template (#93)"

### DIFF
--- a/src/go/tmpl/templates/vmdb.tmpl
+++ b/src/go/tmpl/templates/vmdb.tmpl
@@ -31,15 +31,18 @@ steps:
       - {{ $overlay }}
       {{- end }}
   {{- end }}
-  - fstab: root
-  - grub: bios
-    tag: root
-  - mount-virtual-filesystems: root
   {{- if .Scripts }}
   - chroot: root
     shell: |
 {{ .PostBuild }}
   {{- end }}
+  - fstab: root
+  - grub: bios
+    tag: root
   {{- if .Ramdisk }}
   - ramdisk: root
   {{- end }}
+  - shell: |
+      echo Disk usage of this installation:
+      du -sh "$ROOT"
+    root-fs: root


### PR DESCRIPTION
This reverts commit 98de05bd00ba23d8c1de986aad1f8311702dd480. Using `mount-virtual-filesystems` causes issues during image build, specifically with regarding DNS and not being able to resolve hostnames.