### PR TITLE
feat: add store components as initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ kind: Workflow
 metadata: {}
 spec:
   auto:
-    create: {{BRANCH_NAME}}-<string>
+    create: ${BRANCH_NAME}-<string>
     update: <bool>  # defaults to true
     restart: <bool> # defaults to true
-  topology: {{BRANCH_NAME}}-<string>
-  scenario: {{BRANCH_NAME}}-<string>
+  topology: ${BRANCH_NAME}-<string>
+  scenario: ${BRANCH_NAME}-<string>
   vlans:
     <alias>: <int>
   schedules:

--- a/src/go/api/config/config.go
+++ b/src/go/api/config/config.go
@@ -99,6 +99,10 @@ func Init() error {
 
 		var c store.Config
 
+		// Set BRANCH_NAME to parent directory name of config file being processed
+		// e.g. /phenix/configs/foo/topology.yaml -> BRANCH_NAME=foo
+		os.Setenv("BRANCH_NAME", filepath.Base(filepath.Dir(filepath.Clean(path))))
+
 		switch filepath.Ext(path) {
 		case ".yaml", ".yml":
 			body, err := os.ReadFile(path)
@@ -171,6 +175,11 @@ func Init() error {
 				return fmt.Errorf("updating config in store: %w", err)
 			}
 		}
+	}
+
+	// Mark configs as initialized in the store.
+	if err := store.InitializeComponent(store.COMPONENT_CONFIGS); err != nil {
+		return fmt.Errorf("marking configs as initialized: %w", err)
 	}
 
 	return nil

--- a/src/go/cmd/root.go
+++ b/src/go/cmd/root.go
@@ -109,15 +109,21 @@ var rootCmd = &cobra.Command{
 
 		common.StoreEndpoint = endpoint
 
-		if err := store.Init(store.Endpoint(endpoint)); err != nil {
-			return fmt.Errorf("initializing storage: %w", err)
+		// Initialize storage backend if not already done
+		if !store.IsInitialized(store.COMPONENT_STORE) {
+			if err := store.Init(store.Endpoint(endpoint)); err != nil {
+				return fmt.Errorf("initializing storage: %w", err)
+			}
 		}
 
-		if err := config.Init(); err != nil {
-			return fmt.Errorf("unable to initialize default configs: %w", err)
+		// Initialize default configs if not already done
+		if !store.IsInitialized(store.COMPONENT_CONFIGS) {
+			if err := config.Init(); err != nil {
+				return fmt.Errorf("unable to initialize default configs: %w", err)
+			}
 		}
 
-		//add log file handler after bbolt is live
+		// Add log file handler after bbolt is live
 		logFile := viper.GetString("log.file.path")
 		fileHandlerOpts := plog.GetDefaultFileHandlerOpts()
 		fileLogSettings, err := settings.GetLoggingSettings()

--- a/src/go/store/bolt.go
+++ b/src/go/store/bolt.go
@@ -35,6 +35,37 @@ func (this *BoltDB) Init(opts ...Option) error {
 
 	this.path = u.Host + u.Path
 
+	if err := this.InitializeComponent(COMPONENT_STORE); err != nil {
+		return fmt.Errorf("initializing component %s: %w", COMPONENT_STORE, err)
+	}
+
+	return nil
+}
+
+func (this *BoltDB) IsInitialized(component Component) bool {
+	if err := this.open(); err != nil {
+		return false
+	}
+	defer this.Close()
+
+	v, err := this.get("phenix", string(component))
+	if err != nil {
+		return false
+	}
+
+	return v[0] == 1
+}
+
+func (this *BoltDB) InitializeComponent(component Component) error {
+	if err := this.open(); err != nil {
+		return err
+	}
+	defer this.Close()
+
+	if err := this.put("phenix", string(component), []byte{1}); err != nil {
+		return fmt.Errorf("marking component %s as initialized: %w", component, err)
+	}
+
 	return nil
 }
 

--- a/src/go/store/etcd.go
+++ b/src/go/store/etcd.go
@@ -44,6 +44,28 @@ func (this *Etcd) Init(opts ...Option) error {
 		return fmt.Errorf("creating new Etcd client: %w", err)
 	}
 
+	if err := this.InitializeComponent(COMPONENT_STORE); err != nil {
+		return fmt.Errorf("initializing component %s: %w", COMPONENT_STORE, err)
+	}
+
+	return nil
+}
+func (this *Etcd) IsInitialized(component Component) bool {
+	key := fmt.Sprintf("%s/%s", "phenix", string(component))
+	resp, err := this.cli.Get(context.Background(), key)
+	if err != nil {
+		return false
+	}
+
+	return string(resp.Kvs[0].Value) == "true"
+}
+
+func (this *Etcd) InitializeComponent(component Component) error {
+	key := fmt.Sprintf("%s/%s", "phenix", string(component))
+	if _, err := this.cli.Put(context.Background(), key, "true"); err != nil {
+		return fmt.Errorf("marking component %s as initialized: %w", component, err)
+	}
+
 	return nil
 }
 

--- a/src/go/store/package.go
+++ b/src/go/store/package.go
@@ -54,3 +54,11 @@ func Patch(config *Config, data map[string]interface{}) error {
 func Delete(config *Config) error {
 	return DefaultStore.Delete(config)
 }
+
+func IsInitialized(component Component) bool {
+	return DefaultStore.IsInitialized(component)
+}
+
+func InitializeComponent(component Component) error {
+	return DefaultStore.InitializeComponent(component)
+}

--- a/src/go/store/store.go
+++ b/src/go/store/store.go
@@ -7,6 +7,15 @@ var (
 	ErrNotExist = fmt.Errorf("config does not exist")
 )
 
+type (
+	Component string
+)
+
+const (
+	COMPONENT_CONFIGS Component = "configs"
+	COMPONENT_STORE   Component = "store"
+)
+
 // Store is the interface that identifies all the required functionality for a
 // config store. Not all functions are required to be implemented. If not
 // implemented, they should return an error stating such.
@@ -36,4 +45,13 @@ type Store interface {
 
 	// Delete removes the given config from the config store.
 	Delete(*Config) error
+
+	// IsInitialized checks if the given phenix components have been
+	// initialized. This is used to avoid re-initializing the store or
+	// default configs.
+	IsInitialized(Component) bool
+
+	// InitializeComponent marks the given phenix component as initialized in
+	// the store.
+	InitializeComponent(Component) error
 }

--- a/src/go/web/workflow.go
+++ b/src/go/web/workflow.go
@@ -67,7 +67,6 @@ func ApplyWorkflow(w http.ResponseWriter, r *http.Request) error {
 			return err.SetStatus(http.StatusInternalServerError)
 		}
 
-		os.Setenv("BRANCH_NAME", scope)
 		cfg, err = store.NewConfigFromJSON(body)
 		if err != nil {
 			return weberror.NewWebError(err, "unable to parse phenix workflow config")


### PR DESCRIPTION
# Init store components

## Description
This PR adds a new 'bucket' to the phenix store called `phenix`. Inside the `phenix` bucket are (for now) two components: `store` and `configs`. The purpose is to indicate whether or not these components have been successfully initialized or not. This prevents them from having to be initialized on every call to the `phenix` CLI command (this is the current behavior).

Additionally, this fixes an issue where the `BRANCH_NAME` wasn't getting set before creating the configs from the default directory. `BRANCH_NAME` gets set to the name of the parent directory of the config.

> [!WARNING]
> It is expected that files put into the default configs directory are placed inside their own directory, e.g.:
> `/phenix/configs/foo/{topology|scenario}.yml`

## Related Issue
n/a

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- [X] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested my code.

## Additional Notes
n/a