### PR TITLE
fix(soh): improve powershell checks for hostListeners

### DIFF
--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -1351,15 +1351,35 @@ func (s SOH) portTest(
 	)
 
 	exec := "ss -lntu state all"
+	target := strings.Split(port, ":")
 
 	if strings.EqualFold(node.Hardware().OSType(), "windows") {
+		var filter string
+
+		switch len(target) {
+		case 1:
+			filter = fmt.Sprintf("$_.LocalPort -eq %s", target[0])
+		case portParts:
+			switch {
+			case target[0] == "": // :<port>
+				filter = fmt.Sprintf("$_.LocalPort -eq %s", target[1])
+			case target[1] == "": // <ip>: (why?!)
+				filter = fmt.Sprintf("$_.LocalAddress -eq '%s'", target[0])
+			default: // <ip>:<port>
+				filter = fmt.Sprintf("$_.LocalAddress -eq '%s' -and $_.LocalPort -eq %s", target[0], target[1])
+			}
+		default:
+			wg.AddError(fmt.Errorf("invalid port %s provided", port), meta)
+
+			return
+		}
+
 		exec = fmt.Sprintf(
-			`powershell -command "netstat -an | select-string -pattern 'listening' | select-string -pattern '%s'"`,
-			port,
+			`powershell -command "$tcp=Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue | Where-Object { %s }; $udp=Get-NetUDPEndpoint -ErrorAction SilentlyContinue | Where-Object { %s }; @($tcp+$udp) | Select-Object -First 1"`,
+			filter,
+			filter,
 		)
 	} else {
-		target := strings.Split(port, ":")
-
 		switch len(target) {
 		case 1:
 			exec = fmt.Sprintf("%s 'sport = %s'", exec, target[0])


### PR DESCRIPTION
# fix(soh): improve powershell checks for hostListeners

## Description
Update powershell commands to check for `hostListeners`  in order to accommodate UDP ports and other scenarios. Previously the `netstat -an | Select-String -Pattern LISTENING` would filter out all UDP ports.

<img width="463" height="118" alt="image" src="https://github.com/user-attachments/assets/c6be820f-18d5-4f08-a731-600159d54f37" />


## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- ~New feature~
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~I have commented my code, particularly in hard-to-understand areas.~
- ~I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
I had no idea what `case portParts` was. I don't like the linter config, I do not like it sam-i-am.