### PR TITLE
Separate out kali GUI packages.

### DIFF
--- a/src/go/api/image/constants.go
+++ b/src/go/api/image/constants.go
@@ -111,28 +111,32 @@ var PACKAGES_DEFAULT = []string{
 var PACKAGES_KALI = []string{
 	"linux-image-amd64",
 	"linux-headers-amd64",
+	"default-jre",
+	"kali-linux-core",
+	"kali-tools-top10",
+	"python3-cffi-backend",
 }
 
-var PACKAGES_BIONIC = []string{
+var PACKAGES_UBUNTU = []string{
 	"linux-image-generic",
 	"linux-headers-generic",
 }
 
 var PACKAGES_MINGUI = []string{
 	"xorg",
-	"xserver-xorg-input-all",
+	"xinit",
 	"dbus-x11",
+	"xserver-xorg",
+	"xserver-xorg-input-all",
 	"xserver-xorg-video-qxl",
 	"xserver-xorg-video-vesa",
-	"xinit",
-	"xfce4-terminal",
 	"xfce4",
-	"python3-cffi-backend",
+	"xfce4-terminal",
 }
 
 var PACKAGES_MINGUI_KALI = []string{
-	"ca-certificates-java",
-	"openjdk-11-jre-headless",
+	"xorg",
+	"xfce4-terminal",
 	"kali-desktop-xfce",
 }
 

--- a/src/go/api/image/image.go
+++ b/src/go/api/image/image.go
@@ -38,11 +38,13 @@ var (
 
 // SetDefaults will set default settings to image values if none are set by the
 // user. The default values are:
-//   -- Image size at `5G`
-//   -- The variant is `minbase`
-//   -- The release is `bionic` (Ubuntu 18.04.4 LTS)
-//   -- The mirror is `http://us.archive.ubuntu.com/ubuntu/`
-//   -- The image format is `raw`
+//
+//	-- Image size at `5G`
+//	-- The variant is `minbase`
+//	-- The release is `bionic` (Ubuntu 18.04.4 LTS)
+//	-- The mirror is `http://us.archive.ubuntu.com/ubuntu/`
+//	-- The image format is `raw`
+//
 // This will also remove empty strings in packages and overlays; if overlays are
 // used, the default `/phenix/images` directory is added to the overlay name.
 // Based on the variant value, specific constants will be included during the
@@ -87,15 +89,15 @@ func SetDefaults(img *v1.Image) error {
 		if img.Release == "kali" || img.Release == "kali-rolling" {
 			img.Packages = append(img.Packages, PACKAGES_KALI...)
 		} else {
-			img.Packages = append(img.Packages, PACKAGES_BIONIC...)
+			img.Packages = append(img.Packages, PACKAGES_UBUNTU...)
 		}
 	case "mingui":
-		img.Packages = append(img.Packages, PACKAGES_MINGUI...)
 		if img.Release == "kali" || img.Release == "kali-rolling" {
 			img.Packages = append(img.Packages, PACKAGES_KALI...)
 			img.Packages = append(img.Packages, PACKAGES_MINGUI_KALI...)
 		} else {
-			img.Packages = append(img.Packages, PACKAGES_BIONIC...)
+			img.Packages = append(img.Packages, PACKAGES_UBUNTU...)
+			img.Packages = append(img.Packages, PACKAGES_MINGUI...)
 			if img.Release == "xenial" {
 				img.Packages = append(img.Packages, "qupzilla")
 			} else {


### PR DESCRIPTION
Fixes #105 

Tested with

`phenix image create -r kali -v mingui -f qcow2 kali`

and

`phenix image create -v mingui -f qcow2 mingui`

__*Note: `mingui` for Ubuntu only works with the default release (bionic)*__