### PR TITLE
Add -Force to 'Restart-Computer' and log errors

### DIFF
--- a/src/go/tmpl/templates/windows_startup.tmpl
+++ b/src/go/tmpl/templates/windows_startup.tmpl
@@ -134,5 +134,7 @@ if (($host_name -eq "{{ .Node.General.Hostname }}") -or ("{{ .Node.General.Hostn
     $computer_info = Get-WmiObject -Class Win32_ComputerSystem
     $computer_info.Rename("{{ .Node.General.Hostname }}")
     echo 'Hostname changed. Restarting...'
-    Restart-Computer
+    Restart-Computer -Force
 }
+
+$error | Out-File C:\phenix-startup-error.log


### PR DESCRIPTION
In cases where the phenix-startup service is set to run as SYSTEM, the "Restart-Computer" command will fail silently if a user is logged in (e.g., auto login is configured). Adding -Force bypasses this, and capturing any error output helps debugging.