### PR TITLE
fix(vrouter): ACL rules enforced on VyOS

### DIFF
--- a/src/go/tmpl/templates/vyatta.tmpl
+++ b/src/go/tmpl/templates/vyatta.tmpl
@@ -34,22 +34,14 @@ set protocols ospf interface eth{{ $idx }} retransmit-interval {{ $node.Network.
             {{- end }}
         {{- end }}
         {{- if $iface.RulesetIn }}
-            {{- range $ruleset := $node.Network.Rulesets }}
-                {{- if eq $iface.RulesetIn $ruleset.Name }}
-                    {{- range $rule := $ruleset.Rules }}
-set firewall ipv4 name {{ $iface.RulesetIn }} rule {{ $rule.ID }} inbound-interface name eth{{ $idx }}
-                    {{- end }}
-                {{- end }}
-            {{- end }}
+set firewall ipv4 forward filter rule {{ addInt $idx 1000 }} inbound-interface name eth{{ $idx }}
+set firewall ipv4 forward filter rule {{ addInt $idx 1000 }} action jump
+set firewall ipv4 forward filter rule {{ addInt $idx 1000 }} jump-target {{ $iface.RulesetIn }}
         {{- end }}
         {{- if $iface.RulesetOut }}
-            {{- range $ruleset := $node.Network.Rulesets }}
-                {{- if eq $iface.RulesetOut $ruleset.Name }}
-                    {{- range $rule := $ruleset.Rules }}
-set firewall ipv4 name {{ $iface.RulesetOut }} rule {{ $rule.ID }} outbound-interface name eth{{ $idx }}
-                    {{- end }}
-                {{- end }}
-            {{- end }}
+set firewall ipv4 forward filter rule {{ addInt $idx 2000 }} outbound-interface name eth{{ $idx }}
+set firewall ipv4 forward filter rule {{ addInt $idx 2000 }} action jump
+set firewall ipv4 forward filter rule {{ addInt $idx 2000 }} jump-target {{ $iface.RulesetOut }}
         {{- end }}
     {{- end }}
 # ---------------------------------- SNAT ---------------------------------


### PR DESCRIPTION
# fix(vrouter): ACL rules are now enforced on VyOS

## Description
We add a jump rule for each ingress/egress ruleset in the vrouter VyOS template so that the forward chain jumps traffic to the appropriate name chains that are already created. Note: using the forward chain is a limitation (does not protect the firewall, requires forwarding traffic across interfaces).

Before this fix, firewall (ACL) rules in vrouter vyos template were created, but added to a custom 'name' chain. Custom name chains are not used by default. "Custom firewall chains can be created, with commands set firewall ipv4 name <name> .... In order to use such custom chain, a rule with action jump, and the appropriate target should be defined in a base chain."
https://docs.vyos.io/en/latest/configuration/firewall/ipv4.html

~~I think a re-write of the VyOS template that takes advantage of VyOS zone-based routing would be more efficient and intuitive to users, but would require modification of the vrouter app spec.~~ This does not work (tried in https://github.com/nblair2/sceptre-phenix/tree/fix/vrouter-acl2). Zone-based rules are deny by default, so creating zones is all-or-nothing. User would have to explicitly add an allow established/related to all zones.

## Related Issue
resolves #257 

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~I have commented my code, particularly in hard-to-understand areas.~
- ~I have made corresponding changes to the documentation.~
- ~My changes generate no new warnings.~
- [X] I have tested my code.

## Additional Notes
N/A