### PR TITLE
feat(workflow): allow API to accept tags for experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ repository named `.phenix.yml`) should be applied. Applying the phenix workflow
 config file will trigger existing experiments to be updated and restarted,
 depending on settings within the workflow config file.
 
+Optional tags can be passed as URL querries when the workflow config is applied.
+These tags are stored as a string `key1=value1,key2=value2`.
+
 ### Add/Update Topology or Scenario Config
 
 ```
@@ -59,7 +62,7 @@ curl -XPOST -H "Content-Type: application/x-yaml" \
 ```
 curl -XPOST -H "Content-Type: application/x-yaml" \
   --data-binary @{/path/to/config/file.yml} \
-  http://localhost:3000/api/v1/workflow/apply/{branch name}
+  http://localhost:3000/api/v1/workflow/apply/{branch name}[?tag=key1=value1&tag=key2=value2]
 ```
 
 ### phenix Workflow Config File Documentation

--- a/src/go/store/types.go
+++ b/src/go/store/types.go
@@ -26,11 +26,11 @@ type (
 )
 
 type Config struct {
-	Version  string                 `json:"apiVersion" yaml:"apiVersion"`
-	Kind     string                 `json:"kind" yaml:"kind"`
-	Metadata ConfigMetadata         `json:"metadata" yaml:"metadata"`
-	Spec     map[string]interface{} `json:"spec,omitempty" yaml:"spec,omitempty"`
-	Status   map[string]interface{} `json:"status,omitempty" yaml:"status,omitempty"`
+	Version  string         `json:"apiVersion" yaml:"apiVersion"`
+	Kind     string         `json:"kind" yaml:"kind"`
+	Metadata ConfigMetadata `json:"metadata" yaml:"metadata"`
+	Spec     map[string]any `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Status   map[string]any `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 type ConfigMetadata struct {
@@ -217,7 +217,7 @@ type Event struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
-func NewEvent(format string, args ...interface{}) *Event {
+func NewEvent(format string, args ...any) *Event {
 	return &Event{
 		ID:        uuid.Must(uuid.NewV4()).String(),
 		Timestamp: time.Now(),
@@ -227,7 +227,7 @@ func NewEvent(format string, args ...interface{}) *Event {
 	}
 }
 
-func NewInfoEvent(format string, args ...interface{}) *Event {
+func NewInfoEvent(format string, args ...any) *Event {
 	event := NewEvent(format, args...)
 	event.Type = EventTypeInfo
 

--- a/src/go/types/experiment.go
+++ b/src/go/types/experiment.go
@@ -71,6 +71,9 @@ func (this Experiment) WriteToStore(statusOnly bool) error {
 		return fmt.Errorf("getting experiment %s from store: %w", name, err)
 	}
 
+	// limit metadata updates to annotations so name doesn't accidentally get changed
+	c.Metadata.Annotations = this.Metadata.Annotations
+
 	if !statusOnly {
 		c.Spec = structs.MapDefaultCase(this.Spec, structs.CASESNAKE)
 	}


### PR DESCRIPTION
Users can now send key=value pairs via URL requests to the API when
applying a configuration file. Currently, any query in the form
'tag=key=value' will be stored as an experiment annotation named
`phenix.workflow/tags`, with the value being a simple coma-separated
string of the tags.

Take the following URL as an example.

```
/api/v1/workflow/apply/{BRANCH}?tag=key1=value1&tag=key2=value&foo=bar
```

This will result in the following annotation being added to the
experiment metadata.

```
metadata:
  annotations:
    "phenix.workflow/tags": "key1=value1,key2=value2"
```

Note that the `foo=bar` query parameter is ignored. These tags are then
recorded with other info after each scorch run.