### PR TITLE
bugfix: respect apps disabled=true setting from scenario config

### DIFF
--- a/src/go/api/experiment/experiment.go
+++ b/src/go/api/experiment/experiment.go
@@ -296,7 +296,7 @@ func Create(ctx context.Context, opts ...CreateOption) error {
 		"topology":       topo,
 	}
 
-	if o.disabledApps != nil {
+	if o.disabledApps != nil && len(o.disabledApps) > 0 {
 		plog.Info(plog.TypePhenixApp, fmt.Sprintf("Got disabled applications: %v", o.disabledApps))
 	}
 

--- a/src/go/types/scenario.go
+++ b/src/go/types/scenario.go
@@ -77,7 +77,10 @@ func MakeCustomScenarioFromConfig(c store.Config, disabledApps []string) (ifaces
 
 	//if app name in disabled app list, set to disabled
 	for _, app := range spec.Apps() {
-		app.SetDisabled(slices.Contains(disabledApps, app.Name()))
+
+		if slices.Contains(disabledApps, app.Name()) {
+			app.SetDisabled(true)
+		}
 	}
 
 	return spec, nil

--- a/src/go/types/version/v2/schema.go
+++ b/src/go/types/version/v2/schema.go
@@ -171,6 +171,11 @@ components:
                   setting0: true
                   setting1: 42
                   setting2: universe key
+              disabled:
+                type: boolean
+                default: false
+                example: false
+                nullable: true
               hosts:
                 type: array
                 items:


### PR DESCRIPTION
# bugfix: respect apps disabled=true setting from scenario config

## Description
Apps can already be disabled when running from the command line, but using `disabled: true` in the scenario file does not work. This fixes that logic so that the `disabled:true` setting in the scenario is respected. 

Disabled apps can still have their run stage triggered manually. The main use case I use this for is disabling the `soh` app on startup but triggering it manually later to do healthchecks once the experiment is running

related docs update https://github.com/sandialabs/sceptre-phenix-docs/pull/20 

## Related Issue
If applicable, please link to the issue here (e.g., #123).

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
