### PR TITLE
feat(scorch): replace block per-run

### DIFF
--- a/src/go/api/scorch/app_test.go
+++ b/src/go/api/scorch/app_test.go
@@ -56,7 +56,7 @@ func ExampleExecuteLoop() {
 		components[c.Name] = c
 	}
 
-	if err := executor(context.Background(), components, md.Execute); err != nil {
+	if err := executor(context.Background(), components, md.Runs[0]); err != nil {
 		fmt.Println(err)
 		return
 	}

--- a/src/go/api/scorch/option.go
+++ b/src/go/api/scorch/option.go
@@ -11,16 +11,17 @@ type Option func(*Options)
 
 // Options represents a set of options generic to all components.
 type Options struct {
-	Stage      Action
-	Type       string // used to set the component type
-	Name       string
-	Exp        types.Experiment
-	Meta       scorchmd.ComponentMetadata
-	StartTime  string
-	Run        int
-	Loop       int
-	Count      int
-	Background bool
+	Stage        Action
+	Type         string // used to set the component type
+	Name         string
+	Exp          types.Experiment
+	Meta         scorchmd.ComponentMetadata
+	StartTime    string
+	Run          int
+	Loop         int
+	Count        int
+	Background   bool
+	Replacements scorchmd.ResolvedReplacements
 }
 
 // NewOptions returns an Options struct initialized with the given option list.
@@ -101,5 +102,12 @@ func LoopCount(c int) Option {
 func Background() Option {
 	return func(o *Options) {
 		o.Background = true
+	}
+}
+
+// Replacements sets the resolved replacements for the component.
+func Replacements(r scorchmd.ResolvedReplacements) Option {
+	return func(o *Options) {
+		o.Replacements = r
 	}
 }

--- a/src/go/api/scorch/scorchmd/replace.go
+++ b/src/go/api/scorch/scorchmd/replace.go
@@ -1,0 +1,193 @@
+package scorchmd
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"strings"
+
+	"phenix/util"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// ResolvedReplacements holds the randomly selected value for each replacement key.
+type ResolvedReplacements map[string]any
+
+type UniformDistribution struct {
+	Minimum float64 `mapstructure:"minimum"`
+	Maximum float64 `mapstructure:"maximum"`
+}
+
+type GaussianDistribution struct {
+	Mean   float64 `mapstructure:"mean"`
+	StdDev float64 `mapstructure:"stddev"`
+}
+
+type ExponentialDistribution struct {
+	Mean float64 `mapstructure:"mean"`
+}
+
+type DistributionSpec struct {
+	Type        string                   `mapstructure:"type"`
+	Uniform     *UniformDistribution     `mapstructure:"uniform"`
+	Gaussian    *GaussianDistribution    `mapstructure:"gaussian"`
+	Exponential *ExponentialDistribution `mapstructure:"exponential"`
+}
+
+func (d *DistributionSpec) Generate() (any, error) {
+	count := 0
+	if d.Uniform != nil {
+		count++
+	}
+	if d.Gaussian != nil {
+		count++
+	}
+	if d.Exponential != nil {
+		count++
+	}
+	if count == 0 {
+		return nil, fmt.Errorf("no distribution specified (uniform, gaussian, or exponential)")
+	}
+	if count > 1 {
+		return nil, fmt.Errorf("cannot specify multiple distributions")
+	}
+
+	var val float64
+
+	if d.Gaussian != nil {
+		mean := 10.0
+		stddev := 2.0
+		if d.Gaussian.Mean != 0 {
+			mean = d.Gaussian.Mean
+		}
+		if d.Gaussian.StdDev != 0 {
+			stddev = d.Gaussian.StdDev
+		}
+		val = rand.NormFloat64()*stddev + mean
+	} else if d.Exponential != nil {
+		mean := 10.0
+		if d.Exponential.Mean != 0 {
+			mean = d.Exponential.Mean
+		}
+		val = rand.ExpFloat64() * mean
+	} else {
+		min := d.Uniform.Minimum
+		max := d.Uniform.Maximum
+		if min == 0 && max == 0 {
+			min = 0.0
+			max = 10.0
+		}
+		if max <= min {
+			return nil, fmt.Errorf("uniform maximum (%v) must be greater than minimum (%v)", max, min)
+		}
+		val = min + rand.Float64()*(max-min)
+	}
+
+	if d.Type == "int" {
+		return int64(math.Round(val)), nil
+	}
+	return val, nil
+}
+
+// ResolveReplacements selects a random value for each key in the replace map.
+func ResolveReplacements(replace map[string]any) (ResolvedReplacements, error) {
+	resolved := make(ResolvedReplacements)
+
+	for key, spec := range replace {
+		switch v := spec.(type) {
+
+		// Simple list of values to choose from
+		case []any:
+			if len(v) == 0 {
+				return nil, fmt.Errorf("replacement key %q has empty list", key)
+			}
+			resolved[key] = v[rand.IntN(len(v))]
+
+		// Random distribution
+		case map[string]any:
+			var dist DistributionSpec
+			if err := mapstructure.Decode(v, &dist); err != nil {
+				return nil, fmt.Errorf("decoding distribution spec for key %q: %w", key, err)
+			}
+			val, err := dist.Generate()
+			if err != nil {
+				return nil, fmt.Errorf("generating value for key %q: %w", key, err)
+			}
+			resolved[key] = val
+
+		// Error
+		default:
+			return nil, fmt.Errorf("replacement key %q has unsupported type %T", key, spec)
+		}
+	}
+
+	return resolved, nil
+}
+
+// ApplyReplacements applies the resolved replacements to the given metadata recursively.
+func ApplyReplacements(meta ComponentMetadata, resolved ResolvedReplacements) ComponentMetadata {
+	if len(resolved) == 0 {
+		return meta
+	}
+
+	copied := util.CopyableMap(meta).DeepCopy()
+	return applyToMap(copied, resolved)
+}
+
+func applyToMap(m map[string]any, resolved ResolvedReplacements) map[string]any {
+	for k, v := range m {
+		m[k] = applyToValue(v, resolved)
+	}
+	return m
+}
+
+func applyToSlice(s []any, resolved ResolvedReplacements) []any {
+	for i, v := range s {
+		s[i] = applyToValue(v, resolved)
+	}
+	return s
+}
+
+func applyToValue(v any, resolved ResolvedReplacements) any {
+	switch val := v.(type) {
+	case string:
+		return applyToString(val, resolved)
+	case map[string]any:
+		return applyToMap(val, resolved)
+	case []any:
+		return applyToSlice(val, resolved)
+	default:
+		return v
+	}
+}
+
+func applyToString(s string, resolved ResolvedReplacements) any {
+	// Check if entire string is a replacement key - return typed value
+	if val, ok := resolved[s]; ok {
+		return val
+	}
+
+	// Otherwise do string substitution
+	result := s
+	for key, value := range resolved {
+		result = strings.ReplaceAll(result, key, fmt.Sprintf("%v", value))
+	}
+	return result
+}
+
+// MergeReplacements combines two sets of replacements.
+// Values in 'override' take precedence over values in 'base'.
+func MergeReplacements(base, override ResolvedReplacements) ResolvedReplacements {
+	merged := make(ResolvedReplacements)
+
+	for k, v := range base {
+		merged[k] = v
+	}
+
+	for k, v := range override {
+		merged[k] = v
+	}
+
+	return merged
+}

--- a/src/go/api/scorch/scorchmd/types.go
+++ b/src/go/api/scorch/scorchmd/types.go
@@ -126,14 +126,15 @@ func (this ScorchMetadata) UseExpNameAsIndexName(id int) bool {
 }
 
 type Loop struct {
-	Filebeat  *FilebeatSpec `mapstructure:"filebeat"`
-	Count     int           `mapstructure:"count"`
-	Name      string        `mapstructure:"name"`
-	Configure []string      `mapstructure:"configure"`
-	Start     []string      `mapstructure:"start"`
-	Stop      []string      `mapstructure:"stop"`
-	Cleanup   []string      `mapstructure:"cleanup"`
-	Loop      *Loop         `mapstructure:"loop"` // using a pointer here to avoid cyclical references
+	Filebeat  *FilebeatSpec  `mapstructure:"filebeat"`
+	Count     int            `mapstructure:"count"`
+	Name      string         `mapstructure:"name"`
+	Replace   map[string]any `mapstructure:"replace"`
+	Configure []string       `mapstructure:"configure"`
+	Start     []string       `mapstructure:"start"`
+	Stop      []string       `mapstructure:"stop"`
+	Cleanup   []string       `mapstructure:"cleanup"`
+	Loop      *Loop          `mapstructure:"loop"` // using a pointer here to avoid cyclical references
 }
 
 func (this Loop) ContainsComponent(name string) bool {


### PR DESCRIPTION
#  feat(scorch): replace values for scorch runs/loops

## Description
Scorch runs/loops dynamically replace arbitrary values on the fly. Replacements are calculated at the beggining of each loop and can be selected from a list or a random distribution.

### Example

Scorch config:
```yml
- name: scorch
  metadata:
    components:
      - name: cc
        type: cc
        metadata:
          vms:
            - hostname: testy
              start:
                - type: exec
                  args: 'echo "We have picked RAND1: {{RAND1}}, RAND2: {{RAND2}}, RAND3: {{RAND3}}, override: {{OVERRIDE}}'
    runs:
      - name: replacey
        replace:
          '{{RAND1}}': ['foo', 'bar', 'baz']
          '{{OVERRIDE}}': ['run']
        start: [ cc ]
        loop:
          count: 2
          replace:
            '{{RAND2}}':
                type: int
                uniform:
                  minimum: 10
                  maximum: 100
            '{{OVERRIDE}}': ['loop 1']
          start: [cc]
          loop:
            count: 3
            replace:
              '{{RAND3}}':
                  type: float
                  gaussian:
                    mean: 100.123
                    stddev: 10.456
              '{{OVERRIDE}}': ['loop 2']
            start: [cc]
```

Pertinent log results:
```bash
Feb  3 18:36:14.562 INF Resolved replacements for Scorch loop type=PHENIX-APP run_id=0 loop_idx=0 replacements="map[{{OVERRIDE}}:run {{RAND1}}:bar]" app=scorch
Feb  3 18:36:16.827 INF [2026-02-03T18:36:14] executing command 'echo "We have picked RAND1: bar, RAND2: {{RAND2}}, RAND3: {{RAND3}}, override: run' in VM testy[2026-02-03T18:36:16] command 'echo "We have picked RAND1: bar, RAND2: {{RAND2}}, RAND3: {{RAND3}}, override: run' executed in VM testy using cc type=PHENIX-APP experiment=testy app=scorch component=cc stage=start run=0 loop=0 count=0
Feb  3 18:36:16.827 INF Resolved replacements for Scorch loop type=PHENIX-APP run_id=0 loop_idx=1 replacements="map[{{OVERRIDE}}:loop 1 {{RAND1}}:bar {{RAND2}}:19]" app=scorch
Feb  3 18:36:16.827 INF starting scorch type=SCORCH run="[RUN: 0 - LOOP: 1 - COUNT: 0]"
Feb  3 18:36:22.109 INF [2026-02-03T18:36:17] executing command 'echo "We have picked RAND1: bar, RAND2: 19, RAND3: {{RAND3}}, override: loop 1' in VM testy[2026-02-03T18:36:22] command 'echo "We have picked RAND1: bar, RAND2: 19, RAND3: {{RAND3}}, override: loop 1' executed in VM testy using cc type=PHENIX-APP experiment=testy app=scorch component=cc stage=start run=0 loop=1 count=0
Feb  3 18:36:22.110 INF Resolved replacements for Scorch loop type=PHENIX-APP run_id=0 loop_idx=2 replacements="map[{{OVERRIDE}}:loop 2 {{RAND1}}:bar {{RAND2}}:19 {{RAND3}}:86.97164992182161]" app=scorch
Feb  3 18:36:22.111 INF starting scorch type=SCORCH run="[RUN: 0 - LOOP: 2 - COUNT: 0]"
Feb  3 18:36:27.421 INF [2026-02-03T18:36:22] executing command 'echo "We have picked RAND1: bar, RAND2: 19, RAND3: 86.97164992182161, override: loop 2' in VM testy[2026-02-03T18:36:27] command 'echo "We have picked RAND1: bar, RAND2: 19, RAND3: 86.97164992182161, override: loop 2' executed in VM testy using cc type=PHENIX-APP experiment=testy app=scorch component=cc stage=start run=0 loop=2 count=0
Feb  3 18:36:27.421 INF Resolved replacements for Scorch loop type=PHENIX-APP run_id=0 loop_idx=2 replacements="map[{{OVERRIDE}}:loop 2 {{RAND1}}:bar {{RAND2}}:19 {{RAND3}}:114.48324331867562]" app=scorch
Feb  3 18:36:27.421 INF starting scorch type=SCORCH run="[RUN: 0 - LOOP: 2 - COUNT: 1]"
Feb  3 18:36:31.721 INF [2026-02-03T18:36:27] executing command 'echo "We have picked RAND1: bar, RAND2: 19, RAND3: 114.48324331867562, override: loop 2' in VM testy[2026-02-03T18:36:31] command 'echo "We have picked RAND1: bar, RAND2: 19, RAND3: 114.48324331867562, override: loop 2' executed in VM testy using cc type=PHENIX-APP experiment=testy app=scorch component=cc stage=start run=0 loop=2 count=1
Feb  3 18:36:31.721 INF Resolved replacements for Scorch loop type=PHENIX-APP run_id=0 loop_idx=2 replacements="map[{{OVERRIDE}}:loop 2 {{RAND1}}:bar {{RAND2}}:19 {{RAND3}}:95.97843337384487]" app=scorch
Feb  3 18:36:31.721 INF starting scorch type=SCORCH run="[RUN: 0 - LOOP: 2 - COUNT: 2]"
Feb  3 18:36:37.020 INF [2026-02-03T18:36:31] executing command 'echo "We have picked RAND1: bar, RAND2: 19, RAND3: 95.97843337384487, override: loop 2' in VM testy[2026-02-03T18:36:36] command 'echo "We have picked RAND1: bar, RAND2: 19, RAND3: 95.97843337384487, override: loop 2' executed in VM testy using cc type=PHENIX-APP experiment=testy app=scorch component=cc stage=start run=0 loop=2 count=2
Feb  3 18:36:37.020 INF Resolved replacements for Scorch loop type=PHENIX-APP run_id=0 loop_idx=1 replacements="map[{{OVERRIDE}}:loop 1 {{RAND1}}:bar {{RAND2}}:82]" app=scorch
Feb  3 18:36:37.020 INF starting scorch type=SCORCH run="[RUN: 0 - LOOP: 1 - COUNT: 1]"
Feb  3 18:36:42.327 INF [2026-02-03T18:36:37] executing command 'echo "We have picked RAND1: bar, RAND2: 82, RAND3: {{RAND3}}, override: loop 1' in VM testy[2026-02-03T18:36:42] command 'echo "We have picked RAND1: bar, RAND2: 82, RAND3: {{RAND3}}, override: loop 1' executed in VM testy using cc type=PHENIX-APP experiment=testy app=scorch component=cc stage=start run=0 loop=1 count=1
Feb  3 18:36:42.327 INF Resolved replacements for Scorch loop type=PHENIX-APP run_id=0 loop_idx=2 replacements="map[{{OVERRIDE}}:loop 2 {{RAND1}}:bar {{RAND2}}:82 {{RAND3}}:91.0323724023587]" app=scorch
Feb  3 18:36:42.327 INF starting scorch type=SCORCH run="[RUN: 0 - LOOP: 2 - COUNT: 0]"
Feb  3 18:36:47.613 INF [2026-02-03T18:36:42] executing command 'echo "We have picked RAND1: bar, RAND2: 82, RAND3: 91.0323724023587, override: loop 2' in VM testy[2026-02-03T18:36:47] command 'echo "We have picked RAND1: bar, RAND2: 82, RAND3: 91.0323724023587, override: loop 2' executed in VM testy using cc type=PHENIX-APP experiment=testy app=scorch component=cc stage=start run=0 loop=2 count=0
Feb  3 18:36:47.613 INF Resolved replacements for Scorch loop type=PHENIX-APP run_id=0 loop_idx=2 replacements="map[{{OVERRIDE}}:loop 2 {{RAND1}}:bar {{RAND2}}:82 {{RAND3}}:96.65899272237336]" app=scorch
Feb  3 18:36:47.613 INF starting scorch type=SCORCH run="[RUN: 0 - LOOP: 2 - COUNT: 1]"
Feb  3 18:36:51.922 INF [2026-02-03T18:36:47] executing command 'echo "We have picked RAND1: bar, RAND2: 82, RAND3: 96.65899272237336, override: loop 2' in VM testy[2026-02-03T18:36:51] command 'echo "We have picked RAND1: bar, RAND2: 82, RAND3: 96.65899272237336, override: loop 2' executed in VM testy using cc type=PHENIX-APP experiment=testy app=scorch component=cc stage=start run=0 loop=2 count=1
Feb  3 18:36:51.922 INF Resolved replacements for Scorch loop type=PHENIX-APP run_id=0 loop_idx=2 replacements="map[{{OVERRIDE}}:loop 2 {{RAND1}}:bar {{RAND2}}:82 {{RAND3}}:94.85640056376343]" app=scorch
Feb  3 18:36:51.922 INF starting scorch type=SCORCH run="[RUN: 0 - LOOP: 2 - COUNT: 2]"
Feb  3 18:36:57.221 INF [2026-02-03T18:36:52] executing command 'echo "We have picked RAND1: bar, RAND2: 82, RAND3: 94.85640056376343, override: loop 2' in VM testy[2026-02-03T18:36:57] command 'echo "We have picked RAND1: bar, RAND2: 82, RAND3: 94.85640056376343, override: loop 2' executed in VM testy using cc type=PHENIX-APP experiment=testy app=scorch component=cc stage=start run=0 loop=2 count=2

```

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- ~Bugfix~
- [X] New feature
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation. https://github.com/sandialabs/sceptre-phenix-docs/pull/31
- [X] My changes generate no new warnings.
- [X] I have tested my code.

## Additional Notes
Also refactored redundant configure/start/stop/cleanup functions in scorch execute into a single func