### PR TITLE
feat(vrouter): enable SNMP service for public community from private IPs

### DIFF
--- a/src/go/tmpl/templates/vyatta.tmpl
+++ b/src/go/tmpl/templates/vyatta.tmpl
@@ -221,6 +221,10 @@ set vpn ipsec site-to-site peer {{ $site.Peer }} tunnel {{ $idx }} remote prefix
         {{- end }}
     {{- end }}
 # -------------------------------- Services -------------------------------
+set service snmp community public authorization ro
+set service snmp community public network 10.0.0.0/8
+set service snmp community public network 172.16.0.0/20
+set service snmp community public network 192.168.0.0/24
     {{- if $ssh }}
 set service ssh listen-address {{ $ssh }}
     {{- end }}
@@ -552,13 +556,22 @@ vpn {
     {{- end }}
 }
 
-    {{- if $ssh }}
 service {
+    snmp {
+        community public {
+            authorization ro
+            network 10.0.0.0/8
+            network 172.16.0.0/20
+            network 192.168.0.0/24
+        }
+    }
+
+    {{- if $ssh }}
     ssh {
         listen-address {{ $ssh }}
     }
-}
     {{- end }}
+}
 
 system {
     host-name {{ $node.RouterName }}


### PR DESCRIPTION
# Enable SNMP Service for Routers

## Description

Updated `vrouter` template for Vyatta and Vyos to include a read-only public SNMP community that can be accessed by clients on private networks. 

## Related Issue

N/A

## Type of Change

Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes

@nblair2 per your interest in this feature, please test this if/when you can. Feel free to also update it if you need it to be more configurable.