### PR TITLE
Add Ability to Mount VMs and Download/Upload Files

### DIFF
--- a/src/go/api/config/default/experiment-viewer.yml
+++ b/src/go/api/config/default/experiment-viewer.yml
@@ -19,3 +19,8 @@ spec:
     - "*"
     verbs:
     - list
+  - resources:
+    - "vms/mount"
+    verbs:
+    - post
+    - delete

--- a/src/go/api/config/default/global-viewer.yml
+++ b/src/go/api/config/default/global-viewer.yml
@@ -10,6 +10,15 @@ spec:
     - "*/*"
     resourceNames:
     - "*"
+    - "*/*"
     verbs:
     - list
     - get
+  - resources:
+    - "vms/mount"
+    resourceNames:
+    - "*"
+    - "*/*"
+    verbs:
+    - post
+    - delete

--- a/src/go/api/config/default/vm-viewer.yml
+++ b/src/go/api/config/default/vm-viewer.yml
@@ -14,3 +14,10 @@ spec:
     - "vms/vnc"
     verbs:
     - get
+  - resources:
+    - "vms/mount"
+    verbs:
+    - post
+    - list
+    - delete
+    - get

--- a/src/go/api/experiment/experiment.go
+++ b/src/go/api/experiment/experiment.go
@@ -729,7 +729,7 @@ func Delete(name string) error {
 	return errors
 }
 
-func Files(name, filter string) (file.ExperimentFiles, error) {
+func Files(name, filter string) (file.Files, error) {
 	return file.GetExperimentFiles(name, filter)
 }
 

--- a/src/go/api/vm/vm.go
+++ b/src/go/api/vm/vm.go
@@ -99,6 +99,7 @@ func List(expName string) ([]mm.VM, error) {
 			vm.CPUs = details.CPUs
 			vm.RAM = details.RAM
 			vm.Disk = details.Disk
+			vm.CCActive = details.CCActive
 
 			// `vm.IPv4` could be nil/empty if minimega isn't reporting any IPs for it
 			if len(vm.IPv4) == 0 {
@@ -218,6 +219,7 @@ func Get(expName, vmName string) (*mm.VM, error) {
 	vm.CPUs = details[0].CPUs
 	vm.RAM = details[0].RAM
 	vm.Disk = details[0].Disk
+	vm.CCActive = details[0].CCActive
 
 	// `vm.IPv4` could be nil/empty if minimega isn't reporting any IPs for it
 	if len(vm.IPv4) == 0 {

--- a/src/go/app/startup.go
+++ b/src/go/app/startup.go
@@ -61,8 +61,9 @@ func (this Startup) PreStart(ctx context.Context, exp *types.Experiment) error {
 				if h, ok := ips[iface.Address()]; ok {
 					return fmt.Errorf("duplicate IP detected: %s and %s both have %s configured", h, node.General().Hostname(), iface.Address())
 				}
-
-				ips[iface.Address()] = node.General().Hostname()
+				if iface.Address() != "" {
+					ips[iface.Address()] = node.General().Hostname()
+				}
 			}
 		}
 

--- a/src/go/cmd/ui.go
+++ b/src/go/cmd/ui.go
@@ -57,6 +57,7 @@ func newUiCmd() *cobra.Command {
 				web.ServeWithTLS(viper.GetString("ui.tls-key"), viper.GetString("ui.tls-cert")),
 				web.ServePhenixLogs(viper.GetString("ui.logs.phenix-path")),
 				web.ServeMinimegaLogs(viper.GetString("ui.logs.minimega-path")),
+				web.ServeWithFeatures(viper.GetStringSlice("ui.features")),
 			}
 
 			if MustGetBool(cmd.Flags(), "log-requests") {
@@ -90,6 +91,7 @@ func newUiCmd() *cobra.Command {
 	cmd.Flags().Bool("log-verbose", true, "write UI logs to STDERR")
 	cmd.Flags().String("logs.phenix-path", "", "path to phenix log file to publish to UI")
 	cmd.Flags().String("logs.minimega-path", "", "path to minimega log file to publish to UI")
+	cmd.Flags().StringSlice("features", nil, "list of features to enable (options: vm-mount)")
 
 	viper.BindPFlag("ui.listen-endpoint", cmd.Flags().Lookup("listen-endpoint"))
 	viper.BindPFlag("ui.base-path", cmd.Flags().Lookup("base-path"))
@@ -101,6 +103,7 @@ func newUiCmd() *cobra.Command {
 	viper.BindPFlag("ui.log-verbose", cmd.Flags().Lookup("log-verbose"))
 	viper.BindPFlag("ui.logs.phenix-path", cmd.Flags().Lookup("logs.phenix-path"))
 	viper.BindPFlag("ui.logs.minimega-path", cmd.Flags().Lookup("logs.minimega-path"))
+	viper.BindPFlag("ui.features", cmd.Flags().Lookup("features"))
 
 	viper.BindEnv("ui.listen-endpoint")
 	viper.BindEnv("ui.base-path")
@@ -111,6 +114,7 @@ func newUiCmd() *cobra.Command {
 	viper.BindEnv("ui.log-verbose")
 	viper.BindEnv("ui.logs.phenix-path")
 	viper.BindEnv("ui.logs.minimega-path")
+	viper.BindEnv("ui.features")
 
 	cmd.Flags().Bool("log-requests", false, "Log API requests")
 	cmd.Flags().Bool("log-full", false, "Log API requests and responses")

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -46,6 +46,7 @@ github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0 h1:XJIw/+VlJ+87J+doOxznsAWIdmWuViOVhkQamW5YV28=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
@@ -128,6 +129,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -337,6 +339,7 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
@@ -416,6 +419,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -449,6 +453,8 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
@@ -457,6 +463,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/src/go/util/file/search.go
+++ b/src/go/util/file/search.go
@@ -157,7 +157,7 @@ func BuildTree(searchFilter string) *ExpressionTree {
 
 }
 
-func (node *ExpressionTree) Evaluate(experimentFile *ExperimentFile) bool {
+func (node *ExpressionTree) Evaluate(experimentFile *File) bool {
 
 	if node == nil {
 		return false
@@ -324,7 +324,7 @@ func getSearchFields(term string) []string {
 
 }
 
-func (node *ExpressionTree) match(file *ExperimentFile) bool {
+func (node *ExpressionTree) match(file *File) bool {
 
 	for _, field := range node.searchFields {
 		switch field {
@@ -409,7 +409,7 @@ func (node *ExpressionTree) match(file *ExperimentFile) bool {
 					spec := fileSizeSpec.FindAllStringSubmatch(newTerm, -1)[0][0]
 					newTerm = fileSizeSpec.ReplaceAllString(newTerm, "")
 
-					fileSize, err = strconv.Atoi(newTerm)
+					fileSize, err = strconv.ParseInt(newTerm, 10, 64)
 					if err != nil {
 						return false
 					}
@@ -437,15 +437,15 @@ func (node *ExpressionTree) match(file *ExperimentFile) bool {
 
 				switch compOp {
 				case "<":
-					return file.Size < fileSize.(int)
+					return file.Size < fileSize.(int64)
 				case ">":
-					return file.Size > fileSize.(int)
+					return file.Size > fileSize.(int64)
 				case "=":
-					return file.Size == fileSize.(int)
+					return file.Size == fileSize.(int64)
 				case ">=":
-					return file.Size > fileSize.(int) || file.Size == fileSize.(int)
+					return file.Size > fileSize.(int64) || file.Size == fileSize.(int64)
 				case "<=":
-					return file.Size < fileSize.(int) || file.Size == fileSize.(int)
+					return file.Size < fileSize.(int64) || file.Size == fileSize.(int64)
 
 				}
 

--- a/src/go/util/mm/mmcli/command.go
+++ b/src/go/util/mm/mmcli/command.go
@@ -5,6 +5,7 @@ package mmcli
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // Command represents a command and options to send to minimega.
@@ -13,6 +14,7 @@ type Command struct {
 	Columns   []string
 	Filters   []string
 	Namespace string
+	Timeout   time.Duration
 }
 
 // NewCommand returns a pointer to a new, initialized command.

--- a/src/go/util/mm/option.go
+++ b/src/go/util/mm/option.go
@@ -138,6 +138,8 @@ type c2Options struct {
 	testConn string
 	sendFile string
 
+	mount *bool
+
 	timeout time.Duration
 	wait    bool
 
@@ -199,6 +201,20 @@ func C2TestConn(t string) C2Option {
 func C2SendFile(f string) C2Option {
 	return func(o *c2Options) {
 		o.sendFile = f
+	}
+}
+
+func C2Mount() C2Option {
+	return func(o *c2Options) {
+		t := true
+		o.mount = &t
+	}
+}
+
+func C2Unmount() C2Option {
+	return func(o *c2Options) {
+		f := false
+		o.mount = &f
 	}
 }
 

--- a/src/go/util/mm/types.go
+++ b/src/go/util/mm/types.go
@@ -214,6 +214,7 @@ type VM struct {
 	Captures   []Capture `json:"captures"`
 	Running    bool      `json:"running"`
 	Busy       bool      `json:"busy"`
+	CCActive   bool      `json:"ccActive"`
 	Uptime     float64   `json:"uptime"`
 	Screenshot string    `json:"screenshot,omitempty"`
 	Tags       []string  `json:"tags"`

--- a/src/go/web/features.go
+++ b/src/go/web/features.go
@@ -1,0 +1,19 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"phenix/web/util"
+)
+
+// GET /version
+func GetFeatures(w http.ResponseWriter, r *http.Request) {
+	features := o.features
+	if features == nil {
+		features = make([]string, 0)
+	}
+
+	body, _ := json.Marshal(util.WithRoot("features", features))
+	w.Write(body)
+}

--- a/src/go/web/middleware/auth.go
+++ b/src/go/web/middleware/auth.go
@@ -113,14 +113,19 @@ func AuthMiddleware(jwtKey string) mux.MiddlewareFunc {
 		})
 	}
 
+	// For testing, treats all requests as coming from a given user/role.
+	// To use start with jwt key of format "dev|<username>|<role>"
+	// e.g., "dev|testuser|global-viewer"
 	devAuthMiddleware := func(h http.Handler) http.Handler {
 		creds := strings.Split(jwtKey, "|")
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
+			role, _ := rbac.RoleFromConfig(creds[2])
+
 			ctx = context.WithValue(ctx, "user", creds[1])
-			ctx = context.WithValue(ctx, "role", creds[2])
+			ctx = context.WithValue(ctx, "role", *role)
 
 			h.ServeHTTP(w, r.WithContext(ctx))
 		})

--- a/src/go/web/mount.go
+++ b/src/go/web/mount.go
@@ -1,0 +1,343 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"phenix/util/file"
+	"phenix/util/mm"
+	"phenix/web/rbac"
+	"phenix/web/util"
+
+	log "github.com/activeshadow/libminimega/minilog"
+	"github.com/gorilla/mux"
+)
+
+// Small struct for tracking number of users interacting with a mount and the
+// lock for that mount.
+type MountInfo struct {
+	users int
+	lock  *sync.RWMutex
+}
+
+var (
+	// generally, use exclusive WLock for mount/unmount ops; RLock for file interactions
+	activeMounts = make(map[string]*MountInfo)
+	// locks activeMounts map itself
+	activeMountsMu sync.RWMutex
+)
+
+// POST /experiments/{exp}/vms/{name}/mount
+func MountVM(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	role := r.Context().Value("role").(rbac.Role)
+
+	if !role.Allowed("vms/mount", "post", fmt.Sprintf("%s/%s", vars["exp"], vars["name"])) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	mapKey := mm.GetLocalMountPath(vars["exp"], vars["name"])
+
+	activeMountsMu.Lock()
+	defer activeMountsMu.Unlock()
+
+	mountInfo, exists := activeMounts[mapKey]
+	if exists {
+		log.Info("Adding additional user to mount %s, total=%d", mapKey, mountInfo.users)
+
+		mountInfo.users += 1
+	} else {
+		log.Info("Mounting %s", mapKey)
+
+		_, err := mm.ExecC2Command(mm.C2NS(vars["exp"]), mm.C2VM(vars["name"]), mm.C2Mount(), mm.C2IDClientsByUUID(), mm.C2Timeout(5*time.Second))
+
+		// if already mounted, that's ok, but still add to map
+		if err != nil && !strings.Contains(err.Error(), "already connected") {
+			log.Error(err.Error())
+			http.Error(w, fmt.Sprintf("Error mounting: %s", err), http.StatusInternalServerError)
+
+			return
+		}
+
+		activeMounts[mapKey] = &MountInfo{1, &sync.RWMutex{}}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// POST /experiments/{exp}/vms/{name}/unmount
+func UnmountVM(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	role := r.Context().Value("role").(rbac.Role)
+
+	if !role.Allowed("vms/mount", "delete", fmt.Sprintf("%s/%s", vars["exp"], vars["name"])) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	mapKey := mm.GetLocalMountPath(vars["exp"], vars["name"])
+
+	activeMountsMu.Lock()
+	defer activeMountsMu.Unlock()
+
+	mountInfo, exists := activeMounts[mapKey]
+	if exists {
+		mountInfo.users -= 1
+
+		if mountInfo.users == 0 {
+			log.Info("Unmounting %s", mapKey)
+
+			log.Debug("acquiring lock for mount")
+			mountInfo.lock.Lock()
+			log.Debug("acquired lock for mount")
+
+			_, err := mm.ExecC2Command(mm.C2NS(vars["exp"]), mm.C2VM(vars["name"]), mm.C2Unmount(), mm.C2Timeout(5*time.Second), mm.C2SkipActiveClientCheck(true))
+			if err != nil {
+				mountInfo.lock.Unlock()
+
+				log.Error(err.Error())
+				http.Error(w, fmt.Sprintf("Error unmounting: %s", err), http.StatusInternalServerError)
+
+				return
+			}
+
+			delete(activeMounts, mapKey)
+		} else {
+			log.Info("Call to unmount %s but skipping since %d users remain", mapKey, mountInfo.users)
+		}
+	} else {
+		log.Warn("Tried to unmount VM %s whose lock was not in map", vars["name"])
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GET /experiments/{exp}/vms/{name}/mount/files?path=
+func GetMountFiles(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	basePath := mm.GetLocalMountPath(vars["exp"], vars["name"])
+
+	role := r.Context().Value("role").(rbac.Role)
+	if !role.Allowed("vms/mount", "list", fmt.Sprintf("%s/%s", vars["exp"], vars["name"])) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	log.Info("getting files from mount %s", basePath)
+
+	activeMountsMu.RLock()
+	mountInfo, exists := activeMounts[basePath]
+	activeMountsMu.RUnlock()
+
+	if !exists {
+		http.Error(w, fmt.Sprintf("No existing mount for %s", basePath), http.StatusBadRequest)
+		return
+	}
+
+	log.Debug("acquiring rlock for mount")
+	mountInfo.lock.RLock()
+	log.Debug("acquired rlock for mount")
+	defer mountInfo.lock.RUnlock()
+
+	combinedPath := filepath.Join(basePath, vars["path"])
+	log.Info("combinedPath: %s", combinedPath)
+
+	var (
+		info fs.FileInfo
+		err  error
+		done = make(chan struct{})
+	)
+
+	go func() {
+		info, err = os.Stat(combinedPath)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if err != nil {
+			errString := fmt.Sprintf("Error getting path %s: %v", combinedPath, err)
+
+			log.Error(errString)
+			http.Error(w, errString, http.StatusInternalServerError)
+
+			return
+		}
+
+		if !info.IsDir() {
+			http.Error(w, fmt.Sprintf("Expected directory not file: %s", combinedPath), http.StatusBadRequest)
+			return
+		}
+	case <-time.After(2 * time.Second):
+		err := fmt.Sprintf("timeout getting path %s", combinedPath)
+
+		log.Error(err)
+		http.Error(w, err, http.StatusInternalServerError)
+
+		return
+	}
+
+	if !strings.HasPrefix(combinedPath, basePath) {
+		errString := fmt.Sprintf("Error getting path %s: Path is not within mount", combinedPath)
+		log.Error(errString)
+		http.Error(w, errString, http.StatusBadRequest)
+		return
+	}
+
+	var dirFiles []fs.FileInfo
+	done = make(chan struct{})
+
+	go func() {
+		dirFiles, err = ioutil.ReadDir(combinedPath)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if err != nil {
+			errString := fmt.Sprintf("Error getting files in %s: %v", combinedPath, err)
+
+			log.Error(errString)
+			http.Error(w, errString, http.StatusInternalServerError)
+
+			return
+		}
+
+		var files file.Files
+
+		for _, f := range dirFiles {
+			file := file.MakeFile(f, combinedPath)
+
+			file.Path = strings.TrimPrefix(file.Path, basePath)
+
+			files = append(files, file)
+		}
+
+		body, _ := json.Marshal(util.WithRoot("files", files))
+		w.Write(body)
+	case <-time.After(2 * time.Second):
+		err := fmt.Sprintf("timeout getting files in %s", combinedPath)
+
+		log.Error(err)
+		http.Error(w, err, http.StatusInternalServerError)
+	}
+}
+
+// GET /experiments/{exp}/vms/{name}/files/download?path=
+func DownloadMountFile(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	basePath := mm.GetLocalMountPath(vars["exp"], vars["name"])
+
+	role := r.Context().Value("role").(rbac.Role)
+	if !role.Allowed("vms/mount", "get", fmt.Sprintf("%s/%s", vars["exp"], vars["name"])) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	activeMountsMu.RLock()
+	mountInfo, exists := activeMounts[basePath]
+	activeMountsMu.RUnlock()
+
+	if !exists {
+		http.Error(w, fmt.Sprintf("No existing mount for %s", basePath), http.StatusBadRequest)
+		return
+	}
+
+	mountInfo.lock.RLock()
+	defer mountInfo.lock.RUnlock()
+
+	combinedPath := filepath.Join(basePath, vars["path"])
+	log.Info("combinedPath: %s", combinedPath)
+	fileInfo, err := os.Stat(combinedPath)
+
+	if err != nil {
+		errString := fmt.Sprintf("Error getting path %s: %s", combinedPath, err.Error())
+		log.Error(errString)
+		http.Error(w, errString, http.StatusInternalServerError)
+		return
+	}
+	if !strings.HasPrefix(combinedPath, basePath) {
+		errString := fmt.Sprintf("Error getting path %s: Path is not within mount", combinedPath)
+		log.Error(errString)
+		http.Error(w, errString, http.StatusBadRequest)
+		return
+	}
+	if fileInfo.IsDir() {
+		http.Error(w, fmt.Sprintf("Can't download directory: %s", combinedPath), http.StatusBadRequest)
+		return
+	}
+	log.Info("Download for file: %s", fileInfo.Name())
+
+	w.Header().Set("Content-Disposition", "attachment; filename="+strconv.Quote(fileInfo.Name()))
+	w.Header().Set("Content-Type", "application/octet-stream")
+	http.ServeFile(w, r, combinedPath)
+}
+
+// PUT /experiments/{exp}/vms/{name}/files/download?path=
+func UploadMountFile(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	basePath := mm.GetLocalMountPath(vars["exp"], vars["name"])
+
+	role := r.Context().Value("role").(rbac.Role)
+	if !role.Allowed("vms/mount", "patch", fmt.Sprintf("%s/%s", vars["exp"], vars["name"])) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	activeMountsMu.RLock()
+	mountInfo, exists := activeMounts[basePath]
+	activeMountsMu.RUnlock()
+
+	if !exists {
+		http.Error(w, fmt.Sprintf("No existing mount for %s", basePath), http.StatusBadRequest)
+		return
+	}
+
+	mountInfo.lock.RLock()
+	defer mountInfo.lock.RUnlock()
+
+	combinedPath := filepath.Join(basePath, vars["path"])
+	log.Info("combinedPath: %s", combinedPath)
+	_, err := os.Stat(combinedPath)
+	if err != nil {
+		errString := fmt.Sprintf("Error getting path %s: %s", combinedPath, err.Error())
+		log.Error(errString)
+		http.Error(w, errString, http.StatusInternalServerError)
+		return
+	}
+	if !strings.HasPrefix(combinedPath, basePath) {
+		errString := fmt.Sprintf("Error getting path %s: Path is not within mount", combinedPath)
+		log.Error(errString)
+		http.Error(w, errString, http.StatusBadRequest)
+		return
+	}
+
+	clientFile, handler, err := r.FormFile("file")
+	if err != nil {
+		log.Error(err.Error())
+		http.Error(w, fmt.Sprintf("Error uploading: %s", err.Error()), http.StatusInternalServerError)
+	}
+
+	defer clientFile.Close()
+
+	localFile, err := os.OpenFile(filepath.Join(combinedPath, handler.Filename), os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		log.Error(err.Error())
+		http.Error(w, fmt.Sprintf("Error uploading: %s", err.Error()), http.StatusInternalServerError)
+	}
+
+	defer localFile.Close()
+
+	io.Copy(localFile, clientFile)
+}

--- a/src/go/web/option.go
+++ b/src/go/web/option.go
@@ -26,6 +26,8 @@ type serverOptions struct {
 	basePath  string
 
 	jwtLifetime time.Duration
+
+	features []string
 }
 
 func newServerOptions(opts ...ServerOption) serverOptions {
@@ -34,6 +36,7 @@ func newServerOptions(opts ...ServerOption) serverOptions {
 		users:       []string{"admin@foo.com:foobar:Global Admin"},
 		basePath:    "/",
 		jwtLifetime: 24 * time.Hour,
+		features:    make([]string, 0),
 	}
 
 	for _, opt := range opts {
@@ -65,6 +68,16 @@ func (this serverOptions) tlsEnabled() bool {
 	}
 
 	return true
+}
+
+func (this serverOptions) featured(f string) bool {
+	for _, feature := range this.features {
+		if strings.EqualFold(feature, f) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func ServeOnEndpoint(e string) ServerOption {
@@ -131,5 +144,15 @@ func ServeBasePath(p string) ServerOption {
 func ServeWithJWTLifetime(l time.Duration) ServerOption {
 	return func(o *serverOptions) {
 		o.jwtLifetime = l
+	}
+}
+
+func ServeWithFeatures(f []string) ServerOption {
+	return func(o *serverOptions) {
+		if f == nil {
+			o.features = make([]string, 0)
+		} else {
+			o.features = f
+		}
 	}
 }

--- a/src/go/web/proto/experiment.proto
+++ b/src/go/web/proto/experiment.proto
@@ -96,15 +96,3 @@ message UpdateScheduleRequest {
 message AppList {
 	repeated string applications = 1;
 }
-
-message ExperimentFile {
-	string name = 1;
-	string date = 2;
-	uint32 size = 3;
-	repeated string categories = 4;
-}
-
-message ExperimentFileList {
-	repeated ExperimentFile files = 1;
-	uint32 total = 2;
-}

--- a/src/go/web/proto/vm.proto
+++ b/src/go/web/proto/vm.proto
@@ -20,6 +20,7 @@ message VM {
   string experiment = 15;
   string state = 16;
   repeated string tags = 17;
+  bool cc_active = 18;
 
   string delayed_start = 20 [json_name="delayed_start"];
 }

--- a/src/go/web/server.go
+++ b/src/go/web/server.go
@@ -70,6 +70,7 @@ func Start(opts ...ServerOption) error {
 		}
 	}
 
+	router.HandleFunc("/features", GetFeatures).Methods("GET")
 	router.HandleFunc("/version", GetVersion).Methods("GET")
 	router.HandleFunc("/builder", GetBuilder).Methods("GET")
 	router.HandleFunc("/builder/save", SaveBuilderTopology).Methods("POST")
@@ -170,6 +171,15 @@ func Start(opts ...ServerOption) error {
 	api.HandleFunc("/experiments/{exp}/vms/{name}/snapshots/{snapshot}", RestoreVM).Methods("POST", "OPTIONS")
 	api.HandleFunc("/experiments/{exp}/vms/{name}/commit", CommitVM).Methods("POST", "OPTIONS")
 	api.HandleFunc("/experiments/{exp}/vms/{name}/memorySnapshot", CreateVMMemorySnapshot).Methods("POST", "OPTIONS")
+
+	if o.featured("vm-mount") {
+		api.HandleFunc("/experiments/{exp}/vms/{name}/mount", MountVM).Methods("POST", "OPTIONS")
+		api.HandleFunc("/experiments/{exp}/vms/{name}/unmount", UnmountVM).Methods("DELETE", "OPTIONS")
+		api.HandleFunc("/experiments/{exp}/vms/{name}/files", GetMountFiles).Methods("GET", "OPTIONS").Queries("path", "{path}")
+		api.HandleFunc("/experiments/{exp}/vms/{name}/files/download", DownloadMountFile).Methods("GET", "OPTIONS").Queries("path", "{path}")
+		api.HandleFunc("/experiments/{exp}/vms/{name}/files/upload", UploadMountFile).Methods("PUT", "OPTIONS").Queries("path", "{path}")
+	}
+
 	api.HandleFunc("/vms", GetAllVMs).Methods("GET", "OPTIONS")
 	api.HandleFunc("/applications", GetApplications).Methods("GET", "OPTIONS")
 	api.HandleFunc("/topologies", GetTopologies).Methods("GET", "OPTIONS")

--- a/src/go/web/util/protobuf.go
+++ b/src/go/web/util/protobuf.go
@@ -5,7 +5,6 @@ import (
 
 	"phenix/types"
 	ifaces "phenix/types/interfaces"
-	"phenix/util/file"
 	"phenix/util/mm"
 	"phenix/web/cache"
 	"phenix/web/proto"
@@ -108,6 +107,7 @@ func VMToProtobuf(exp string, vm mm.VM, topology ifaces.TopologySpec) *proto.VM 
 		Experiment: exp,
 		State:      vm.State,
 		Tags:       vm.Tags,
+		CcActive:   vm.CCActive,
 	}
 
 	if topology == nil {
@@ -190,20 +190,4 @@ func UserToProtobuf(u rbac.User) *proto.User {
 	}
 
 	return user
-}
-
-func ExperimentFileListToProtobuf(experimentFiles []file.ExperimentFile) *proto.ExperimentFileList {
-	var protoExperimentFiles []*proto.ExperimentFile
-
-	for _, experimentFile := range experimentFiles {
-		protoExperimentFiles = append(protoExperimentFiles,
-			&proto.ExperimentFile{
-				Name:       experimentFile.Name,
-				Date:       experimentFile.Date,
-				Size:       uint32(experimentFile.Size),
-				Categories: experimentFile.Categories,
-			})
-	}
-
-	return &proto.ExperimentFileList{Files: protoExperimentFiles}
 }

--- a/src/js/.eslintrc.js
+++ b/src/js/.eslintrc.js
@@ -9,9 +9,12 @@ module.exports = {
   ],
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
   },
   parserOptions: {
     parser: 'babel-eslint'
   }
+
+  
 }

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -12,7 +12,7 @@
     "@fortawesome/fontawesome-free": "^5.15.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/vue-fontawesome": "^2.0.6",
-    "buefy": "^0.8.0",
+    "buefy": "^0.9.22",
     "d3": "^6.2.0",
     "file-saver": "^2.0.5",
     "js-yaml": "^4.1.0",

--- a/src/js/src/App.vue
+++ b/src/js/src/App.vue
@@ -3,7 +3,7 @@ This is the main file for the Vue app. It sets the header, footer,
 and body to the overall Vue window. Header and Footer are separate
 Vue components. There is a dispatch that is used to check for auto
 login and returns a user to Experiments component if successful.
- -->
+-->
 
 <template>
   <div class="container">
@@ -34,7 +34,16 @@ login and returns a user to Experiments component if successful.
       }
     },
     
-    created () {
+    async created () {
+      try {
+        let resp     = await fetch(this.$router.resolve({ name: 'features'}).href);
+        let features = await resp.json();
+
+        this.$store.commit( 'FEATURES', features['features'] );
+      } catch (err) {
+        console.log(`ERROR getting features: ${err}`);
+      }
+
       this.wsConnect();
 
       this.unwatch = this.$store.watch(
@@ -242,6 +251,10 @@ clue what this stuff does.
   $table-background-color: #484848;
   
   $button-text-color: whitesmoke;
+
+
+  $breadcrumb-item-color: $info !important;
+  $breadcrumb-item-active-color: $light-invert !important;
 
   $light: #686868;
   $light-invert: findColorInvert( $light );

--- a/src/js/src/components/Configs.vue
+++ b/src/js/src/components/Configs.vue
@@ -206,43 +206,41 @@
               </div>
             </section>
           </template>
-          <template slot-scope="props">
-            <b-table-column field="kind" label="Kind" width="200" sortable>
-              {{ props.row.kind }}
-            </b-table-column>
-            <b-table-column field="name" label="Name" width="400" sortable>
-              <template v-if="adminUser()">
-                <b-tooltip label="view config" type="is-dark">
-                  <div class="field">
-                    <div @click="viewConfig( props.row )">
-                      {{ props.row.metadata.name }}
-                    </div>
+          <b-table-column field="kind" label="Kind" width="200" sortable v-slot="props">
+            {{ props.row.kind }}
+          </b-table-column>
+          <b-table-column field="name" label="Name" width="400" sortable v-slot="props">
+            <template v-if="adminUser()">
+              <b-tooltip label="view config" type="is-dark">
+                <div class="field">
+                  <div @click="viewConfig( props.row )">
+                    {{ props.row.metadata.name }}
                   </div>
-                </b-tooltip>
-                &nbsp;
-                <b-tag type="is-info" v-if="isBuilderTopology(props.row)">builder</b-tag>
-              </template>
-              <template v-else>
-                {{ props.row.metadata.name }}
-                &nbsp;
-                <b-tag type="is-info" v-if="isBuilderTopology(props.row)">builder</b-tag>
-              </template>
-            </b-table-column>
-            <b-table-column field="updated" label="Last Updated">
-              {{ props.row.metadata.updated }}
-            </b-table-column>
-            <b-table-column v-if="globalUser()" label="Actions" centered>
-              <button class="button is-light is-small action" @click="action( 'edit', props.row )">
-                <b-icon icon="edit"></b-icon>
-              </button>
-              <button class="button is-light is-small action" @click="action( 'dl', props.row )">
-                <b-icon icon="download"></b-icon>
-              </button>
-              <button class="button is-light is-small action" @click="action( 'del', props.row )">
-                <b-icon icon="trash"></b-icon>
-              </button>
-            </b-table-column>
-          </template>
+                </div>
+              </b-tooltip>
+              &nbsp;
+              <b-tag type="is-info" v-if="isBuilderTopology(props.row)">builder</b-tag>
+            </template>
+            <template v-else>
+              {{ props.row.metadata.name }}
+              &nbsp;
+              <b-tag type="is-info" v-if="isBuilderTopology(props.row)">builder</b-tag>
+            </template>
+          </b-table-column>
+          <b-table-column field="updated" label="Last Updated" v-slot="props">
+            {{ props.row.metadata.updated }}
+          </b-table-column>
+          <b-table-column v-if="globalUser()" label="Actions" centered v-slot="props">
+            <button class="button is-light is-small action" @click="action( 'edit', props.row )">
+              <b-icon icon="edit"></b-icon>
+            </button>
+            <button class="button is-light is-small action" @click="action( 'dl', props.row )">
+              <b-icon icon="download"></b-icon>
+            </button>
+            <button class="button is-light is-small action" @click="action( 'del', props.row )">
+              <b-icon icon="trash"></b-icon>
+            </button>
+          </b-table-column>
         </b-table>
         <br>
         <b-field v-if="paginationNeeded" grouped position="is-right">

--- a/src/js/src/components/Experiments.vue
+++ b/src/js/src/components/Experiments.vue
@@ -124,67 +124,65 @@
               </div>
             </section>
           </template>
-          <template slot-scope="props">
-            <b-table-column field="name" label="Name" width="200" sortable>
-              <template v-if="updating( props.row.status )">
+          <b-table-column field="name" label="Name" width="200" sortable v-slot="props">
+            <template v-if="updating( props.row.status )">
+              {{ props.row.name }}
+            </template>
+            <template v-else>
+              <router-link class="navbar-item" :to="{ name: 'experiment', params: { id: props.row.name }}">
                 {{ props.row.name }}
-              </template>
-              <template v-else>
-                <router-link class="navbar-item" :to="{ name: 'experiment', params: { id: props.row.name }}">
-                  {{ props.row.name }}
-                </router-link>
-              </template>
-            </b-table-column>
-            <b-table-column field="status" label="Status" width="100" sortable centered>
-              <template v-if="props.row.status == 'starting'">
-                <section>
-                  <b-progress size="is-medium" type="is-warning" show-value :value=props.row.percent format="percent"></b-progress>
-                </section>
-              </template>
-              <template v-else-if="adminUser()">                
-                  <b-tooltip :label="getExpControlLabel(props.row.name,props.row.status)" type="is-dark">
-                   <span class="tag is-medium" :class="decorator( props.row.status )">
-                      <div class="field">
-                        <div class="field" @click="( props.row.running ) ? stop( props.row.name, props.row.status ) : start( props.row.name, props.row.status )">
-                          {{ props.row.status }}
-                        </div>
+              </router-link>
+            </template>
+          </b-table-column>
+          <b-table-column field="status" label="Status" width="100" sortable centered v-slot="props">
+            <template v-if="props.row.status == 'starting'">
+              <section>
+                <b-progress size="is-medium" type="is-warning" show-value :value=props.row.percent format="percent"></b-progress>
+              </section>
+            </template>
+            <template v-else-if="adminUser()">                
+                <b-tooltip :label="getExpControlLabel(props.row.name,props.row.status)" type="is-dark">
+                  <span class="tag is-medium" :class="decorator( props.row.status )">
+                    <div class="field">
+                      <div class="field" @click="( props.row.running ) ? stop( props.row.name, props.row.status ) : start( props.row.name, props.row.status )">
+                        {{ props.row.status }}
                       </div>
-                    </span>
-                  </b-tooltip>                
-              </template>
-              <template v-else>
-                <span class="tag is-medium" :class="decorator( props.row.status )">
-                  {{ props.row.status }}
-                </span>
-              </template>
-            </b-table-column>
-            <b-table-column field="topology" label="Topology" width="200">
-              {{ props.row.topology | lowercase }}
-            </b-table-column>
-            <b-table-column field="scenario" label="Scenario" width="200">
-              {{ props.row.scenario | lowercase }}
-            </b-table-column>
-            <b-table-column field="start_time" label="Start Time" width="250" sortable>
-              {{ props.row.start_time }}
-            </b-table-column>
-            <b-table-column field="vm_count" label="VMs" width="100" centered sortable>
-              {{ props.row.vm_count }}
-            </b-table-column>
-            <b-table-column field="vlan_range" label="VLANs" width="100" centered>
-              {{ props.row.vlan_min }} - {{ props.row.vlan_max}} ({{ props.row.vlan_count }})
-            </b-table-column>
-            <b-table-column v-if="globalUser()" label="Actions" width="150" centered>
-              <button class="button is-light is-small action" :disabled="updating( props.row.status )" @click="del( props.row.name, props.row.running )">
-                <b-icon icon="trash"></b-icon>
-              </button>
-              <router-link class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'soh', params: { id: props.row.name }}">
-                <b-icon icon="heartbeat"></b-icon>
-              </router-link>
-              <router-link class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'scorch', params: { id: props.row.name }}">
-                <b-icon icon="fire"></b-icon>
-              </router-link>
-            </b-table-column>
-          </template>
+                    </div>
+                  </span>
+                </b-tooltip>                
+            </template>
+            <template v-else>
+              <span class="tag is-medium" :class="decorator( props.row.status )">
+                {{ props.row.status }}
+              </span>
+            </template>
+          </b-table-column>
+          <b-table-column field="topology" label="Topology" width="200" v-slot="props">
+            {{ props.row.topology | lowercase }}
+          </b-table-column>
+          <b-table-column field="scenario" label="Scenario" width="200" v-slot="props">
+            {{ props.row.scenario | lowercase }}
+          </b-table-column>
+          <b-table-column field="start_time" label="Start Time" width="250" sortable v-slot="props">
+            {{ props.row.start_time }}
+          </b-table-column>
+          <b-table-column field="vm_count" label="VMs" width="100" centered sortable v-slot="props">
+            {{ props.row.vm_count }}
+          </b-table-column>
+          <b-table-column field="vlan_range" label="VLANs" width="100" centered v-slot="props">
+            {{ props.row.vlan_min }} - {{ props.row.vlan_max}} ({{ props.row.vlan_count }})
+          </b-table-column>
+          <b-table-column v-if="globalUser()" label="Actions" width="150" centered v-slot="props">
+            <button class="button is-light is-small action" :disabled="updating( props.row.status )" @click="del( props.row.name, props.row.running )">
+              <b-icon icon="trash"></b-icon>
+            </button>
+            <router-link class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'soh', params: { id: props.row.name }}">
+              <b-icon icon="heartbeat"></b-icon>
+            </router-link>
+            <router-link class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'scorch', params: { id: props.row.name }}">
+              <b-icon icon="fire"></b-icon>
+            </router-link>
+          </b-table-column>
         </b-table>
         <br>
         <b-field v-if="paginationNeeded" grouped position="is-right">

--- a/src/js/src/components/Hosts.vue
+++ b/src/js/src/components/Hosts.vue
@@ -17,44 +17,42 @@ available for experiments, the number of VMs, and host uptime.
       :pagination-size="table.paginationSize"
       :default-sort-direction="table.defaultSortDirection"
       default-sort="name">
-        <template slot-scope="props">
-          <b-table-column field="name" label="Name" width="150" sortable>
-            {{ hostName(props.row) }}
-          </b-table-column>
-          <b-table-column field="cpus" label="CPUs" width="50" sortable centered>
-            {{ props.row.cpus }}
-          </b-table-column>
-          <b-table-column field="load" label="Load" width="250" centered>
-            <span class="tag" :class="decorator(props.row.load[0], props.row.cpus)">
-              {{ props.row.load[ 0 ] }}
-            </span>
-            --
-            <span class="tag" :class="decorator(props.row.load[1], props.row.cpus)">
-              {{ props.row.load[ 1 ] }}
-            </span>
-            --
-            <span class="tag" :class="decorator(props.row.load[2], props.row.cpus)">
-              {{ props.row.load[ 2 ] }}
-            </span>
-          </b-table-column>
-          <b-table-column field="mem_used" label="RAM Used" width="100" centered>
-            <span class="tag" :class="decorator(props.row.memused, props.row.memtotal)">
-              {{ props.row.memused | ram }}
-            </span>
-          </b-table-column>
-          <b-table-column field="mem_total" label="RAM Total" width="100" centered>
-            {{ props.row.memtotal | ram }}
-          </b-table-column>
-          <b-table-column field="bandwidth" label="Bandwidth (MB/sec)" width="200" centered>
-            {{ props.row.bandwidth }}
-          </b-table-column>
-          <b-table-column field="no_vms" label="# of VMs" width="100" sortable centered>
-            {{ props.row.vms }}
-          </b-table-column>
-          <b-table-column field="uptime" label="Uptime" width="165">
-            {{ props.row.uptime | uptime }}
-          </b-table-column>
-        </template>
+        <b-table-column field="name" label="Name" width="150" sortable v-slot="props">
+          {{ hostName(props.row) }}
+        </b-table-column>
+        <b-table-column field="cpus" label="CPUs" width="50" sortable centered v-slot="props">
+          {{ props.row.cpus }}
+        </b-table-column>
+        <b-table-column field="load" label="Load" width="250" centered v-slot="props">
+          <span class="tag" :class="decorator(props.row.load[0], props.row.cpus)">
+            {{ props.row.load[ 0 ] }}
+          </span>
+          --
+          <span class="tag" :class="decorator(props.row.load[1], props.row.cpus)">
+            {{ props.row.load[ 1 ] }}
+          </span>
+          --
+          <span class="tag" :class="decorator(props.row.load[2], props.row.cpus)">
+            {{ props.row.load[ 2 ] }}
+          </span>
+        </b-table-column>
+        <b-table-column field="mem_used" label="RAM Used" width="100" centered v-slot="props">
+          <span class="tag" :class="decorator(props.row.memused, props.row.memtotal)">
+            {{ props.row.memused | ram }}
+          </span>
+        </b-table-column>
+        <b-table-column field="mem_total" label="RAM Total" width="100" centered v-slot="props">
+          {{ props.row.memtotal | ram }}
+        </b-table-column>
+        <b-table-column field="bandwidth" label="Bandwidth (MB/sec)" width="200" centered v-slot="props">
+          {{ props.row.bandwidth }}
+        </b-table-column>
+        <b-table-column field="no_vms" label="# of VMs" width="100" sortable centered v-slot="props">
+          {{ props.row.vms }}
+        </b-table-column>
+        <b-table-column field="uptime" label="Uptime" width="165" v-slot="props">
+          {{ props.row.uptime | uptime }}
+        </b-table-column>
     </b-table>
     <br>
     <b-field v-if="paginationNeeded" grouped position="is-right">

--- a/src/js/src/components/Scorch.vue
+++ b/src/js/src/components/Scorch.vue
@@ -34,55 +34,53 @@
           </div>
         </section>
       </template>
-      <template slot-scope="props">
-        <b-table-column field="name" label="Experiment" width="400" sortable>
-          <template v-if="adminUser()">
-            <b-tooltip label="view SCORCH components" type="is-dark">
-              <router-link class="navbar-item" :to="{ name: 'scorchruns', params: { id: props.row.name } }">
-                {{ props.row.name }}
-              </router-link>
-            </b-tooltip>
-          </template>
-          <template v-else>
-            {{ props.row.name }}
-          </template>
-        </b-table-column>
-        <b-table-column field="status" label="Experiment Status" width="100" sortable centered>
-          <template v-if="props.row.status == 'starting'">
-            <section>
-              <b-progress size="is-medium" type="is-warning" show-value :value=props.row.percent format="percent"></b-progress>
-            </section>
-          </template>
-          <template v-else-if="adminUser()">
-            <b-tooltip :label="expControlLabel( props.row )" type="is-dark">
-              <span class="tag is-medium" :class="expStatusDecorator( props.row.status )">
-                <div class="field" @click="expControl( props.row )">
-                  {{ props.row.status }}
-                </div>
-              </span>
-            </b-tooltip>
-          </template>
-          <template v-else>
-            <span class="tag is-medium" :class="statusDecorator( props.row.status )">
-              {{ props.row.status }}
-            </span>
-          </template>
-        </b-table-column>
-        <b-table-column v-if="globalUser()" label="Scorch Status" width="100" centered>
-          <b-tooltip :label="scorchControlLabel( props.row )" type="is-dark">
-            <span class="tag is-medium" :class="scorchStatusDecorator( props.row )">
-              <div class="field" @click="scorchControl( props.row, -1)">
-                {{ scorchStatus( props.row ) }}
+      <b-table-column field="name" label="Experiment" width="400" sortable v-slot="props">
+        <template v-if="adminUser()">
+          <b-tooltip label="view SCORCH components" type="is-dark">
+            <router-link class="navbar-item" :to="{ name: 'scorchruns', params: { id: props.row.name } }">
+              {{ props.row.name }}
+            </router-link>
+          </b-tooltip>
+        </template>
+        <template v-else>
+          {{ props.row.name }}
+        </template>
+      </b-table-column>
+      <b-table-column field="status" label="Experiment Status" width="100" sortable centered v-slot="props">
+        <template v-if="props.row.status == 'starting'">
+          <section>
+            <b-progress size="is-medium" type="is-warning" show-value :value=props.row.percent format="percent"></b-progress>
+          </section>
+        </template>
+        <template v-else-if="adminUser()">
+          <b-tooltip :label="expControlLabel( props.row )" type="is-dark">
+            <span class="tag is-medium" :class="expStatusDecorator( props.row.status )">
+              <div class="field" @click="expControl( props.row )">
+                {{ props.row.status }}
               </div>
             </span>
-          </b-tooltip>
-        </b-table-column>
-        <b-table-column v-if="globalUser()" label="Terminal" width="100" centered>
-          <button class="button is-small is-white" @click="showExperimentTerminal( props.row.name )" :disabled="!props.row.terminal">
-            <b-icon icon="terminal"></b-icon>
-          </button>
-        </b-table-column>
-      </template>
+          </b-tooltip>                
+        </template>
+        <template v-else>
+          <span class="tag is-medium" :class="statusDecorator( props.row.status )">
+            {{ props.row.status }}
+          </span>
+        </template>
+      </b-table-column>
+      <b-table-column v-if="globalUser()" label="Scorch Status" width="100" centered v-slot="props">
+        <b-tooltip :label="scorchControlLabel( props.row )" type="is-dark">
+          <span class="tag is-medium" :class="scorchStatusDecorator( props.row )">
+            <div class="field" @click="scorchControl( props.row, -1)">
+              {{ scorchStatus( props.row ) }}
+            </div>
+          </span>
+        </b-tooltip>
+      </b-table-column>
+      <b-table-column v-if="globalUser()" label="Terminal" width="100" centered v-slot="props">
+        <button class="button is-small is-white" @click="showExperimentTerminal( props.row.name )" :disabled="!props.row.terminal">
+          <b-icon icon="terminal"></b-icon>
+        </button>
+      </b-table-column>
     </b-table>
     <b-loading :is-full-page="true" :active.sync="isWaiting" :can-cancel="false"></b-loading>
     <b-modal :active.sync="terminal.modal" :on-cancel="resetTerminal" has-modal-card>

--- a/src/js/src/components/StateOfHealth.vue
+++ b/src/js/src/components/StateOfHealth.vue
@@ -37,20 +37,15 @@
               <b-table
                 :data="detailsModal.soh.reachability"
                 default-sort="hostname">
-                <template slot-scope="props">
-                  <b-table-column field="hostname" label="Target Host" sortable>
-                    {{ props.row.metadata.hostname }}
-                  </b-table-column>
-                  <b-table-column field="timestamp" label="Timestamp" sortable>
-                    {{ props.row.timestamp }}
-                  </b-table-column>
-                  <b-table-column field="success" label="Success" sortable>
-                    {{ props.row.success }}
-                  </b-table-column>
-                  <b-table-column field="error" label="Error" sortable>
-                    {{ props.row.error }}
-                  </b-table-column>
-                </template>
+                <b-table-column field="hostname" label="Host" sortable v-slot="props">
+                  {{ props.row.hostname }}
+                </b-table-column>
+                <b-table-column field="timestamp" label="Timestamp" sortable v-slot="props">
+                  {{ props.row.timestamp }}
+                </b-table-column>
+                <b-table-column field="error" label="Error" sortable v-slot="props">
+                  {{ props.row.error }}
+                </b-table-column>
               </b-table>
               <br>
             </div>
@@ -59,20 +54,15 @@
               <b-table
                 :data="detailsModal.soh.processes"
                 default-sort="process">
-                <template slot-scope="props">
-                  <b-table-column field="process" label="Process" sortable>
-                    {{ props.row.metadata.proc }}
-                  </b-table-column>
-                  <b-table-column field="timestamp" label="Timestamp" sortable>
-                    {{ props.row.timestamp }}
-                  </b-table-column>
-                  <b-table-column field="success" label="Success" sortable>
-                    {{ props.row.success }}
-                  </b-table-column>
-                  <b-table-column field="error" label="Error" sortable>
-                    {{ props.row.error }}
-                  </b-table-column>
-                </template>
+                <b-table-column field="process" label="Process" sortable v-slot="props">
+                  {{ props.row.process }}
+                </b-table-column>
+                <b-table-column field="timestamp" label="Timestamp" sortable v-slot="props">
+                  {{ props.row.timestamp }}
+                </b-table-column>
+                <b-table-column field="error" label="Error" sortable v-slot="props">
+                  {{ props.row.error }}
+                </b-table-column>
               </b-table>
               <br>
             </div>
@@ -81,20 +71,18 @@
               <b-table
                 :data="detailsModal.soh.listeners"
                 default-sort="listener">
-                <template slot-scope="props">
-                  <b-table-column field="listener" label="Listener" sortable>
-                    {{ props.row.metadata.port }}
-                  </b-table-column>
-                  <b-table-column field="timestamp" label="Timestamp" sortable>
-                    {{ props.row.timestamp }}
-                  </b-table-column>
-                  <b-table-column field="success" label="Success" sortable>
-                    {{ props.row.success }}
-                  </b-table-column>
-                  <b-table-column field="error" label="Error" sortable>
-                    {{ props.row.error }}
-                  </b-table-column>
-                </template>
+                <b-table-column field="listener" label="Listener" sortable v-slot="props">
+                  {{ props.row.listener }}
+                </b-table-column>
+                <b-table-column field="timestamp" label="Timestamp" sortable v-slot="props">
+                  {{ props.row.timestamp }}
+                </b-table-column>
+                <b-table-column field="success" label="Success" sortable v-slot="props">
+                  {{ props.row.success }}
+                </b-table-column>
+                <b-table-column field="error" label="Error" sortable v-slot="props">
+                  {{ props.row.error }}
+                </b-table-column>
               </b-table>
               <br>
             </div>
@@ -103,20 +91,18 @@
               <b-table
                 :data="detailsModal.soh.customTests"
                 default-sort="test">
-                <template slot-scope="props">
-                  <b-table-column field="test" label="Test Name" sortable>
-                    {{ props.row.metadata.test }}
-                  </b-table-column>
-                  <b-table-column field="timestamp" label="Timestamp" sortable>
-                    {{ props.row.timestamp }}
-                  </b-table-column>
-                  <b-table-column field="success" label="Success" sortable>
-                    {{ props.row.success }}
-                  </b-table-column>
-                  <b-table-column field="error" label="Error" sortable>
-                    {{ props.row.error }}
-                  </b-table-column>
-                </template>
+                <b-table-column field="test" label="Test Name" sortable v-slot="props">
+                  {{ props.row.metadata.test }}
+                </b-table-column>
+                <b-table-column field="timestamp" label="Timestamp" sortable v-slot="props">
+                  {{ props.row.timestamp }}
+                </b-table-column>
+                <b-table-column field="success" label="Success" sortable v-slot="props">
+                  {{ props.row.success }}
+                </b-table-column>
+                <b-table-column field="error" label="Error" sortable v-slot="props">
+                  {{ props.row.error }}
+                </b-table-column>
               </b-table>
               <br>
             </div>
@@ -291,17 +277,15 @@
                     <b-table
                       :data="n.soh.reachability"
                       default-sort="host">
-                      <template slot-scope="props">
-                        <b-table-column field="hostname" label="Host" sortable>
-                          {{ props.row.hostname }}
-                        </b-table-column>
-                        <b-table-column field="timestamp" label="Timestamp" sortable>
-                          {{ props.row.timestamp }}
-                        </b-table-column>
-                        <b-table-column field="error" label="Error" sortable>
-                          {{ props.row.error }}
-                        </b-table-column>
-                      </template>
+                      <b-table-column field="hostname" label="Host" sortable v-slot="props">
+                        {{ props.row.hostname }}
+                      </b-table-column>
+                      <b-table-column field="timestamp" label="Timestamp" sortable v-slot="props">
+                        {{ props.row.timestamp }}
+                      </b-table-column>
+                      <b-table-column field="error" label="Error" sortable v-slot="props">
+                        {{ props.row.error }}
+                      </b-table-column>
                     </b-table>
                     <br>
                   </div>
@@ -310,17 +294,15 @@
                     <b-table
                       :data="n.soh.processes"
                       default-sort="process">
-                      <template slot-scope="props">
-                        <b-table-column field="process" label="Process" sortable>
-                          {{ props.row.process }}
-                        </b-table-column>
-                        <b-table-column field="timestamp" label="Timestamp" sortable>
-                          {{ props.row.timestamp }}
-                        </b-table-column>
-                        <b-table-column field="error" label="Error" sortable>
-                          {{ props.row.error }}
-                        </b-table-column>
-                      </template>
+                      <b-table-column field="process" label="Process" sortable v-slot="props">
+                        {{ props.row.process }}
+                      </b-table-column>
+                      <b-table-column field="timestamp" label="Timestamp" sortable v-slot="props">
+                        {{ props.row.timestamp }}
+                      </b-table-column>
+                      <b-table-column field="error" label="Error" sortable v-slot="props">
+                        {{ props.row.error }}
+                      </b-table-column>
                     </b-table>
                     <br>
                   </div>
@@ -329,17 +311,15 @@
                     <b-table
                       :data="n.soh.listeners"
                       default-sort="listener">
-                      <template slot-scope="props">
-                        <b-table-column field="listener" label="Listener" sortable>
-                          {{ props.row.listener }}
-                        </b-table-column>
-                        <b-table-column field="timestamp" label="Timestamp" sortable>
-                          {{ props.row.timestamp }}
-                        </b-table-column>
-                        <b-table-column field="error" label="Error" sortable>
-                          {{ props.row.error }}
-                        </b-table-column>
-                      </template>
+                      <b-table-column field="listener" label="Listener" sortable v-slot="props">
+                        {{ props.row.listener }}
+                      </b-table-column>
+                      <b-table-column field="timestamp" label="Timestamp" sortable v-slot="props">
+                        {{ props.row.timestamp }}
+                      </b-table-column>
+                      <b-table-column field="error" label="Error" sortable v-slot="props">
+                        {{ props.row.error }}
+                      </b-table-column>
                     </b-table>
                     <br>
                   </div>

--- a/src/js/src/components/StoppedExperiment.vue
+++ b/src/js/src/components/StoppedExperiment.vue
@@ -164,122 +164,120 @@
                   </div>
                 </section>
               </template>
-              <template slot-scope="props">
-                <b-table-column  field="multiselect" label="">              
-                  <template v-slot:header="{ column }">
-                    <b-tooltip label="Select/Unselect All" type="is-dark">
-                    <b-checkbox @input="selectAllVMs" v-model="checkAll" type="is-primary"/>
-                    </b-tooltip>
-                  </template>
-                  <template>
-                    <div>
-                      <b-checkbox v-model="selectedRows" :native-value=props.row.name type="is-primary"/>
-                    </div>
-                  </template>                  
-                </b-table-column>
-                <b-table-column field="name" label="VM" sortable>
-                  <template v-if="adminUser()">
-                    <b-tooltip label="get info on the vm" type="is-dark">
-                      <div class="field">
-                        <div @click="expModal.active = true; expModal.vm = props.row">
-                          {{ props.row.name }}
-                        </div>
-                      </div>
-                    </b-tooltip>
-                  </template>
-                  <template v-else>
-                    {{ props.row.name }}
-                  </template>
-                </b-table-column>
-                <b-table-column field="host" label="Host" width="200" sortable>
-                  <template v-if="adminUser()">
-                    <b-tooltip label="assign the vm to a specific host" type="is-dark">
-                      <b-field>
-                        <b-select :value="props.row.host" expanded @input="( value ) => assignHost( props.row.name, value )">
-                          <option
-                            v-for="( h, index ) in hosts"
-                            :key="index"
-                            :value="h">
-                            {{ h }}
-                          </option>
-                        </b-select>
-                        <p class='control'>
-                          <button class='button' 
-                                  @click="unassignHost( props.row.name, props.row.host )">
-                            <b-icon icon="window-close"></b-icon>
-                          </button>
-                        </p>
-                      </b-field>
-                    </b-tooltip>
-                  </template>
-                  <template v-else>
-                    {{ props.row.host }}
-                  </template>
-                </b-table-column>
-                <b-table-column field="ipv4" label="IPv4">
-                  <div v-for="(ip,index) in props.row.ipv4" :key="index">
-                    {{ ip }}
+              <b-table-column  field="multiselect" label="" >              
+                <template v-slot:header="{ column }">
+                  <b-tooltip label="Select/Unselect All" type="is-dark">
+                  <b-checkbox @input="selectAllVMs" v-model="checkAll" type="is-primary"/>
+                  </b-tooltip>
+                </template>
+                <template v-slot:default="props">
+                  <div>
+                    <b-checkbox v-model="selectedRows" :native-value=props.row.name type="is-primary"/>
                   </div>
-                </b-table-column>
-                <b-table-column field="cpus" label="CPUs" sortable centered>
-                  <template v-if="adminUser()">
-                    <b-tooltip label="menu for assigning vm(s) cpus" type="is-dark">
-                      <b-select :value="props.row.cpus" expanded @input="( value ) => assignCpu( props.row.name, value )">
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="3">3</option>
-                        <option value="4">4</option>
-                      </b-select>
-                    </b-tooltip>
-                  </template>
-                  <template v-else>
-                    {{ props.row.cpus }}
-                  </template>
-                </b-table-column>
-                <b-table-column field="ram" label="Memory" sortable centered>
-                  <template v-if="adminUser()">
-                    <b-tooltip label="menu for assigning vm(s) memory" type="is-dark">
-                      <b-select :value="props.row.ram" expanded @input="( value ) => assignRam( props.row.name, value )">
-                        <option value="512">512 MB</option>
-                        <option value="1024">1 GB</option>
-                        <option value="2048">2 GB</option>
-                        <option value="3072">3 GB</option>
-                        <option value="4096">4 GB</option>
-                        <option value="8192">8 GB</option>
-                        <option value="12288">12 GB</option>
-                        <option value="16384">16 GB</option>
-                      </b-select>
-                    </b-tooltip>
-                  </template>
-                  <template v-else>
-                    {{ props.row.ram }}
-                  </template>
-                </b-table-column>
-                <b-table-column field="disk" label="Disk">
-                  <template v-if="adminUser()">
-                    <b-tooltip :label="getDiskToolTip(props.row.disk)" type="is-dark">
-                      <b-select :value="props.row.disk" expanded @input="( value ) => assignDisk( props.row.name, value )">
-                        <option
-                          v-for="( d, index ) in disks"
-                          :key="index"
-                          :value="d">
-                            {{ getBaseName(d) }}
-                        </option>
-                      </b-select>
-                    </b-tooltip>
-                  </template>
-                  <template v-else>
-                    {{ getBaseName(props.row.disk) }}
-                  </template>
-                </b-table-column>
-                <b-table-column v-if="experimentUser()" label="Boot" centered>
-                  <b-tooltip :label="getBootLabel( props.row.name, props.row.dnb )" type="is-dark">
-                    <div @click="updateDnb( props.row.name, !props.row.dnb )">
-                      <font-awesome-icon :class="bootDecorator( props.row.dnb )" icon="bolt" />
+                </template>                  
+              </b-table-column>
+              <b-table-column field="name" label="VM" sortable v-slot="props">
+                <template v-if="adminUser()">
+                  <b-tooltip label="get info on the vm" type="is-dark">
+                    <div class="field">
+                      <div @click="expModal.active = true; expModal.vm = props.row">
+                        {{ props.row.name }}
+                      </div>
                     </div>
                   </b-tooltip>
-                </b-table-column>
-              </template>
+                </template>
+                <template v-else>
+                  {{ props.row.name }}
+                </template>
+              </b-table-column>
+              <b-table-column field="host" label="Host" width="200" sortable v-slot="props">
+                <template v-if="adminUser()">
+                  <b-tooltip label="assign the vm to a specific host" type="is-dark">
+                    <b-field>
+                      <b-select :value="props.row.host" expanded @input="( value ) => assignHost( props.row.name, value )">
+                        <option
+                          v-for="( h, index ) in hosts"
+                          :key="index"
+                          :value="h">
+                          {{ h }}
+                        </option>
+                      </b-select>
+                      <p class='control'>
+                        <button class='button' 
+                                @click="unassignHost( props.row.name, props.row.host )">
+                          <b-icon icon="window-close"></b-icon>
+                        </button>
+                      </p>
+                    </b-field>
+                  </b-tooltip>
+                </template>
+                <template v-else>
+                  {{ props.row.host }}
+                </template>
+              </b-table-column>
+              <b-table-column field="ipv4" label="IPv4" v-slot="props">
+                <div v-for="(ip,index) in props.row.ipv4" :key="index">
+                  {{ ip }}
+                </div>
+              </b-table-column>
+              <b-table-column field="cpus" label="CPUs" sortable centered v-slot="props">
+                <template v-if="adminUser()">
+                  <b-tooltip label="menu for assigning vm(s) cpus" type="is-dark">
+                    <b-select :value="props.row.cpus" expanded @input="( value ) => assignCpu( props.row.name, value )">
+                      <option value="1">1</option>
+                      <option value="2">2</option>
+                      <option value="3">3</option>
+                      <option value="4">4</option>
+                    </b-select>
+                  </b-tooltip>
+                </template>
+                <template v-else>
+                  {{ props.row.cpus }}
+                </template>
+              </b-table-column>
+              <b-table-column field="ram" label="Memory" sortable centered v-slot="props">
+                <template v-if="adminUser()">
+                  <b-tooltip label="menu for assigning vm(s) memory" type="is-dark">
+                    <b-select :value="props.row.ram" expanded @input="( value ) => assignRam( props.row.name, value )">
+                      <option value="512">512 MB</option>
+                      <option value="1024">1 GB</option>
+                      <option value="2048">2 GB</option>
+                      <option value="3072">3 GB</option>
+                      <option value="4096">4 GB</option>
+                      <option value="8192">8 GB</option>
+                      <option value="12288">12 GB</option>
+                      <option value="16384">16 GB</option>
+                    </b-select>
+                  </b-tooltip>
+                </template>
+                <template v-else>
+                  {{ props.row.ram }}
+                </template>
+              </b-table-column>
+              <b-table-column field="disk" label="Disk" v-slot="props">
+                <template v-if="adminUser()">
+                  <b-tooltip :label="getDiskToolTip(props.row.disk)" type="is-dark">
+                    <b-select :value="props.row.disk" expanded @input="( value ) => assignDisk( props.row.name, value )">
+                      <option
+                        v-for="( d, index ) in disks"
+                        :key="index"
+                        :value="d">
+                          {{ getBaseName(d) }}
+                      </option>
+                    </b-select>
+                  </b-tooltip>
+                </template>
+                <template v-else>
+                  {{ getBaseName(props.row.disk) }}
+                </template>
+              </b-table-column>
+              <b-table-column v-if="experimentUser()" label="Boot" centered v-slot="props">
+                <b-tooltip :label="getBootLabel( props.row.name, props.row.dnb )" type="is-dark">
+                  <div @click="updateDnb( props.row.name, !props.row.dnb )">
+                    <font-awesome-icon :class="bootDecorator( props.row.dnb )" icon="bolt" />
+                  </div>
+                </b-tooltip>
+              </b-table-column>
           </b-table>
           <br>
           <b-field v-if="paginationNeeded" grouped position="is-right">
@@ -310,43 +308,41 @@
                 </div>
               </section>
             </template>
-            <template slot-scope="props">
-              <b-table-column field="name" label="Name" sortable>                  
-                <template v-if="props.row.plainText">
-                  <b-tooltip label="view file" type="is-dark">
-                    <div class="field">
-                      <div @click="viewFile( props.row )">
-                        {{ props.row.name }}
-                      </div>
+            <b-table-column field="name" label="Name" sortable v-slot="props">                  
+              <template v-if="props.row.plainText">
+                <b-tooltip label="view file" type="is-dark">
+                  <div class="field">
+                    <div @click="viewFile( props.row )">
+                      {{ props.row.name }}
                     </div>
-                  </b-tooltip>
-                </template>
-                <template v-else>
-                  {{ props.row.name }}
-                </template>
-              </b-table-column>
-              <b-table-column field="path" label="Path" centered>
-                <b-tooltip :label="'/phenix/images/' + experiment.name + '/files/' + props.row.path" type="is-dark">
-                  <b-icon icon="info-circle" size="is-small" />
+                  </div>
                 </b-tooltip>
-              </b-table-column>
-              <b-table-column field="categories" label="Category">
-                <b-taglist>
-                  <b-tag v-for="( c, index ) in props.row.categories" :key="index" type="is-light">{{ c }}</b-tag>
-                </b-taglist>
-              </b-table-column>
-              <b-table-column field="date" label="Date" sortable centered>                  
-                {{ props.row.date }}                      
-              </b-table-column>
-              <b-table-column field="size" label="Size" sortable centered>                  
-                {{ props.row.size }}                      
-              </b-table-column>
-              <b-table-column field="actions" label="Actions" centered>
-                <a :href="fileDownloadURL(props.row.name, props.row.path)" target="_blank">
-                  <b-icon icon="file-download" size="is-small"></b-icon>
-                </a>
-              </b-table-column>
-            </template>
+              </template>
+              <template v-else>
+                {{ props.row.name }}
+              </template>
+            </b-table-column>
+            <b-table-column field="path" label="Path" centered v-slot="props">
+              <b-tooltip :label="'/phenix/images/' + experiment.name + '/files/' + props.row.path" type="is-dark">
+                <b-icon icon="info-circle" size="is-small" />
+              </b-tooltip>
+            </b-table-column>
+            <b-table-column field="categories" label="Category" v-slot="props">
+              <b-taglist>
+                <b-tag v-for="( c, index ) in props.row.categories" :key="index" type="is-light">{{ c }}</b-tag>
+              </b-taglist>
+            </b-table-column>
+            <b-table-column field="date" label="Date" sortable centered v-slot="props">                  
+              {{ props.row.date }}                      
+            </b-table-column>
+            <b-table-column field="size" label="Size" sortable centered v-slot="props">                  
+              {{ props.row.size | fileSize }}                      
+            </b-table-column>
+            <b-table-column field="actions" label="Actions" centered v-slot="props">
+              <a :href="fileDownloadURL(props.row.name, props.row.path)" target="_blank">
+                <b-icon icon="file-download" size="is-small"></b-icon>
+              </a>
+            </b-table-column>
           </b-table>
           <br>
           <b-field v-if="filesPaginationNeeded" grouped position="is-right">
@@ -702,11 +698,6 @@
                       this.files.push(files[i]);
                     }
                   }
-                }
-
-                // Format the file sizes
-                for(let i = 0; i < this.files.length; i++){
-                  this.files[i].size = this.formatFileSize(this.files[i].size)
                 }
 
                 // Only add successful searches to the search history
@@ -1252,18 +1243,6 @@
         // clear the selection
         this.unSelectAllVMs()
       }, 
-      
-      formatFileSize(fileSize){
-        if(fileSize < Math.pow(10,3)){
-          return fileSize.toFixed(2) + ' B'
-        } else if(fileSize >= Math.pow(10,3) && fileSize < Math.pow(10,6)){
-          return (fileSize/Math.pow(10,3)).toFixed(2) + ' KB'
-        } else if (fileSize >= Math.pow(10,6) && fileSize < Math.pow(10,9)){
-          return (fileSize/Math.pow(10,6)).toFixed(2) + ' MB'
-        } else if (fileSize >= Math.pow(10,9)) {
-          return (fileSize/Math.pow(10,9)).toFixed(2) + ' GB'
-        }
-      },
 
       getBaseName (diskName) { 
         return diskName.substring( diskName.lastIndexOf("/") + 1 );

--- a/src/js/src/components/Users.vue
+++ b/src/js/src/components/Users.vue
@@ -94,36 +94,34 @@
           :pagination-size="table.paginationSize"
           :default-sort-direction="table.defaultSortDirection"
           default-sort="username">
-          <template slot-scope="props">
-            <b-table-column field="username" label="User" sortable>
-              <template v-if="adminUser()">
-                <b-tooltip label="change user settings" type="is-dark">
-                  <div class="field">
-                    <div @click="editUser( props.row.username )">
-                      {{ props.row.username }}
-                    </div>
+          <b-table-column field="username" label="User" sortable v-slot="props">
+            <template v-if="adminUser()">
+              <b-tooltip label="change user settings" type="is-dark">
+                <div class="field">
+                  <div @click="editUser( props.row.username )">
+                    {{ props.row.username }}
                   </div>
-                </b-tooltip>
-              </template>
-              <template v-else>
-                {{ props.row.username }}
-              </template>
-            </b-table-column>
-            <b-table-column field="first_name" label="First Name">
-              {{ props.row.first_name }}
-            </b-table-column>
-            <b-table-column field="last_name" label="Last Name" sortable>
-              {{ props.row.last_name }}
-            </b-table-column>
-            <b-table-column field="role" label="Role" sortable>
-              {{ props.row.role_name ? props.row.role_name : "Not yet assigned" }}
-            </b-table-column>
-            <b-table-column v-if="adminUser()" label="Delete" width="50" centered>
-              <button class="button is-light is-small" @click="deleteUser( props.row.username )">
-                <b-icon icon="trash"></b-icon>
-              </button>
-            </b-table-column>
-          </template>
+                </div>
+              </b-tooltip>
+            </template>
+            <template v-else>
+              {{ props.row.username }}
+            </template>
+          </b-table-column>
+          <b-table-column field="first_name" label="First Name" v-slot="props">
+            {{ props.row.first_name }}
+          </b-table-column>
+          <b-table-column field="last_name" label="Last Name" sortable v-slot="props">
+            {{ props.row.last_name }}
+          </b-table-column>
+          <b-table-column field="role" label="Role" sortable v-slot="props">
+            {{ props.row.role_name ? props.row.role_name : "Not yet assigned" }}
+          </b-table-column>
+          <b-table-column v-if="adminUser()" label="Delete" width="50" centered v-slot="props">
+            <button class="button is-light is-small" @click="deleteUser( props.row.username )">
+              <b-icon icon="trash"></b-icon>
+            </button>
+          </b-table-column>
         </b-table>
         <br>
         <b-field v-if="paginationNeeded" grouped position="is-right">

--- a/src/js/src/components/VMMountBrowserModal.vue
+++ b/src/js/src/components/VMMountBrowserModal.vue
@@ -1,0 +1,181 @@
+<template>
+  <form action="">
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title mr-6">{{this.targetVm}} Mount</p>
+      <button type="button" class="delete light" @click="$emit('close')"></button>
+    </header>
+    <section class="modal-card-body">
+      <b-breadcrumb>
+            <b-breadcrumb-item v-for="p in pathParts" :key="p.upTo" @click.native="currentPath = p.upTo" :active="p == pathParts.at(-1)">
+              {{p.part}}
+            </b-breadcrumb-item>
+      </b-breadcrumb>
+      <b-table :data="files" :loading="filesLoading" class="fixed-table">
+        <b-table-column field="name" label="File" v-slot="props">
+            <a v-if="props.row.isDir" @click="currentPath = props.row.path">{{ `${props.row.name}/` }}</a>
+            <a v-else @click="downloadFile(props.row.path)">{{props.row.name}}</a>
+        </b-table-column>
+        <b-table-column field="size" label="Size" width="128px" v-slot="props">
+          <div v-if="props.row.isDir">&nbsp;</div>
+          <div v-else>{{ props.row.size | fileSize }}</div>
+        </b-table-column>
+        <b-table-column field="date" label="Date" width="212px" v-slot="props">
+            {{ props.row.date }}
+        </b-table-column>
+        <template #empty>
+          <div class="has-text-centered">No Files in Directory</div>
+        </template>
+      </b-table>
+    </section>
+    <footer class="modal-card-foot">
+      <b-field v-show="this.isExpUser" class="file is-info" style="margin-bottom: 0;">
+        <b-upload @input="handleUpload" class="file-label" :class="{disabled: currentUploadProgress !== null}" 
+                  :disabled="currentUploadProgress !== null">
+            <span class="file-cta">
+                <b-icon class="file-icon" icon="upload"></b-icon>
+                <span class="file-label" :disabled="currentUploadProgress !== null">Upload File</span>
+            </span>
+        </b-upload>
+      </b-field>
+      <b-progress class="progress mx-3" v-show="currentUploadProgress !== null" :value="currentUploadProgress" :max="100" show-value>
+        {{this.currentUploadFileName}} : {{parseFloat(this.currentUploadProgress).toFixed(2)}}%
+      </b-progress>
+    </footer>
+  </div>
+</form>
+</template>
+
+<script>
+
+export default {
+  props: [
+    'targetExp',
+    'targetVm',
+    "isExpUser"
+  ],
+
+  data() {
+    return {
+      files: [],
+      filesLoading: false,
+      currentPath: "/",
+      currentUploadProgress: null,
+      currentUploadFileName: ""
+    }
+  },
+
+  beforeDestroy() {
+    this.unmount()
+  },
+
+  beforeMount() {
+    this.$http.post(`experiments/${this.targetExp}/vms/${this.targetVm}/mount`).then(_ => {
+     this.getFiles();
+      
+    }, err => {
+      this.errorDialog('Error mounting vm ' + this.targetVm + ": " + err.body);
+      this.$parent.close();
+    });
+    window.addEventListener('beforeunload', this.unmount);
+  },
+
+  computed: {
+    // split current path into list of directories
+    pathParts() {
+      let parts = this.currentPath.split('/')
+      let p = parts.slice(1).map(p => {
+        return {
+          part: p,
+          upTo: parts.slice(0, parts.indexOf(p) + 1).join('/')
+        }
+      })
+      // prepend special entry for returning to base of mount
+      p.unshift({part: 'mnt', upTo: '/'})
+      return p
+    }
+  },
+
+  watch : {
+    // grab files for current path whenever it changes
+    currentPath() {
+      this.getFiles()
+    }
+  },
+
+  methods: {
+    getFiles() {
+      this.filesLoading = true;
+      this.$http.get(`experiments/${this.targetExp}/vms/${this.targetVm}/files`, { 
+          params: { 'path': this.currentPath } 
+        }).then(success => {
+          this.files = success.body.files === null ? [] : success.body.files
+          this.filesLoading = false;
+        }, err => {
+          this.filesLoading = false;
+          this.errorDialog(`Error getting files: ${err.body}`)
+        });
+    },
+
+    downloadFile(path) {
+      this.$buefy.dialog.confirm({
+        type: "is-info",
+        message: `Download ${path}?`,
+        onConfirm: () => {
+          window.open(`${process.env.BASE_URL}api/v1/experiments/${this.targetExp}/vms/${this.targetVm}/files/download?token=${this.$store.state.token}&path=${encodeURIComponent(path)}`, '_blank');
+        }
+      });
+    },
+
+    handleUpload(file) {
+      let formData = new FormData();
+      formData.append('file', file);
+      this.currentUploadFileName = file.name;
+      this.currentUploadProgress = 0;
+      this.$http.put(`experiments/${this.targetExp}/vms/${this.targetVm}/files/upload`, formData, { 
+          params: { 'path': this.currentPath}, 
+          headers: {'Content-Type': 'multipart/form-data' },
+          uploadProgress: (event) => {
+            this.currentUploadProgress = event.loaded / event.total * 100;
+          }
+        }).then(_ => {
+          this.currentUploadProgress = null;
+          this.getFiles();
+        }, err => {
+          this.errorDialog(`Error uploading: ${err.body}`)
+          this.currentUploadProgress = null;
+        });
+    },
+
+    errorDialog(msg) {
+      console.error(msg)
+      this.$buefy.toast.open({
+        message: msg,
+        type: 'is-danger',
+        duration: 5000
+      });
+    },
+
+    unmount() {
+      this.$http.delete(`experiments/${this.targetExp}/vms/${this.targetVm}/unmount`)
+        .then(_ => {}, err => {
+          // Only show error if files or path have changed. 
+          // Otherwise, mount failed and no need to show another error message
+          if (this.files.length !== 0 || this.currentPath !== "/")
+            this.errorDialog(`Error unmounting vm: ${err.body}`)
+        });
+    }
+  }
+}
+</script>
+  
+<style lang="scss">
+  .fixed-table {
+    height: 75vh;
+    overflow: auto;
+  }
+  .disabled > .file-cta {
+    background-color: gray !important;
+  }
+
+</style>

--- a/src/js/src/main.js
+++ b/src/js/src/main.js
@@ -78,6 +78,18 @@ Vue.filter( 'uptime', function( value ) {
   }
 })
 
+Vue.filter( 'fileSize', function (fileSize) {
+  if(fileSize < Math.pow(10,3)) {
+    return fileSize.toFixed(2) + ' B'
+  } else if(fileSize >= Math.pow(10,3) && fileSize < Math.pow(10,6)) {
+    return (fileSize/Math.pow(10,3)).toFixed(2) + ' KB'
+  } else if (fileSize >= Math.pow(10,6) && fileSize < Math.pow(10,9)) {
+    return (fileSize/Math.pow(10,6)).toFixed(2) + ' MB'
+  } else if (fileSize >= Math.pow(10,9)) {
+    return (fileSize/Math.pow(10,9)).toFixed(2) + ' GB'
+  }
+})
+
 Vue.prototype.errorNotification = errorNotification;
 Vue.errorNotification = errorNotification;
 

--- a/src/js/src/router.js
+++ b/src/js/src/router.js
@@ -36,6 +36,7 @@ const router = new Router({
 
     {path: '/builder?token=:token', name: 'builder'},
     {path: '/version',              name: 'version'},
+    {path: '/features',             name: 'features'},
 
     {path: '/api/v1/experiments/:id/files/:name\\?path=:path&token=:token', name: 'file'},
     {path: '/api/v1/experiments/:id/vms/:name/vnc?token=:token',            name: 'vnc'},

--- a/src/js/src/store.js
+++ b/src/js/src/store.js
@@ -10,7 +10,9 @@ export default new Vuex.Store({
     token:    localStorage.getItem( 'phenix.token' ),
     role:     localStorage.getItem( 'phenix.role' ),
     auth:     localStorage.getItem( 'phenix.auth' ) === 'true',
-    next:     null
+    next:     null,
+
+    features: [],
   },
 
   mutations: {
@@ -54,6 +56,10 @@ export default new Vuex.Store({
 
     'NEXT' ( state, to ) {
       state.next = to;
+    },
+
+    'FEATURES' ( state, features ) {
+      state.features = features;
     }
   },
   
@@ -72,6 +78,10 @@ export default new Vuex.Store({
     
     auth: state => {
       return state.auth;
+    },
+
+    features: state => {
+      return state.features;
     }
   }
 });

--- a/src/js/vue.config.js
+++ b/src/js/vue.config.js
@@ -15,6 +15,12 @@ module.exports = {
         changeOrigin: true,
         logLevel: 'debug',
         ws: true
+      },
+      '/features': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        logLevel: 'debug',
+        ws: true
       }
     }
   }

--- a/src/js/yarn.lock
+++ b/src/js/yarn.lock
@@ -1843,12 +1843,12 @@ browserslist@^4.0.0, browserslist@^4.3.4, browserslist@^4.5.4, browserslist@^4.8
     electron-to-chromium "^1.3.322"
     node-releases "^1.1.42"
 
-buefy@^0.8.0:
-  version "0.8.20"
-  resolved "https://registry.yarnpkg.com/buefy/-/buefy-0.8.20.tgz#75708800548220654575903d031a81fc8575b7f3"
-  integrity sha512-pg8Cn0m9cjqp2/vaKT4VIfU8KIumuX/gAT1GtearXRs56+kKqAPx3j9O8cm9W6P4jPUCHajKX6H8AqD0ram2Bg==
+buefy@^0.9.22:
+  version "0.9.22"
+  resolved "https://registry.yarnpkg.com/buefy/-/buefy-0.9.22.tgz#6172dd498b138f5689c9e12671235db772c1f66c"
+  integrity sha512-rA9Bf7+2lZupL1PlQU60o7cc0Og4MRz9it5LZlKOIwPENM1uEOjH48EFnNFniLyxIcz6vln0EicS96GsVCFx1Q==
   dependencies:
-    bulma "0.7.5"
+    bulma "0.9.4"
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -1879,10 +1879,10 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bulma@0.7.5:
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.5.tgz#35066c37f82c088b68f94450be758fc00a967208"
-  integrity sha512-cX98TIn0I6sKba/DhW0FBjtaDpxTelU166pf7ICXpCCuplHWyu6C9LYZmL5PEsnePIeJaiorsTEzzNk3Tsm1hw==
+bulma@0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.4.tgz#0ca8aeb1847a34264768dba26a064c8be72674a1"
+  integrity sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ==
 
 bytes@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
When interacting with a VM in a running experiment, users can now access
files within the VM directly from the UI by clicking the `mount vm`
button within the VM's informational modal.

RBAC policies are applied to limit the ability for users to mount and
unmount VMs, as well as list, download, and upload files to and from
VMs.

Note that this feature only works if the miniccc agent is active within
the VM. If it's not, the `mount vm` button will be disabled.

Also note that this feature is also currently behind a feature flag in
the phenix UI named `vm-mount` that is not enabled by default. To enable
it, pass the `--features=vm-mount` flag to the `phenix ui` command when
starting the UI process.

Additional notes and changes:

* buefy dependency was upgraded to 0.9.22
  * this enabled use of the "breadcrumbs" component in the mount modal
  * this also required updating all tables due to a breaking change
* added flag for "cc active" to the frontend which is visible in the vm
  info modal
* created common vue filter for formatting file sizes
* fixed developer jwt signing key and added comment documenting use
* generalized ExperimentFile object to File and removed some unused code
  for ExperimentFiles in protobuf
* changed ESLint rules to not warn of unused variables if the variable
  starts with _