### PR TITLE
feat: support configuring serial ports at the minimega host level

### DIFF
--- a/docker/Dockerfile.minimega
+++ b/docker/Dockerfile.minimega
@@ -1,0 +1,17 @@
+# Update GitHub workflow configs and docker-compose config to change the version
+# of minimega required for use with phenix.
+ARG  MM_REV
+FROM ghcr.io/activeshadow/minimega/minimega:${MM_REV}
+
+ARG   MINIMEGA_REVISION
+LABEL org.opencontainers.image.base.name="ghcr.io/activeshadow/minimega/minimega:${MM_REV}"
+ARG   PHENIX_REVISION=local-dev
+LABEL gov.sandia.phenix.revision="${PHENIX_REVISION}"
+
+# iptables needed in minimega container for scorch and tap apps
+# socat needed in minimega container for serial app
+RUN apt update && apt install -y iptables socat \
+  && apt autoremove -y \
+  && apt clean -y \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/cache/apt/archives/*

--- a/src/go/api/soh/soh.go
+++ b/src/go/api/soh/soh.go
@@ -7,10 +7,11 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/mitchellh/mapstructure"
-
 	"phenix/api/experiment"
 	"phenix/api/vm"
+	"phenix/app"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 const defaultEdgeLength = 150
@@ -19,7 +20,10 @@ var vlanAliasRegex = regexp.MustCompile(`(.*) \(\d*\)`)
 
 func Get(expName, statusFilter string) (*Network, error) { //nolint:funlen // complex logic
 	// Create an empty network
-	network := new(Network)
+	network := &Network{
+		Nodes: []Node{},
+		Edges: []Edge{},
+	}
 
 	exp, err := experiment.Get(expName)
 	if err != nil {
@@ -69,6 +73,7 @@ func Get(expName, statusFilter string) (*Network, error) { //nolint:funlen // co
 	// Internally use to track connections, VM's state, and whether or not the
 	// VM is in minimega
 	var (
+		vmIDs      = make(map[string]int)
 		interfaces = make(map[string]int)
 		ifaceCount = len(vms) + 1
 		edgeCount  int
@@ -76,6 +81,8 @@ func Get(expName, statusFilter string) (*Network, error) { //nolint:funlen // co
 
 	// Traverse the experiment VMs and create topology
 	for _, vm := range vms {
+		vmIDs[vm.Name] = vm.ID
+
 		var vmState string
 
 		/*
@@ -124,7 +131,7 @@ func Get(expName, statusFilter string) (*Network, error) { //nolint:funlen // co
 
 		// Look at the VM's interface and create an interface node
 		// Unless it is a member of the ignore list
-		var vlanIgnoreList = []string{
+		vlanIgnoreList := []string{
 			"MGMT",
 			"MIRROR", // default in mirror app https://github.com/sandialabs/sceptre-phenix-apps/blob/main/src/go/cmd/phenix-app-mirror/types.go#L56
 		}
@@ -167,6 +174,32 @@ func Get(expName, statusFilter string) (*Network, error) { //nolint:funlen // co
 
 			network.Edges = append(network.Edges, edge)
 			edgeCount++
+		}
+	}
+
+	// Check to see if a scenario exists for this experiment and if it contains a
+	// "serial" app. If so, add edges for all the serial connections.
+	for _, a := range exp.Apps() {
+		if a.Name() == "serial" {
+			var config app.SerialConfig
+
+			if err := a.ParseMetadata(&config); err != nil {
+				continue // TODO: handle this better? Like warn the user perhaps?
+			}
+
+			for _, conn := range config.Connections {
+				// create edge for serial connection
+				edge := Edge{
+					ID:     edgeCount,
+					Source: vmIDs[conn.Src],
+					Target: vmIDs[conn.Dst],
+					Length: 150,
+					Type:   "serial",
+				}
+
+				network.Edges = append(network.Edges, edge)
+				edgeCount++
+			}
 		}
 	}
 

--- a/src/go/api/soh/types.go
+++ b/src/go/api/soh/types.go
@@ -24,10 +24,11 @@ type Node struct {
 }
 
 type Edge struct {
-	ID     int `json:"id"`
-	Source int `json:"source"`
-	Target int `json:"target"`
-	Length int `json:"length"`
+	ID     int    `json:"id"`
+	Type   string `json:"type"`
+	Source int    `json:"source"`
+	Target int    `json:"target"`
+	Length int    `json:"length"`
 }
 
 type Network struct {

--- a/src/go/app/serial.go
+++ b/src/go/app/serial.go
@@ -8,10 +8,30 @@ import (
 
 	"phenix/tmpl"
 	"phenix/types"
+	"phenix/util/mm"
+
 	ifaces "phenix/types/interfaces"
 )
 
 const appNameSerial = "serial"
+
+var (
+	idFormat  = "%s_serial_%s_%d"
+	lfFormat  = "/tmp/%s_serial_%s_%s_%d.log"
+	optFormat = "-chardev socket,id=%[1]s,path=/tmp/%[1]s,server,nowait -device pci-serial,chardev=%[1]s"
+
+	defaultStartPort = 40500
+)
+
+type SerialConfig struct {
+	Connections []SerialConnectionConfig `mapstructure:"connections"`
+}
+
+type SerialConnectionConfig struct {
+	Src  string `mapstructure:"src"`
+	Dst  string `mapstructure:"dst"`
+	Port int    `mapstructure:"port"`
+}
 
 type Serial struct{}
 
@@ -131,10 +151,91 @@ func (Serial) PreStart(ctx context.Context, exp *types.Experiment) error {
 		}
 	}
 
+	// Check to see if a scenario exists for this experiment and if it contains a
+	// "serial" app. If so, configure serial ports according to the app config.
+	for _, app := range exp.Apps() {
+		if app.Name() == "serial" {
+			var config SerialConfig
+
+			if err := app.ParseMetadata(&config); err != nil {
+				continue // TODO: handle this better? Like warn the user perhaps?
+			}
+
+			for i, conn := range config.Connections {
+				src := exp.Spec.Topology().FindNodeByName(conn.Src)
+
+				if src == nil {
+					continue // TODO: handle this better? Like warn the user perhaps?
+				}
+
+				appendQEMUFlags(exp.Metadata.Name, src, i)
+
+				dst := exp.Spec.Topology().FindNodeByName(conn.Dst)
+
+				if src == nil {
+					continue // TODO: handle this better? Like warn the user perhaps?
+				}
+
+				appendQEMUFlags(exp.Metadata.Name, dst, i)
+			}
+		}
+	}
+
 	return nil
 }
 
 func (Serial) PostStart(ctx context.Context, exp *types.Experiment) error {
+	// Check to see if a scenario exists for this experiment and if it contains a
+	// "serial" app. If so, configure serial ports according to the app config.
+	for _, app := range exp.Apps() {
+		if app.Name() == "serial" {
+			var (
+				schedule = exp.Status.Schedules()
+				config   SerialConfig
+			)
+
+			if err := app.ParseMetadata(&config); err != nil {
+				continue // TODO: handle this better? Like warn the user perhaps?
+			}
+
+			for i, conn := range config.Connections {
+				var (
+					logFile = fmt.Sprintf(lfFormat, exp.Metadata.Name, conn.Src, conn.Dst, i)
+					srcID   = fmt.Sprintf(idFormat, exp.Metadata.Name, conn.Src, i)
+					dstID   = fmt.Sprintf(idFormat, exp.Metadata.Name, conn.Dst, i)
+					srcHost = schedule[conn.Src]
+					dstHost = schedule[conn.Dst]
+				)
+
+				if srcHost == dstHost { // single socat process on host connecting unix sockets
+					socat := fmt.Sprintf("socat -lf%s -d -d -d -d UNIX-CONNECT:/tmp/%s UNIX-CONNECT:/tmp/%s", logFile, srcID, dstID)
+
+					if err := mm.MeshBackground(srcHost, socat); err != nil {
+						return fmt.Errorf("starting socat on %s: %w", srcHost, err)
+					}
+				} else { // single socat process on each host connected via TCP
+					port := conn.Port
+
+					if port == 0 {
+						port = defaultStartPort + i
+					}
+
+					srcSocat := fmt.Sprintf("socat -lf%s -d -d -d -d UNIX-CONNECT:/tmp/%s TCP-LISTEN:%d", logFile, srcID, port)
+
+					if err := mm.MeshBackground(srcHost, srcSocat); err != nil {
+						return fmt.Errorf("starting socat on %s: %w", srcHost, err)
+					}
+
+					dstSocat := fmt.Sprintf("socat -lf%s -d -d -d -d UNIX-CONNECT:/tmp/%s TCP-CONNECT:%s:%d", logFile, dstID, srcHost, port)
+
+					if err := mm.MeshBackground(dstHost, dstSocat); err != nil {
+						return fmt.Errorf("starting socat on %s: %w", dstHost, err)
+					}
+				}
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -143,5 +244,29 @@ func (Serial) Running(ctx context.Context, exp *types.Experiment) error {
 }
 
 func (Serial) Cleanup(ctx context.Context, exp *types.Experiment) error {
+	return nil
+}
+
+func appendQEMUFlags(exp string, node ifaces.NodeSpec, idx int) error {
+	var (
+		id      = fmt.Sprintf(idFormat, exp, node.General().Hostname(), idx)
+		options = fmt.Sprintf(optFormat, id)
+	)
+
+	var qemuAppend []string
+
+	if advanced := node.Advanced(); advanced != nil {
+		if v, ok := advanced["qemu-append"]; ok {
+			if strings.Contains(v, options) {
+				return nil
+			}
+
+			qemuAppend = []string{v}
+		}
+	}
+
+	qemuAppend = append(qemuAppend, options)
+	node.AddAdvanced("qemu-append", strings.Join(qemuAppend, " "))
+
 	return nil
 }

--- a/src/go/app/serial.go
+++ b/src/go/app/serial.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/mitchellh/mapstructure"
 
 	"phenix/tmpl"
 	"phenix/types"
@@ -23,6 +26,41 @@ var (
 	defaultStartPort = 40500
 )
 
+const serialDeviceAnnotation = "phenix/serial-device"
+
+var supportedExternalSerialBaudRates = map[int]struct{}{
+	50:      {},
+	75:      {},
+	110:     {},
+	134:     {},
+	150:     {},
+	200:     {},
+	300:     {},
+	600:     {},
+	1200:    {},
+	1800:    {},
+	2400:    {},
+	4800:    {},
+	9600:    {},
+	19200:   {},
+	38400:   {},
+	57600:   {},
+	115200:  {},
+	230400:  {},
+	460800:  {},
+	500000:  {},
+	576000:  {},
+	921600:  {},
+	1000000: {},
+	1152000: {},
+	1500000: {},
+	2000000: {},
+	2500000: {},
+	3000000: {},
+	3500000: {},
+	4000000: {},
+}
+
 type SerialConfig struct {
 	Connections []SerialConnectionConfig `mapstructure:"connections"`
 }
@@ -31,6 +69,17 @@ type SerialConnectionConfig struct {
 	Src  string `mapstructure:"src"`
 	Dst  string `mapstructure:"dst"`
 	Port int    `mapstructure:"port"`
+}
+
+type externalSerialConfig struct {
+	Host     string `mapstructure:"host"`
+	Device   string `mapstructure:"device"`
+	BaudRate int    `mapstructure:"baud_rate"`
+}
+
+type serialSocatCommand struct {
+	host    string
+	command string
 }
 
 type Serial struct{}
@@ -93,6 +142,10 @@ func (Serial) Configure(ctx context.Context, exp *types.Experiment) error {
 }
 
 func (Serial) PreStart(ctx context.Context, exp *types.Experiment) error {
+	if err := validateSerialDeviceAnnotationScope(exp); err != nil {
+		return err
+	}
+
 	// loop through nodes
 	for _, node := range exp.Spec.Topology().Nodes() {
 		if node.External() {
@@ -154,29 +207,21 @@ func (Serial) PreStart(ctx context.Context, exp *types.Experiment) error {
 	// Check to see if a scenario exists for this experiment and if it contains a
 	// "serial" app. If so, configure serial ports according to the app config.
 	for _, app := range exp.Apps() {
-		if app.Name() == "serial" {
+		if app.Name() == appNameSerial {
 			var config SerialConfig
 
 			if err := app.ParseMetadata(&config); err != nil {
-				continue // TODO: handle this better? Like warn the user perhaps?
+				return fmt.Errorf("parsing serial app metadata: %w", err)
 			}
 
+			// Track VM-to-external host assignments across all connections so one
+			// VM cannot be pinned to physical serial devices on different hosts.
+			vmExternalHosts := make(map[string]string)
+
 			for i, conn := range config.Connections {
-				src := exp.Spec.Topology().FindNodeByName(conn.Src)
-
-				if src == nil {
-					continue // TODO: handle this better? Like warn the user perhaps?
+				if err := serialPreStartConnection(exp, conn, i, vmExternalHosts); err != nil {
+					return fmt.Errorf("configuring serial connection %d (%s -> %s): %w", i, conn.Src, conn.Dst, err)
 				}
-
-				appendQEMUFlags(exp.Metadata.Name, src, i)
-
-				dst := exp.Spec.Topology().FindNodeByName(conn.Dst)
-
-				if src == nil {
-					continue // TODO: handle this better? Like warn the user perhaps?
-				}
-
-				appendQEMUFlags(exp.Metadata.Name, dst, i)
 			}
 		}
 	}
@@ -185,51 +230,29 @@ func (Serial) PreStart(ctx context.Context, exp *types.Experiment) error {
 }
 
 func (Serial) PostStart(ctx context.Context, exp *types.Experiment) error {
+	if err := validateSerialDeviceAnnotationScope(exp); err != nil {
+		return err
+	}
+
 	// Check to see if a scenario exists for this experiment and if it contains a
 	// "serial" app. If so, configure serial ports according to the app config.
 	for _, app := range exp.Apps() {
-		if app.Name() == "serial" {
-			var (
-				schedule = exp.Status.Schedules()
-				config   SerialConfig
-			)
+		if app.Name() == appNameSerial {
+			var config SerialConfig
 
 			if err := app.ParseMetadata(&config); err != nil {
-				continue // TODO: handle this better? Like warn the user perhaps?
+				return fmt.Errorf("parsing serial app metadata: %w", err)
 			}
 
 			for i, conn := range config.Connections {
-				var (
-					logFile = fmt.Sprintf(lfFormat, exp.Metadata.Name, conn.Src, conn.Dst, i)
-					srcID   = fmt.Sprintf(idFormat, exp.Metadata.Name, conn.Src, i)
-					dstID   = fmt.Sprintf(idFormat, exp.Metadata.Name, conn.Dst, i)
-					srcHost = schedule[conn.Src]
-					dstHost = schedule[conn.Dst]
-				)
+				commands, err := serialPostStartCommands(exp, conn, i)
+				if err != nil {
+					return fmt.Errorf("configuring serial connection %d (%s -> %s): %w", i, conn.Src, conn.Dst, err)
+				}
 
-				if srcHost == dstHost { // single socat process on host connecting unix sockets
-					socat := fmt.Sprintf("socat -lf%s -d -d -d -d UNIX-CONNECT:/tmp/%s UNIX-CONNECT:/tmp/%s", logFile, srcID, dstID)
-
-					if err := mm.MeshBackground(srcHost, socat); err != nil {
-						return fmt.Errorf("starting socat on %s: %w", srcHost, err)
-					}
-				} else { // single socat process on each host connected via TCP
-					port := conn.Port
-
-					if port == 0 {
-						port = defaultStartPort + i
-					}
-
-					srcSocat := fmt.Sprintf("socat -lf%s -d -d -d -d UNIX-CONNECT:/tmp/%s TCP-LISTEN:%d", logFile, srcID, port)
-
-					if err := mm.MeshBackground(srcHost, srcSocat); err != nil {
-						return fmt.Errorf("starting socat on %s: %w", srcHost, err)
-					}
-
-					dstSocat := fmt.Sprintf("socat -lf%s -d -d -d -d UNIX-CONNECT:/tmp/%s TCP-CONNECT:%s:%d", logFile, dstID, srcHost, port)
-
-					if err := mm.MeshBackground(dstHost, dstSocat); err != nil {
-						return fmt.Errorf("starting socat on %s: %w", dstHost, err)
+				for _, command := range commands {
+					if err := mm.MeshBackground(command.host, command.command); err != nil {
+						return fmt.Errorf("starting socat on %s: %w", command.host, err)
 					}
 				}
 			}
@@ -245,6 +268,290 @@ func (Serial) Running(ctx context.Context, exp *types.Experiment) error {
 
 func (Serial) Cleanup(ctx context.Context, exp *types.Experiment) error {
 	return nil
+}
+
+func serialPreStartConnection(exp *types.Experiment, conn SerialConnectionConfig, idx int, vmExternalHosts map[string]string) error {
+	src, dst, err := serialConnectionNodes(exp, conn)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case src.External() && dst.External():
+		return fmt.Errorf("external-to-external serial links are not supported")
+	case src.External() || dst.External():
+		vm, external := serialVMExternalNodes(src, dst)
+
+		cfg, err := parseExternalSerialConfig(external)
+		if err != nil {
+			return err
+		}
+
+		if err := scheduleVMForExternalSerial(exp, vm, cfg.Host, vmExternalHosts); err != nil {
+			return err
+		}
+
+		if err := appendQEMUFlags(exp.Metadata.Name, vm, idx); err != nil {
+			return err
+		}
+	default:
+		if err := appendQEMUFlags(exp.Metadata.Name, src, idx); err != nil {
+			return err
+		}
+
+		if err := appendQEMUFlags(exp.Metadata.Name, dst, idx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serialPostStartCommands(exp *types.Experiment, conn SerialConnectionConfig, idx int) ([]serialSocatCommand, error) {
+	src, dst, err := serialConnectionNodes(exp, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case src.External() && dst.External():
+		return nil, fmt.Errorf("external-to-external serial links are not supported")
+	case src.External() || dst.External():
+		vm, external := serialVMExternalNodes(src, dst)
+
+		cfg, err := parseExternalSerialConfig(external)
+		if err != nil {
+			return nil, err
+		}
+
+		return vmToExternalSerialSocatCommand(exp, conn, idx, vm, cfg)
+	default:
+		return vmToVMSerialSocatCommands(exp.Metadata.Name, conn, idx, exp.Status.Schedules()), nil
+	}
+}
+
+func serialConnectionNodes(exp *types.Experiment, conn SerialConnectionConfig) (ifaces.NodeSpec, ifaces.NodeSpec, error) {
+	if strings.TrimSpace(conn.Src) == "" {
+		return nil, nil, fmt.Errorf("source node is required")
+	}
+
+	if strings.TrimSpace(conn.Dst) == "" {
+		return nil, nil, fmt.Errorf("destination node is required")
+	}
+
+	src := exp.Spec.Topology().FindNodeByName(conn.Src)
+	if src == nil {
+		return nil, nil, fmt.Errorf("source node %q not found", conn.Src)
+	}
+
+	dst := exp.Spec.Topology().FindNodeByName(conn.Dst)
+	if dst == nil {
+		return nil, nil, fmt.Errorf("destination node %q not found", conn.Dst)
+	}
+
+	return src, dst, nil
+}
+
+func serialVMExternalNodes(src, dst ifaces.NodeSpec) (ifaces.NodeSpec, ifaces.NodeSpec) {
+	if src.External() {
+		return dst, src
+	}
+
+	return src, dst
+}
+
+func validateSerialDeviceAnnotationScope(exp *types.Experiment) error {
+	for _, node := range exp.Spec.Topology().Nodes() {
+		if node.External() {
+			continue
+		}
+
+		if _, ok := node.GetAnnotation(serialDeviceAnnotation); ok {
+			return fmt.Errorf(
+				"node %q has %q annotation, which is only valid on external nodes",
+				node.General().Hostname(),
+				serialDeviceAnnotation,
+			)
+		}
+	}
+
+	return nil
+}
+
+func scheduleVMForExternalSerial(exp *types.Experiment, vm ifaces.NodeSpec, externalHost string, vmExternalHosts map[string]string) error {
+	vmName := vm.General().Hostname()
+	if vmName == "" {
+		return fmt.Errorf("VM endpoint hostname is required")
+	}
+
+	if host, ok := vmExternalHosts[vmName]; ok && host != externalHost {
+		return fmt.Errorf("VM %q connects to external serial nodes on different hosts: %q and %q", vmName, host, externalHost)
+	}
+
+	schedules := exp.Spec.Schedules()
+	if schedules == nil {
+		schedules = make(map[string]string)
+	}
+
+	if scheduledHost := schedules[vmName]; scheduledHost != "" && scheduledHost != externalHost {
+		return fmt.Errorf(
+			"VM %q is scheduled to host %q but external serial device is on host %q",
+			vmName,
+			scheduledHost,
+			externalHost,
+		)
+	}
+
+	schedules[vmName] = externalHost
+	exp.Spec.SetSchedule(schedules)
+	vmExternalHosts[vmName] = externalHost
+
+	return nil
+}
+
+func parseExternalSerialConfig(node ifaces.NodeSpec) (externalSerialConfig, error) {
+	nodeName := node.General().Hostname()
+
+	raw, ok := node.GetAnnotation(serialDeviceAnnotation)
+	if !ok {
+		return externalSerialConfig{}, fmt.Errorf("external node %q missing %q annotation", nodeName, serialDeviceAnnotation)
+	}
+
+	var cfg externalSerialConfig
+	if err := mapstructure.Decode(raw, &cfg); err != nil {
+		return externalSerialConfig{}, fmt.Errorf("decoding %q annotation for external node %q: %w", serialDeviceAnnotation, nodeName, err)
+	}
+
+	cfg.Host = strings.TrimSpace(cfg.Host)
+	cfg.Device = strings.TrimSpace(cfg.Device)
+
+	if err := validateExternalSerialHost(cfg.Host); err != nil {
+		return externalSerialConfig{}, fmt.Errorf("invalid %q annotation for external node %q: %w", serialDeviceAnnotation, nodeName, err)
+	}
+
+	if err := validateExternalSerialDevice(cfg.Device); err != nil {
+		return externalSerialConfig{}, fmt.Errorf("invalid %q annotation for external node %q: %w", serialDeviceAnnotation, nodeName, err)
+	}
+
+	if err := validateExternalSerialBaudRate(cfg.BaudRate); err != nil {
+		return externalSerialConfig{}, fmt.Errorf("invalid %q annotation for external node %q: %w", serialDeviceAnnotation, nodeName, err)
+	}
+
+	return cfg, nil
+}
+
+func validateExternalSerialHost(host string) error {
+	if host == "" {
+		return fmt.Errorf("host is required")
+	}
+
+	if strings.ContainsAny(host, " \t\r\n") {
+		return fmt.Errorf("host %q cannot contain whitespace", host)
+	}
+
+	return nil
+}
+
+func validateExternalSerialDevice(device string) error {
+	if device == "" {
+		return fmt.Errorf("device is required")
+	}
+
+	if strings.ContainsAny(device, " \t\r\n") {
+		return fmt.Errorf("device %q cannot contain whitespace", device)
+	}
+
+	if !strings.HasPrefix(device, "/dev/") {
+		return fmt.Errorf("device %q must be an absolute /dev path", device)
+	}
+
+	clean := filepath.Clean(device)
+	if clean != device || !strings.HasPrefix(clean, "/dev/") {
+		return fmt.Errorf("device %q must be a clean absolute /dev path", device)
+	}
+
+	if strings.ContainsAny(device, ",;&|`$<>(){}[]*?!'\"\\") {
+		return fmt.Errorf("device %q contains unsupported characters", device)
+	}
+
+	return nil
+}
+
+func validateExternalSerialBaudRate(baudRate int) error {
+	if baudRate == 0 {
+		return nil
+	}
+
+	if baudRate < 0 {
+		return fmt.Errorf("baud_rate must be positive")
+	}
+
+	if _, ok := supportedExternalSerialBaudRates[baudRate]; !ok {
+		return fmt.Errorf("baud_rate %d is not supported", baudRate)
+	}
+
+	return nil
+}
+
+func vmToVMSerialSocatCommands(expName string, conn SerialConnectionConfig, idx int, schedule map[string]string) []serialSocatCommand {
+	var (
+		logFile = fmt.Sprintf(lfFormat, expName, conn.Src, conn.Dst, idx)
+		srcID   = fmt.Sprintf(idFormat, expName, conn.Src, idx)
+		dstID   = fmt.Sprintf(idFormat, expName, conn.Dst, idx)
+		srcHost = schedule[conn.Src]
+		dstHost = schedule[conn.Dst]
+	)
+
+	if srcHost == dstHost { // single socat process on host connecting unix sockets
+		socat := fmt.Sprintf("socat -lf%s -d -d -d -d UNIX-CONNECT:/tmp/%s UNIX-CONNECT:/tmp/%s", logFile, srcID, dstID)
+
+		return []serialSocatCommand{{host: srcHost, command: socat}}
+	}
+
+	port := conn.Port
+	if port == 0 {
+		port = defaultStartPort + idx
+	}
+
+	srcSocat := fmt.Sprintf("socat -lf%s -d -d -d -d UNIX-CONNECT:/tmp/%s TCP-LISTEN:%d", logFile, srcID, port)
+	dstSocat := fmt.Sprintf("socat -lf%s -d -d -d -d UNIX-CONNECT:/tmp/%s TCP-CONNECT:%s:%d", logFile, dstID, srcHost, port)
+
+	return []serialSocatCommand{
+		{host: srcHost, command: srcSocat},
+		{host: dstHost, command: dstSocat},
+	}
+}
+
+func vmToExternalSerialSocatCommand(exp *types.Experiment, conn SerialConnectionConfig, idx int, vm ifaces.NodeSpec, cfg externalSerialConfig) ([]serialSocatCommand, error) {
+	vmName := vm.General().Hostname()
+	vmHost := exp.Status.Schedules()[vmName]
+	if vmHost == "" {
+		return nil, fmt.Errorf("VM %q has no runtime schedule for external serial host %q", vmName, cfg.Host)
+	}
+
+	if vmHost != cfg.Host {
+		return nil, fmt.Errorf(
+			"VM %q is running on host %q but external serial device is on host %q",
+			vmName,
+			vmHost,
+			cfg.Host,
+		)
+	}
+
+	logFile := fmt.Sprintf(lfFormat, exp.Metadata.Name, conn.Src, conn.Dst, idx)
+	vmID := fmt.Sprintf(idFormat, exp.Metadata.Name, vmName, idx)
+	socat := fmt.Sprintf("socat -lf%s -d -d -d -d UNIX-CONNECT:/tmp/%s %s", logFile, vmID, cfg.socatAddress())
+
+	return []serialSocatCommand{{host: cfg.Host, command: socat}}, nil
+}
+
+func (cfg externalSerialConfig) socatAddress() string {
+	address := fmt.Sprintf("OPEN:%s,raw,echo=0", cfg.Device)
+	if cfg.BaudRate != 0 {
+		address += fmt.Sprintf(",b%d", cfg.BaudRate)
+	}
+
+	return address
 }
 
 func appendQEMUFlags(exp string, node ifaces.NodeSpec, idx int) error {

--- a/src/go/app/serial_test.go
+++ b/src/go/app/serial_test.go
@@ -1,0 +1,304 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"phenix/store"
+	"phenix/types"
+	v1 "phenix/types/version/v1"
+	v2 "phenix/types/version/v2"
+)
+
+func TestSerialPreStartSchedulesVMToExternalHost(t *testing.T) {
+	vm := serialTestVM("vm1")
+	external := serialTestExternal("plc-serial0", "compute1", "/dev/ttyUSB0", 0)
+	exp := serialTestExperiment(t, []*v1.Node{vm, external}, nil, nil, []map[string]any{
+		{"src": "vm1", "dst": "plc-serial0"},
+	})
+
+	if err := (Serial{}).PreStart(context.Background(), exp); err != nil {
+		t.Fatalf("unexpected PreStart error: %v", err)
+	}
+
+	if got := exp.Spec.Schedules()["vm1"]; got != "compute1" {
+		t.Fatalf("expected vm1 to be scheduled on compute1, got %q", got)
+	}
+
+	qemuAppend := vm.Advanced()["qemu-append"]
+	if !strings.Contains(qemuAppend, "serial-exp_serial_vm1_0") {
+		t.Fatalf("expected qemu-append to include VM serial socket, got %q", qemuAppend)
+	}
+
+	if external.Advanced()["qemu-append"] != "" {
+		t.Fatalf("expected external node not to get qemu-append, got %q", external.Advanced()["qemu-append"])
+	}
+}
+
+func TestSerialPreStartConflictingScheduleFails(t *testing.T) {
+	exp := serialTestExperiment(t, []*v1.Node{
+		serialTestVM("vm1"),
+		serialTestExternal("plc-serial0", "compute1", "/dev/ttyUSB0", 0),
+	}, map[string]string{"vm1": "compute2"}, nil, []map[string]any{
+		{"src": "vm1", "dst": "plc-serial0"},
+	})
+
+	err := (Serial{}).PreStart(context.Background(), exp)
+	if err == nil {
+		t.Fatal("expected PreStart to fail")
+	}
+
+	if !strings.Contains(err.Error(), "scheduled to host \"compute2\"") {
+		t.Fatalf("expected schedule conflict error, got %v", err)
+	}
+}
+
+func TestSerialPreStartVMExternalDifferentHostsFails(t *testing.T) {
+	exp := serialTestExperiment(t, []*v1.Node{
+		serialTestVM("vm1"),
+		serialTestExternal("plc-serial0", "compute1", "/dev/ttyUSB0", 0),
+		serialTestExternal("plc-serial1", "compute2", "/dev/ttyUSB1", 0),
+	}, nil, nil, []map[string]any{
+		{"src": "vm1", "dst": "plc-serial0"},
+		{"src": "vm1", "dst": "plc-serial1"},
+	})
+
+	err := (Serial{}).PreStart(context.Background(), exp)
+	if err == nil {
+		t.Fatal("expected PreStart to fail")
+	}
+
+	if !strings.Contains(err.Error(), "different hosts") {
+		t.Fatalf("expected multiple external host error, got %v", err)
+	}
+}
+
+func TestSerialPreStartSerialDeviceAnnotationOnVMFails(t *testing.T) {
+	vm := serialTestVM("vm1")
+	vm.AnnotationsF = map[string]any{
+		serialDeviceAnnotation: map[string]any{
+			"host":   "compute1",
+			"device": "/dev/ttyUSB0",
+		},
+	}
+
+	exp := serialTestExperiment(t, []*v1.Node{vm}, nil, nil, nil)
+
+	err := (Serial{}).PreStart(context.Background(), exp)
+	if err == nil {
+		t.Fatal("expected PreStart to fail")
+	}
+
+	if !strings.Contains(err.Error(), "only valid on external nodes") {
+		t.Fatalf("expected external-only annotation error, got %v", err)
+	}
+}
+
+func TestSerialPostStartVMToExternalCommandIsLocalOnly(t *testing.T) {
+	exp := serialTestExperiment(t, []*v1.Node{
+		serialTestVM("vm1"),
+		serialTestExternal("plc-serial0", "compute1", "/dev/ttyUSB0", 115200),
+	}, nil, map[string]string{"vm1": "compute1"}, []map[string]any{
+		{"src": "vm1", "dst": "plc-serial0"},
+	})
+
+	commands, err := serialPostStartCommands(exp, SerialConnectionConfig{Src: "vm1", Dst: "plc-serial0"}, 0)
+	if err != nil {
+		t.Fatalf("unexpected command build error: %v", err)
+	}
+
+	if len(commands) != 1 {
+		t.Fatalf("expected one same-host socat command, got %d", len(commands))
+	}
+
+	want := "socat -lf/tmp/serial-exp_serial_vm1_plc-serial0_0.log -d -d -d -d " +
+		"UNIX-CONNECT:/tmp/serial-exp_serial_vm1_0 OPEN:/dev/ttyUSB0,raw,echo=0,b115200"
+	if commands[0].host != "compute1" || commands[0].command != want {
+		t.Fatalf("unexpected command:\nhost: %s\ncommand: %s", commands[0].host, commands[0].command)
+	}
+
+	if strings.Contains(commands[0].command, "TCP-") {
+		t.Fatalf("expected local-only command without TCP bridge, got %q", commands[0].command)
+	}
+}
+
+func TestSerialVMToVMSocatCommandsUnchanged(t *testing.T) {
+	sameHost := vmToVMSerialSocatCommands(
+		"serial-exp",
+		SerialConnectionConfig{Src: "vm1", Dst: "vm2"},
+		0,
+		map[string]string{"vm1": "compute1", "vm2": "compute1"},
+	)
+
+	if len(sameHost) != 1 {
+		t.Fatalf("expected one same-host command, got %d", len(sameHost))
+	}
+
+	wantSameHost := "socat -lf/tmp/serial-exp_serial_vm1_vm2_0.log -d -d -d -d " +
+		"UNIX-CONNECT:/tmp/serial-exp_serial_vm1_0 UNIX-CONNECT:/tmp/serial-exp_serial_vm2_0"
+	if sameHost[0].host != "compute1" || sameHost[0].command != wantSameHost {
+		t.Fatalf("unexpected same-host command:\nhost: %s\ncommand: %s", sameHost[0].host, sameHost[0].command)
+	}
+
+	crossHost := vmToVMSerialSocatCommands(
+		"serial-exp",
+		SerialConnectionConfig{Src: "vm1", Dst: "vm2"},
+		1,
+		map[string]string{"vm1": "compute1", "vm2": "compute2"},
+	)
+
+	if len(crossHost) != 2 {
+		t.Fatalf("expected two cross-host commands, got %d", len(crossHost))
+	}
+
+	wantListen := "socat -lf/tmp/serial-exp_serial_vm1_vm2_1.log -d -d -d -d " +
+		"UNIX-CONNECT:/tmp/serial-exp_serial_vm1_1 TCP-LISTEN:40501"
+	wantConnect := "socat -lf/tmp/serial-exp_serial_vm1_vm2_1.log -d -d -d -d " +
+		"UNIX-CONNECT:/tmp/serial-exp_serial_vm2_1 TCP-CONNECT:compute1:40501"
+
+	if crossHost[0].host != "compute1" || crossHost[0].command != wantListen {
+		t.Fatalf("unexpected listen command:\nhost: %s\ncommand: %s", crossHost[0].host, crossHost[0].command)
+	}
+
+	if crossHost[1].host != "compute2" || crossHost[1].command != wantConnect {
+		t.Fatalf("unexpected connect command:\nhost: %s\ncommand: %s", crossHost[1].host, crossHost[1].command)
+	}
+}
+
+func TestSerialExternalAnnotationValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		node *v1.Node
+		want string
+	}{
+		{
+			name: "missing annotation",
+			node: serialTestExternalWithoutAnnotation("plc-serial0"),
+			want: "missing \"phenix/serial-device\" annotation",
+		},
+		{
+			name: "invalid annotation shape",
+			node: serialTestExternalWithAnnotation("plc-serial0", "not-a-map"),
+			want: "decoding",
+		},
+		{
+			name: "missing host",
+			node: serialTestExternal("plc-serial0", "", "/dev/ttyUSB0", 0),
+			want: "host is required",
+		},
+		{
+			name: "invalid device path",
+			node: serialTestExternal("plc-serial0", "compute1", "ttyUSB0", 0),
+			want: "absolute /dev path",
+		},
+		{
+			name: "invalid device characters",
+			node: serialTestExternal("plc-serial0", "compute1", "/dev/ttyUSB0,b9600", 0),
+			want: "unsupported characters",
+		},
+		{
+			name: "invalid baud rate",
+			node: serialTestExternal("plc-serial0", "compute1", "/dev/ttyUSB0", 12345),
+			want: "not supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseExternalSerialConfig(tt.node)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error containing %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestSerialPreStartExternalToExternalFails(t *testing.T) {
+	exp := serialTestExperiment(t, []*v1.Node{
+		serialTestExternal("plc-serial0", "compute1", "/dev/ttyUSB0", 0),
+		serialTestExternal("plc-serial1", "compute1", "/dev/ttyUSB1", 0),
+	}, nil, nil, []map[string]any{
+		{"src": "plc-serial0", "dst": "plc-serial1"},
+	})
+
+	err := (Serial{}).PreStart(context.Background(), exp)
+	if err == nil {
+		t.Fatal("expected PreStart to fail")
+	}
+
+	if !strings.Contains(err.Error(), "external-to-external serial links are not supported") {
+		t.Fatalf("expected external-to-external error, got %v", err)
+	}
+}
+
+func serialTestExperiment(t *testing.T, nodes []*v1.Node, specSchedules map[string]string, statusSchedules map[string]string, connections []map[string]any) *types.Experiment {
+	t.Helper()
+
+	return &types.Experiment{
+		Metadata: store.ConfigMetadata{Name: "serial-exp"},
+		Spec: &v1.ExperimentSpec{
+			ExperimentNameF: "serial-exp",
+			BaseDirF:        t.TempDir(),
+			TopologyF:       &v1.TopologySpec{NodesF: nodes},
+			ScenarioF: &v2.ScenarioSpec{AppsF: []*v2.ScenarioApp{
+				{
+					NameF: appNameSerial,
+					MetadataF: map[string]any{
+						"connections": connections,
+					},
+				},
+			}},
+			SchedulesF: specSchedules,
+		},
+		Status: &v1.ExperimentStatus{
+			SchedulesF: statusSchedules,
+		},
+	}
+}
+
+func serialTestVM(name string) *v1.Node {
+	return &v1.Node{
+		TypeF: "VirtualMachine",
+		GeneralF: &v1.General{
+			HostnameF: name,
+		},
+		HardwareF: &v1.Hardware{
+			OSTypeF: osLinux,
+		},
+		NetworkF: &v1.Network{},
+	}
+}
+
+func serialTestExternal(name, host, device string, baudRate int) *v1.Node {
+	annotation := map[string]any{
+		"host":   host,
+		"device": device,
+	}
+	if baudRate != 0 {
+		annotation["baud_rate"] = baudRate
+	}
+
+	return serialTestExternalWithAnnotation(name, annotation)
+}
+
+func serialTestExternalWithoutAnnotation(name string) *v1.Node {
+	external := true
+
+	return &v1.Node{
+		TypeF:     "External",
+		GeneralF:  &v1.General{HostnameF: name},
+		ExternalF: &external,
+	}
+}
+
+func serialTestExternalWithAnnotation(name string, annotation any) *v1.Node {
+	node := serialTestExternalWithoutAnnotation(name)
+	node.AnnotationsF = map[string]any{serialDeviceAnnotation: annotation}
+
+	return node
+}

--- a/src/go/app/user.go
+++ b/src/go/app/user.go
@@ -172,8 +172,14 @@ func (u UserApp) shellOut(ctx context.Context, action Action, exp *types.Experim
 	}
 
 	switch action {
-	case ActionConfigure, ActionPreStart:
+	case ActionConfigure:
 		exp.SetSpec(result.Spec)
+	case ActionPreStart:
+		exp.SetSpec(result.Spec)
+
+		if metadata, ok := result.Status.AppStatus()[u.options.Name]; ok {
+			exp.Status.SetAppStatus(u.options.Name, metadata)
+		}
 	case ActionPostStart, ActionRunning:
 		if metadata, ok := result.Status.AppStatus()[u.options.Name]; ok {
 			exp.Status.SetAppStatus(u.options.Name, metadata)

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -1427,6 +1427,26 @@ func (Minimega) MeshShellResponse(host, command string) (string, error) {
 	return "", errors.New("error running MeshShellResponse()")
 }
 
+func (Minimega) MeshBackground(host, command string) error {
+	cmd := mmcli.NewCommand()
+
+	if host == "" {
+		host = Headnode()
+	}
+
+	if IsHeadnode(host) {
+		cmd.Command = fmt.Sprintf("background %s", command)
+	} else {
+		cmd.Command = fmt.Sprintf("mesh send %s background %s", host, command)
+	}
+
+	if err := mmcli.ErrorResponse(mmcli.Run(cmd)); err != nil {
+		return fmt.Errorf("backgrounding shell command (host %s) %s: %w", host, command, err)
+	}
+
+	return nil
+}
+
 func (Minimega) MeshSend(ns, host, command string) error {
 	var cmd *mmcli.Command
 

--- a/src/go/util/mm/mm.go
+++ b/src/go/util/mm/mm.go
@@ -51,5 +51,6 @@ type MM interface { //nolint:interfacebloat // legacy interface
 	TapVLAN(...TapOption) error
 	MeshShell(string, string) error
 	MeshShellResponse(string, string) (string, error)
+	MeshBackground(string, string) error
 	MeshSend(string, string, string) error
 }

--- a/src/go/util/mm/package.go
+++ b/src/go/util/mm/package.go
@@ -152,6 +152,10 @@ func MeshShellResponse(host, cmd string) (string, error) {
 	return DefaultMM.MeshShellResponse(host, cmd)
 }
 
+func MeshBackground(host, cmd string) error {
+	return DefaultMM.MeshBackground(host, cmd)
+}
+
 func MeshSend(ns, host, command string) error {
 	return DefaultMM.MeshSend(ns, host, command)
 }

--- a/src/js/src/components/StateOfHealth.vue
+++ b/src/js/src/components/StateOfHealth.vue
@@ -260,16 +260,12 @@
               </div>
             </div>
             <div>
-              <b-tooltip label="menu for selecting networks" type="is-light" multilined>
-                <b-dropdown v-model="showEdgetType" class="is-right" aria-role="list">
-                  <button class="button is-light" slot="trigger">
-                    <b-icon icon="bars"></b-icon>
-                  </button>
-                  <b-dropdown-item v-for="( n, index ) in networks" :key="index" :value="n">
-                    <font color="#202020">{{ n }}</font>
-                  </b-dropdown-item>
-                </b-dropdown>
-              </b-tooltip>
+              <b-dropdown v-model="showEdgeType" aria-role="list" :triggers="['hover']">
+                <b-button label="Link Type" type="is-light" slot="trigger" />
+                <b-dropdown-item v-for="( n, index ) in networks" :key="index" :value="n" aria-role="listitem">
+                  <font color="#202020">{{ n }}</font>
+                </b-dropdown-item>
+              </b-dropdown>
             </div>
             <div class="column" />
           </div>
@@ -593,14 +589,17 @@ export default {
       return '#999';
     },
 
+    setEdge( type ) {
+      this.showEdgeType = type;
+      this.resetNetwork();
+    },
+
     generateGraph () {
       if ( this.nodes == null ) {
         return;
       }
 
-      const nodes = this.nodes.map( d => Object.create( d ) );
-      // const links = this.edges.map( d => Object.create( d ) );
-
+      const nodes = this.nodes;
       const links = this.edges.filter( (d) => {
         switch ( this.showEdgeType ) {
           case 'all': {
@@ -617,7 +616,7 @@ export default {
         }
       }, this);
 
-      const width = 600;
+      const width  = 600;
       const height = 400;
 
       const simulation = d3.forceSimulation( nodes )
@@ -1070,6 +1069,10 @@ export default {
         this.generateChord();
       }
     },
+
+    showEdgeType: function () {
+      this.generateGraph();
+    }
   },
 
   data() {
@@ -1157,5 +1160,9 @@ export default {
 
   ul {
     column-count: 1;
+  }
+
+  .dropdown-item.is-active {
+    background-color: whitesmoke;
   }
 </style>

--- a/src/js/src/components/StateOfHealth.vue
+++ b/src/js/src/components/StateOfHealth.vue
@@ -207,7 +207,7 @@
     </b-modal>
     <!-- END STYLE MODAL -->
     <hr>
-    <div class="columns is-centered"> 
+    <div class="columns is-centered">
       <div class="column is-1">
         <router-link class="button is-dark" :to="{ name: 'experiment', params: { id: this.$route.params.id }}">
           <b-tooltip label="return to the experiment component" type="is-light is-right" :delay="1000">
@@ -258,6 +258,18 @@
               <div v-else>
                 <b-button @click="execSoH" type="is-light">Run SOH</b-button>
               </div>
+            </div>
+            <div>
+              <b-tooltip label="menu for selecting networks" type="is-light" multilined>
+                <b-dropdown v-model="showEdgetType" class="is-right" aria-role="list">
+                  <button class="button is-light" slot="trigger">
+                    <b-icon icon="bars"></b-icon>
+                  </button>
+                  <b-dropdown-item v-for="( n, index ) in networks" :key="index" :value="n">
+                    <font color="#202020">{{ n }}</font>
+                  </b-dropdown-item>
+                </b-dropdown>
+              </b-tooltip>
             </div>
             <div class="column" />
           </div>
@@ -476,7 +488,7 @@ export default {
                   d3.selectAll('circle').attr( "fill", this.updateNodeColor );
                 }
               }
-              
+
               break;
             }
             case 'delete': {
@@ -486,7 +498,7 @@ export default {
                   d3.selectAll('circle').attr( "fill", this.updateNodeColor );
                 }
               }
-              
+
               break;
             }
           }
@@ -573,13 +585,37 @@ export default {
       return colors[ node.status ];
     },
 
+    updateEdgeColor( edge ) {
+      if ( edge.type == "serial" ) {
+        return '#A020F0' // purple
+      }
+
+      return '#999';
+    },
+
     generateGraph () {
       if ( this.nodes == null ) {
         return;
       }
 
       const nodes = this.nodes.map( d => Object.create( d ) );
-      const links = this.edges.map( d => Object.create( d ) );
+      // const links = this.edges.map( d => Object.create( d ) );
+
+      const links = this.edges.filter( (d) => {
+        switch ( this.showEdgeType ) {
+          case 'all': {
+            return true;
+          }
+
+          case 'network': {
+            return d.type !== 'serial';
+          }
+
+          case 'serial': {
+            return d.type === 'serial';
+          }
+        }
+      }, this);
 
       const width = 600;
       const height = 400;
@@ -605,11 +641,11 @@ export default {
       );
 
       const link = g.append( "g" )
-        .attr( "stroke", "#999" )
-        .attr( "stroke-opacity", 0.6 )
         .selectAll( "line" )
         .data( links )
         .join( "line" )
+        .attr( "stroke-opacity", 0.6 )
+        .attr( "stroke", this.updateEdgeColor )
         .attr( "stroke-width", d => Math.sqrt( d.value ) );
 
       const defs = svg.append( "svg:defs" );
@@ -750,7 +786,7 @@ export default {
       }
 
       let circle = d3.select( e.target );
-      
+
       circle
         .transition()
         .attr( "r", 15 )
@@ -793,18 +829,18 @@ export default {
         event.subject.fx = event.subject.x;
         event.subject.fy = event.subject.y;
       }
-      
+
       function dragged ( event ) {
         event.subject.fx = event.x;
         event.subject.fy = event.y;
       }
-      
+
       function dragended ( event ) {
         if ( !event.active ) simulation.alphaTarget( 0 );
         event.subject.fx = null;
         event.subject.fy = null;
       }
-      
+
       return d3.drag()
         .on( "start", dragstarted )
         .on( "drag", dragged )
@@ -822,16 +858,16 @@ export default {
 
       const innerRadius = Math.min(width, height) * .35;
       const outerRadius = innerRadius * 1.018;
-      
+
       const chord = d3.chord()
         .padAngle(10 / innerRadius)
         .sortSubgroups(d3.descending)
         .sortChords(d3.descending);
-      
+
       const arc = d3.arc()
         .innerRadius(innerRadius)
         .outerRadius(outerRadius);
-      
+
       const ribbon = d3.ribbon()
         .radius(innerRadius - 1)
         .padAngle(1 / innerRadius);
@@ -858,7 +894,7 @@ export default {
         .selectAll("g")
         .data(chords.groups)
         .join("g");
-      
+
       group.append("path")
         .attr("fill", d => color(names[d.index]))
         .attr("stroke", d => color(names[d.index]))
@@ -901,7 +937,7 @@ export default {
             ? `↑ ${names[d.index]}`
             : `${names[d.index]} ↓`;
         });
-      
+
       svg.append("g")
         .attr("fill-opacity", 0.8)
         .selectAll("path")
@@ -1042,9 +1078,15 @@ export default {
       sohInitialized: false,
       sohRunning: false,
       flows: false,
+      volume: [],
       nodes: [],
       edges: [],
-      volume: [],
+      showEdgeType: 'all',
+      networks: [
+       'all',
+       'network',
+       'serial'
+      ],
       radioButton: '',
       vlan: VLAN,
       detailsModal: {


### PR DESCRIPTION
# feat: support configuring serial ports at the minimega host level

## Description

This branch expands the serial app so experiments can model and wire serial
connections across minimega hosts, including connections from VMs to external
physical serial devices. It also moves serial connectivity toward a consistent
QEMU socket plus `socat` bridge model for both VM-to-VM and VM-to-external
links, which enables serial connections for Windows VMs as well as Linux VMs.

The previous default implementation only generated Linux guest startup scripts
for serial interfaces. This branch instead configures serial devices at the
minimega/QEMU layer, so Windows VMs can participate in serial connections
without requiring guest-side Linux startup behavior.

The main review areas are:

- serial app configuration and lifecycle behavior
- minimega host/mesh command helpers
- SOH topology graph support for serial links
- validation around external serial device annotations

### What Changed

#### Serial app

- Added serial connection handling for VM-to-VM links across minimega hosts.
- Added support for VM-to-external serial device links using external topology
  nodes annotated with `phenix/serial-device`.
- Uses the same core approach for VM-to-VM and VM-to-external serial:
  - attach QEMU serial socket devices to participating VMs
  - bridge those sockets with `socat` on the relevant minimega host
  - use TCP only when VM endpoints run on different minimega hosts
- Enables Windows VMs to participate in serial connections because the serial
  device is configured through QEMU rather than Linux-only guest startup
  injection.
- External serial device annotations include host, device path, and optional
  baud rate.
- Serial app now schedules VMs onto the minimega host that owns the external
  serial device.
- Added validation for:
  - external-only use of `phenix/serial-device`
  - missing or malformed serial connection endpoints
  - unsupported external-to-external serial links
  - conflicting VM schedules across external serial hosts
  - unsafe or invalid `/dev/...` device paths
  - unsupported baud rates
- Added idempotent QEMU serial socket flag generation.
- Added `socat` command generation for same-host, cross-host, and
  VM-to-external serial links.

#### Minimega support

- Added minimega helpers for cluster host discovery, headnode detection, mesh
  shell/background execution, and minimega arg lookup.
- Added `socat` to the minimega container image so serial bridge commands can
  run on minimega hosts.
- Updated user app PreStart handling so app status metadata can be preserved
  when user apps return status during PreStart.

#### State of Health UI/API

- Added serial edges to the SOH topology response.
- Added edge typing so the UI can distinguish network links from serial links.
- Added SOH graph filtering for all links, network links, or serial links.
- Render serial links in a distinct color.
- Added external node status/legend handling.
- Added a temporary network refresh path to force graph regeneration while link
  update behavior is still being investigated.

#### Tests

- Added serial app unit tests covering:
  - VM scheduling to external serial hosts
  - schedule conflict errors
  - multiple external-host conflicts
  - annotation scope validation
  - VM-to-external `socat` command generation
  - existing VM-to-VM command behavior
  - external annotation validation
  - external-to-external rejection

## Related Issue

N/A

## Type of Change

Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

None
