### PR TITLE
fix: minimega_node hostname validation

### DIFF
--- a/src/go/types/version/v1/schema.go
+++ b/src/go/types/version/v1/schema.go
@@ -224,6 +224,8 @@ components:
             hostname:
               type: string
               minLength: 1
+              maxLength: 63
+              pattern: '^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'
               example: ADServer
             description:
               type: string

--- a/src/go/types/version/v2/schema.go
+++ b/src/go/types/version/v2/schema.go
@@ -250,6 +250,9 @@ components:
           properties:
             hostname:
               type: string
+              minLength: 1
+              maxLength: 63
+              pattern: '^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'
               example: ADServer
             description:
               type: string


### PR DESCRIPTION
# fix: minimega_node hostname validation

## Description

Update the node spec for hostnames to disallow special characters in hostnames. Previously we allowed any hostname, which caused problems when implemented in VMs. For example, setting `hostname: my_host` in a phenix topology would work. However, when the `hostname.sh` startup script runs, it calls `hostnamectl`, which will set the pretty name to `my_host`, but the static name would be sanitized to `myhost`. Then, when this VM checks in with minimega, it would use the static name of `myhost`. When phenix tries to execute miniccc commands against a host by looking for `my_host`, it fail because minimega does not have such a host.

There are various sources of documentation on linux and [windows](https://learn.microsoft.com/en-us/troubleshoot/windows-server/active-directory/naming-conventions-for-computer-domain-site-ou#computer-names) hostnames, most of which also reference the DNS RFC. But since we are directly dependant on `hostnamectl`, the [man page](https://man7.org/linux/man-pages/man1/hostnamectl.1.html) provides clear direction on allowed characters:
>         The static and transient hostnames must each be either a
>         single DNS label (a string composed of 7-bit ASCII lower-case
>         characters and no spaces or dots, limited to the format
>         allowed for DNS domain name labels), or a sequence of such
>         labels separated by single dots that forms a valid DNS FQDN.
>         The hostname must be at most 64 characters, which is a Linux
>         limitation (DNS allows longer names).

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- ~New feature~
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~I have commented my code, particularly in hard-to-understand areas.~
- [x] I have made corresponding changes to the documentation. https://github.com/sandialabs/sceptre-phenix-docs/pull/28/files
- ~My changes generate no new warnings.~
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
