### PR TITLE
fix(api): register handler for GET scorch terminals

### DIFF
--- a/src/go/web/server.go
+++ b/src/go/web/server.go
@@ -189,6 +189,7 @@ func Start(opts ...ServerOption) error {
 	api.HandleFunc("/experiments/{name}/scorch/terminals/{pid}", scorch.ConnectTerminal).Methods("GET", "OPTIONS")
 	api.HandleFunc("/experiments/{name}/scorch/terminals/{pid}/exit/{id}", scorch.ExitTerminal).Methods("POST", "OPTIONS")
 	api.HandleFunc("/experiments/{name}/scorch/terminals/{pid}/ws/{id}", scorch.StreamTerminal).Methods("GET", "OPTIONS")
+	api.HandleFunc("/experiments/{name}/scorch/terminals/{run}/{loop}/{stage}/{cmp}", scorch.ConnectTerminal).Methods("GET", "OPTIONS")
 	api.HandleFunc("/experiments/{name}/soh", GetExperimentSoH).Methods("GET", "OPTIONS")
 	api.HandleFunc("/experiments/{exp}/vms", GetVMs).Methods("GET", "OPTIONS")
 	api.HandleFunc("/experiments/{exp}/vms", UpdateVMs).Methods("PATCH", "OPTIONS")
@@ -268,7 +269,6 @@ func Start(opts ...ServerOption) error {
 		{"/workflow/apply/{branch}", weberror.ErrorHandler(ApplyWorkflow), []string{"POST"}},
 		{"/workflow/configs/{branch}", weberror.ErrorHandler(WorkflowUpsertConfig), []string{"POST"}},
 	}
-
 
 	optionRoutes := []route{
 		{"/options", weberror.ErrorHandler(GetOptions), []string{"GET"}},


### PR DESCRIPTION
# Pull Request Title

## Description
Registers a handler for API call that was created and 'documented' but not registered in the webserver.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- ~[ ] New feature~
- ~[ ] Documentation update~
- ~[ ] Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~[ ] I have commented my code, particularly in hard-to-understand areas.~
- ~[ ] I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [X] I have tested my code.

## Additional Notes
I encountered this issue on a quest to 'drive' scorch programmatically through the API. Kicking off a pipeline is already provided before, but I wanted the ability to wait on an external condition to be true before advancing through a break component (terminal). With this fix, I can do it, but the solution feels a little hacky.

#### Current process
* [`curl -x GET /experiments/$EXP/scorch/terminals/$RUN/$LOOP/$STAGE/$COMPONENT`](https://github.com/nblair2/sceptre-phenix/blob/main/src/go/web/scorch/handlers.go#L77) to get info about named component including the WSS location and exit URL.
* [`websocat $LOCATION &`](https://github.com/nblair2/sceptre-phenix/blob/main/src/go/web/scorch/handlers.go#L110)
* [`curl -X PUT $EXIT`](https://github.com/nblair2/sceptre-phenix/blob/main/src/go/web/scorch/handlers.go#L148) to close the terminal (break) and continue the pipeline

the `websocat` connection is a hack. Without the websocket handshake, the terminal can't be closed in step 3. I am looking for suggestions from someone more experienced with the terminal/websocket on what the best path forward would be:
* make a separate component and don't try to use a terminal as a simple break
* add a new API endpoint?
* change the logic so that terminals can be closed before a websocket connection is made.  

