### PR TITLE
feat: includeTopologies

### DIFF
--- a/src/go/types/interfaces/topology.go
+++ b/src/go/types/interfaces/topology.go
@@ -3,6 +3,7 @@ package ifaces
 import "time"
 
 type TopologySpec interface {
+	IncludedTopologies() []string
 	Nodes() []NodeSpec
 	BootableNodes() []NodeSpec
 	SchedulableNodes(string) []NodeSpec

--- a/src/go/types/version/v0/topology.go
+++ b/src/go/types/version/v0/topology.go
@@ -8,6 +8,10 @@ type TopologySpec struct {
 	NodesF []*Node `json:"nodes" yaml:"nodes" structs:"nodes" mapstructure:"nodes"`
 }
 
+func (this *TopologySpec) IncludedTopologies() []string {
+	return nil
+}
+
 func (this *TopologySpec) Nodes() []ifaces.NodeSpec {
 	if this == nil {
 		return nil

--- a/src/go/types/version/v1/schema.go
+++ b/src/go/types/version/v1/schema.go
@@ -133,9 +133,19 @@ components:
           example: johndoe@example.com
     Topology:
       type: object
-      required:
-      - nodes
+      anyOf:
+      - required:
+        - nodes
+      - required:
+        - includeTopologies
       properties:
+        includeTopologies:
+          type: array
+          items:
+            type: string
+          example:
+          - /phenix/topologies/enterprise/phenix-configs/topology.yml
+          - store-topo
         nodes:
           type: array
           items:

--- a/src/go/types/version/v1/topology.go
+++ b/src/go/types/version/v1/topology.go
@@ -8,7 +8,16 @@ import (
 )
 
 type TopologySpec struct {
-	NodesF []*Node `json:"nodes" yaml:"nodes" structs:"nodes" mapstructure:"nodes"`
+	IncludeTopologiesF []string `json:"includeTopologies" yaml:"includeTopologies" structs:"includeTopologies" mapstructure:"includeTopologies"`
+	NodesF             []*Node  `json:"nodes" yaml:"nodes" structs:"nodes" mapstructure:"nodes"`
+}
+
+func (this *TopologySpec) IncludedTopologies() []string {
+	if this == nil {
+		return nil
+	}
+
+	return this.IncludeTopologiesF
 }
 
 func (this *TopologySpec) Nodes() []ifaces.NodeSpec {


### PR DESCRIPTION
# feat: includeTopologies

## Description
This change introduces the ability to nest and compose topologies by leveraging existing stored topologies or defined in files on disk. This allows for modularity and reusability when defining complex topologies

Ex:
```yml
...
  includeTopooliges:
    - /phenix/topologies/enterprise/phenix-configs/topolgy.yml
    - /phenix/topolgies/ot/phenix-configs/topolgy.yml
    - store-topo
  nodes:
...
```


## Related Issue
Tangential to #247
Documentation https://github.com/sandialabs/sceptre-phenix-docs/pull/27

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [X] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.
