### PR TITLE
fix(soh): location of custom test scripts now get referenced correctly

### DIFF
--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -1294,7 +1294,7 @@ func (this SOH) customTest(ctx context.Context, wg *mm.StateGroup, ns string, no
 		}
 	}
 
-	command := fmt.Sprintf("%s /tmp/miniccc/files/%s/%s", executor, ns, script)
+	command := fmt.Sprintf("%s /tmp/miniccc/files/%s", executor, script)
 	opts := []mm.C2Option{mm.C2NS(ns), mm.C2VM(host), mm.C2SendFile(script), mm.C2Command(command), mm.C2Timeout(this.md.c2Timeout)}
 
 	if this.md.useUUIDForC2Active(host) {


### PR DESCRIPTION
This commit reverts a change made in commit 2bff3622 that prefixed the location of custom test scripts in VMs with the experiment namespace.

minimega cc will search for a file to be sent in nested directories, but will not prefix it with the nested directory in the VM if the file was not prefixed with the nested directory when provided to the cc send command.

fixes #175