### PR TITLE
feat(image): add image create arg for kernel parameters

### DIFF
--- a/src/go/cmd/image.go
+++ b/src/go/cmd/image.go
@@ -128,6 +128,10 @@ func newImageCreateCmd() *cobra.Command {
 				img.ScriptPaths = strings.Split(scripts, ",")
 			}
 
+			if kernel := MustGetString(cmd.Flags(), "kernel-args"); kernel != "" {
+				img.Kernel = strings.Split(kernel, ",")
+			}
+
 			units := img.Size[len(img.Size)-1:]
 			if units != "M" && units != "G" {
 				return fmt.Errorf("Must provide a valid unit for disk size option (e.g., '500M' or '10G')")
@@ -156,7 +160,8 @@ func newImageCreateCmd() *cobra.Command {
 	cmd.Flags().Bool("skip-default-pkgs", false, "Skip default packages typically included in all builds")
 	cmd.Flags().StringP("packages", "P", "", "List of packages to include in addition to those provided by variant (separated by comma)")
 	cmd.Flags().StringP("scripts", "T", "", "List of scripts to include in addition to the defaults (include full path; separated by comma)")
-	cmd.Flags().Bool("no-virtuals", false, `Don't add virtual filesystem mounts to chroot before executing scripts when running vmdb2 (default is 'false')`)
+	cmd.Flags().Bool("no-virtuals", false, "Don't add virtual filesystem mounts to chroot before executing scripts when running vmdb2 (default is 'false')")
+	cmd.Flags().StringP("kernel-args", "k", "", "List of parameters which grub will pass to the Linux kernel (e.g. 'net.ifnames=0','consoleblank=0'); separated by comma)")
 
 	return cmd
 }
@@ -177,11 +182,11 @@ func newImageCreateFromCmd() *cobra.Command {
 			}
 
 			var (
-				name     = args[0]
-				saveas   = args[1]
-				overlays []string
-				packages []string
-				scripts  []string
+				name         = args[0]
+				saveas       = args[1]
+				overlays     []string
+				packages     []string
+				scripts      []string
 			)
 
 			if opt := MustGetString(cmd.Flags(), "overlays"); opt != "" {

--- a/src/go/tmpl/templates/vmdb.tmpl
+++ b/src/go/tmpl/templates/vmdb.tmpl
@@ -54,6 +54,12 @@ steps:
   - fstab: root
   - grub: bios
     tag: root
+{{- if gt (len .Kernel) 0 }}
+    kernel-params:
+  {{- range $param := .Kernel }}
+      - {{ $param }}
+  {{- end }}
+{{- end }}
 {{- if .Ramdisk }}
   - ramdisk: root
 {{- end }}

--- a/src/go/types/version/v1/image.go
+++ b/src/go/types/version/v1/image.go
@@ -30,6 +30,7 @@ type Image struct {
 	ScriptOrder         []string          `json:"script_order" yaml:"script_order" structs:"script_order" mapstructure:"script_order"`
 	Components          []string          `json:"components" yaml:"components"`
 	NoVirtuals          bool              `json:"no_virtuals" yaml:"no_virtuals" structs:"no_virtuals" mapstructure:"no_virtuals"`
+	Kernel              []string          `json:"kernel" yaml:"kernel"`
 
 	Cache       bool     `json:"-" yaml:"-" structs:"-" mapstructure:"-"`
 	ScriptPaths []string `json:"-" yaml:"-" structs:"-" mapstructure:"-"`


### PR DESCRIPTION
# Support kernel args in phenix image create

## Description
The vmdb2 tool used inside phenix image supports kernel parameters in the `grub` [plugin section](https://gitlab.com/glattercj/vmdb2/-/blob/main/vmdb/plugins/grub.mdwn?ref_type=heads#L37). This pull request adds the ability to specify the kernel parameters from the `phenix image create ...` command line argument which are then passed to vmdb2.

## Related Issue
n/a

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [X] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested my code.

## Additional Notes
This adds the `--kernel-args` or `-k` command line arg to the `phenix image create ...` command. The value eventually gets placed into the .vmdb template file and rendered for use by the `vmdb2` tool.
