### PR TITLE
fix: mm.GetVMInfo allow empty disks

### DIFF
--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -200,8 +200,17 @@ func (this Minimega) GetVMInfo(opts ...Option) VMs {
 		vm.RAM, _ = strconv.Atoi(row["memory"])
 		vm.CPUs, _ = strconv.Atoi(row["vcpus"])
 
+		fields := strings.Fields(row["disks"])
+		if len(fields) == 0 {
+			// VM has no disk configured e.g., still BUILDING
+			// Still append the VM with what we have — callers handle empty Disk
+			plog.Debug(plog.TypeSystem, "VM has no disk configured", "namespace", o.ns, "vm", vm.Name)
+			vms = append(vms, vm)
+			continue
+		}
+
 		// TODO: confirm multiple disks are separated by whitespace.
-		disk := strings.Fields(row["disks"])[0]
+		disk := fields[0]
 		// diskspec can include multiple settings separated by comma. Path to disk
 		// will always be first setting.
 		disk = strings.Split(disk, ",")[0]


### PR DESCRIPTION
# Pull Request Title

## Description
When running `mmcli.GetVMInfo()` during periods of heavy use (starting multiple experiments at the same time), occasionally phenix would panic when trying to read the disk from a tabular mm response. We now continue gracefully even if no disk exists.

## Related Issue
Fixes #274

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- ~New feature~
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A