### PR TITLE
feat(vrouter): SNMP configuration vyos/vyatta

### DIFF
--- a/src/go/tmpl/templates/vyatta.tmpl
+++ b/src/go/tmpl/templates/vyatta.tmpl
@@ -4,6 +4,7 @@
 {{- $vyos := index . "vyos" -}}
 {{- $passwd := index . "passwd" -}}
 {{- $ssh := index . "ssh" -}}
+{{- $snmp := index . "snmp" -}}
 {{- $emulators := index . "emulators" -}}
 {{- $snat := index . "snat" -}}
 {{- $dnat := index . "dnat" -}}
@@ -221,13 +222,46 @@ set vpn ipsec site-to-site peer {{ $site.Peer }} tunnel {{ $idx }} remote prefix
         {{- end }}
     {{- end }}
 # -------------------------------- Services -------------------------------
+# SSH
     {{- if $ssh }}
 set service ssh listen-address {{ $ssh }}
     {{- end }}
+# NTP
     {{- if $ntpAddr }}
 set service ntp server {{ $ntpAddr }} prefer
     {{- else }}
 delete service ntp
+    {{- end }}
+# SNMP
+    {{- if $snmp }}
+        {{- if $snmp.ListenAddr }}
+set service snmp listen-address {{ $snmp.ListenAddr }}
+        {{- end }}
+        {{- if $snmp.Contact }}
+set service snmp contact '{{ $snmp.Contact }}'
+        {{- end }}
+        {{- if $snmp.Location }}
+set service snmp location '{{ $snmp.Location }}'
+        {{- end }}
+        {{- if $snmp.SystemName }}
+set service snmp description '{{ $snmp.SystemName }}'
+        {{- end }}
+        {{- range $community := $snmp.Communities }}
+            {{- if $community.Name }}
+set service snmp community '{{ $community.Name }}'
+                {{- if $community.Authorization }}
+set service snmp community '{{ $community.Name }}' authorization {{ $community.Authorization }}
+                {{- else }}
+set service snmp community '{{ $community.Name }}' authorization ro
+                {{- end }}
+                {{- range $client := $community.Clients }}
+set service snmp community '{{ $community.Name }}' client {{ $client }}
+                {{- end }}
+                {{- range $target := $community.TrapTargets }}
+set service snmp trap-target {{ $target }} community '{{ $community.Name }}'
+                {{- end }}
+            {{- end }}
+        {{- end }}
     {{- end }}
 # --------------------------------- System --------------------------------
 set system host-name {{ $node.RouterName }}
@@ -552,11 +586,48 @@ vpn {
     {{- end }}
 }
 
-    {{- if $ssh }}
+    {{- if or $ssh $snmp }}
 service {
+        {{- if $ssh }}
     ssh {
         listen-address {{ $ssh }}
     }
+        {{- end}}
+        {{- if $snmp }}
+    snmp {
+            {{- if $snmp.ListenAddr }}
+        listen-address {{ $snmp.ListenAddr }}
+            {{- end }}
+            {{- if $snmp.Contact }}
+        contact "{{ $snmp.Contact }}"
+            {{- end }}
+            {{- if $snmp.Location }}
+        location "{{ $snmp.Location }}"
+            {{- end }}
+            {{- if $snmp.SystemName }}
+        description "{{ $snmp.SystemName }}"
+            {{- end }}
+            {{- range $community := $snmp.Communities }}
+                {{- if $community.Name }}
+        community {{ $community.Name }} {
+                    {{- if $community.Authorization }}
+            authorization {{ $community.Authorization }}
+                    {{- else }}
+            authorization ro
+                    {{- end }}
+                    {{- range $client := $community.Clients }}
+            client {{ $client }}
+                    {{- end }}
+        }
+                    {{- range $target := $community.TrapTargets }}
+        trap-target {{ $target }} {
+            community "{{ $community.Name }}"
+        }
+                    {{- end }}
+                {{- end }}
+            {{- end }}
+    }
+        {{- end}}
 }
     {{- end }}
 


### PR DESCRIPTION
# feat(vrouter): SNMP configuration vyos/vyatta

## Description
Adds ability to turn on and configure snmp via the vrouter app for vyos or vyatta hosts.

```yaml
spec:
  apps:
    - name: vrouter
      hosts:
        - hostname: rtr
          metadata:
            snmp:
              listenAddress: 10.0.0.254
              systemName: edge-router-01
              location: "Lab A, Rack 2, U 24"
              contact: "network-admins@example.com"
              communities:
                - name: readonly-community
                  authorization: ro
                  trapTargets:
                    - 10.0.50.5
                - name: readwrite-community
                  authorization: rw
                  clients:
                    - 10.0.1.11
                  trapTargets:
                    - 10.0.50.5
```

## Related Issue
Superset of #255 
[sceptre-phenix-docs#21](https://github.com/sandialabs/sceptre-phenix-docs/pull/21)

## Type of Change
Please select the type of change your pull request introduces:
- [~] Bugfix
- [x] New feature
- [~] Documentation update
- [~] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.
