### PR TITLE
feat: different Go/Python APPS_REPO/BRANCH in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,10 +72,14 @@ RUN make -C src/go phenix-tunneler
 
 # Allow installing from a fork of sceptre-phenix-apps that could
 # exist on GitHub or elsewhere.
+# We can specify one APPS_REPO and APPS_BRANCH for both Go and Python
 ARG APPS_REPO=github.com/sandialabs/sceptre-phenix-apps
 ARG APPS_BRANCH=main
+# Or the user can override Go and Python apps repos/branches separately
+ARG GO_APPS_REPO=${APPS_REPO}
+ARG GO_APPS_BRANCH=${APPS_BRANCH}
 
-RUN git clone --branch ${APPS_BRANCH} https://${APPS_REPO}.git /phenix-apps
+RUN git clone --branch ${GO_APPS_BRANCH} https://${GO_APPS_REPO}.git /phenix-apps
 
 WORKDIR /phenix-apps/src/go
 
@@ -152,12 +156,16 @@ RUN python3 -m pip install --break-system-packages --no-cache-dir /tmp/minimega
 
 # Allow installing from a fork of sceptre-phenix-apps that could
 # exist on GitHub or elsewhere.
+# We can specify one APPS_REPO and APPS_BRANCH for both Go and Python
 ARG APPS_REPO=github.com/sandialabs/sceptre-phenix-apps
 ARG APPS_BRANCH=main
+# Or the user can override Go and Python apps repos/branches separately
+ARG PY_APPS_REPO=${APPS_REPO}
+ARG PY_APPS_BRANCH=${APPS_BRANCH}
 
 # Install phenix user apps
 RUN python3 -m pip install --break-system-packages --ignore-installed --no-cache-dir \
-  "git+https://${APPS_REPO}.git@${APPS_BRANCH}#egg=phenix-apps&subdirectory=src/python"
+  "git+https://${PY_APPS_REPO}.git@${PY_APPS_BRANCH}#egg=phenix-apps&subdirectory=src/python"
 
 # Copy binaries from gobuilder stage
 COPY --from=gobuilder /phenix/bin/phenix   /usr/local/bin/phenix


### PR DESCRIPTION

# different Go/Python APPS_REPO/BRANCH in Dockerfile

## Description
This allows the traditional APPS_REPO / APPS_BRANCH arguments in docker build to use the same repo / branch for both go and python apps, but also allows the user to sepcify seperate repo / branch for each, since the installs are done differently. Now, docker build can accept `GO_APPS_REPO` `GO_APPS_BRANCH` and `PY_APPS_REPO` `PY_APPS_BRANCH`.

## Related Issue
#251 

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [X] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
N/A