### PR TITLE
feat(ntp): add chrony support, set MaxPollInterval to 64s

### DIFF
--- a/src/go/.golangci.yml
+++ b/src/go/.golangci.yml
@@ -407,18 +407,10 @@ linters:
       - common-false-positives
     # Excluding configuration per-path, per-linter, per-text and per-source.
     rules:
-      - source: 'TODO'
-        linters: [ godot ]
-      - text: 'should have a package comment'
-        linters: [ revive ]
-      - text: 'exported \S+ \S+ should have comment( \(or a comment on this block\))? or be unexported'
-        linters: [ revive ]
-      - text: 'package comment should be of the form ".+"'
-        source: '// ?(nolint|TODO)'
-        linters: [ revive ]
-      - text: 'comment on exported \S+ \S+ should be of the form ".+"'
-        source: '// ?(nolint|TODO)'
-        linters: [ revive, staticcheck ]
+      - source: 'TODO|FIXME|BUG|HACK|NOTE|OPTIMIZE'
+        linters:
+          - godot
+          - godox
       - path: '_test\.go'
         linters:
           - bodyclose
@@ -429,11 +421,3 @@ linters:
           - gosec
           - noctx
           - wrapcheck
-      - path: "go.mod"
-        text: "local replacement are not allowed"
-        linters: [ gomoddirectives ]
-    paths:
-      # Excluding because of godoclint "package has more than one godoc"
-      - api/config/doc.go
-      - app/doc.go
-      - util/mm/doc.go

--- a/src/go/api/scorch/app.go
+++ b/src/go/api/scorch/app.go
@@ -219,7 +219,6 @@ func (s Scorch) startFilebeat(
 		stdErr bytes.Buffer
 	)
 
-	//nolint:godox // TODO
 	// TODO: don't rely on `shell.ProcessExists` since it's not working correctly
 	// for detecting zombie (defunct) processes. For example, when filebeat fails
 	// to start because of an issue w/ the config the current code still thinks

--- a/src/go/api/scorch/terminal.go
+++ b/src/go/api/scorch/terminal.go
@@ -37,7 +37,6 @@ func terminal(ctx context.Context, dir, cmd string, args []string, envs ...strin
 		for range ch {
 			err = pty.InheritSize(os.Stdin, tty)
 			if err != nil {
-				//nolint:godox // TODO
 				// TODO
 				_ = err
 			}

--- a/src/go/api/scorch/user.go
+++ b/src/go/api/scorch/user.go
@@ -137,7 +137,6 @@ func (u UserComponent) shellOut(ctx context.Context, stage Action) error {
 		return fmt.Errorf("marshaling experiment metadata to JSON: %w", err)
 	}
 
-	//nolint:godox // TODO
 	// TODO: consider letting the child process send a signal indicating it wants
 	// to run in the background instead of having to configure it in the scenario.
 

--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -1431,7 +1431,6 @@ func injectICMPAllowRules(nodes []ifaces.NodeSpec) error {
 	for _, node := range nodes {
 		// This only adds ICMP allow rules if one or more rulesets already exist. If
 		// no rulesets exist then ICMP should already be allowed.
-		//nolint:godox // TODO
 		// TODO: right now, we simply add a rule to allow ICMP to/from anywhere
 		// without checking the default rule or seeing if an ICMP rule already
 		// exists. May want to improve on this if it causes issues.

--- a/src/go/api/vm/topology.go
+++ b/src/go/api/vm/topology.go
@@ -80,7 +80,6 @@ func Topology(exp string, ignore []string) (topology, error) {
 			}
 
 			if !cached {
-				//nolint:godox // TODO
 				// TODO: what if these change during an experiment (e.g., via user updates)?
 				search.AddVLAN(iface, node.ID)
 				search.AddIP(vm.IPv4[i], node.ID)
@@ -105,7 +104,6 @@ func Topology(exp string, ignore []string) (topology, error) {
 	}
 
 	if !cached {
-		//nolint:godox // TODO
 		// TODO: cache with expire?
 		_ = cache.Set(cacheKey, search)
 	}

--- a/src/go/app/app.go
+++ b/src/go/app/app.go
@@ -45,6 +45,9 @@ const (
 	ActionPostStart Action = "post-start"
 	ActionRunning   Action = "running"
 	ActionCleanup   Action = "cleanup"
+
+	osWindows = "windows"
+	osLinux   = "linux"
 )
 
 var (

--- a/src/go/app/ntp.go
+++ b/src/go/app/ntp.go
@@ -13,9 +13,6 @@ import (
 	"phenix/types"
 )
 
-const osWindows = "windows"
-const osLinux = "linux"
-
 type NTPAppMetadata struct {
 	DefaultSource NTPAppSource `mapstructure:"defaultSource"`
 }
@@ -55,6 +52,21 @@ func (s NTPAppSource) IPAddress(exp *types.Experiment) string {
 	return ""
 }
 
+type ntpTypeConfig struct {
+	tmpl string
+	dest string
+	mode string
+}
+
+// NTPTemplateData is the data passed to NTP configuration templates.
+// Source is the upstream NTP server IP address (empty string means use the
+// local clock). Server controls whether the config should allow other hosts to
+// use this VM as an NTP source.
+type NTPTemplateData struct {
+	Source string
+	Server bool
+}
+
 type NTP struct{}
 
 func (NTP) Init(...Option) error {
@@ -69,154 +81,130 @@ func (NTP) Configure(ctx context.Context, exp *types.Experiment) error {
 	return nil
 }
 
-//nolint:cyclop,funlen // complex logic
 func (NTP) PreStart(ctx context.Context, exp *types.Experiment) error {
-	var (
-		ntpDir  = exp.Spec.BaseDir() + "/ntp"
-		servers = exp.Spec.Topology().FindNodesWithLabels("ntp-server")
-	)
+	ntpDir := exp.Spec.BaseDir() + "/ntp"
+	servers := exp.Spec.Topology().FindNodesWithLabels("ntp-server")
 
-	// If an ntp-server was specified via a node label, then continue on with the
-	// legacy way of setting up NTP so as to provide backwards compatility with
-	// existing topology configurations.
-
-	if len(servers) == 0 {
-		// Check to see if a scenario exists for this experiment and if it contains
-		// a "ntp" app. If so, use it to configure NTP for the experiment.
-		for _, app := range exp.Apps() {
-			if app.Name() == "ntp" {
-				var amd NTPAppMetadata
-
-				_ = mapstructure.Decode(app.Metadata(), &amd)
-
-				// Might be an empty string, but that's okay... for now.
-				defaultSource := amd.DefaultSource.IPAddress(exp)
-
-				for _, host := range app.Hosts() {
-					node := exp.Spec.Topology().FindNodeByName(host.Hostname())
-					if node == nil {
-						continue
-					}
-
-					var hmd NTPAppHostMetadata
-
-					_ = mapstructure.Decode(host.Metadata(), &hmd)
-
-					var (
-						source = hmd.Source.IPAddress(exp)
-						cfg    = ntpDir + "/" + node.General().Hostname()
-					)
-
-					if hmd.Client != "" {
-						if source == "" {
-							if defaultSource == "" {
-								return fmt.Errorf(
-									"no NTP source configured for host %s (and no default source configured)",
-									host.Hostname(),
-								)
-							}
-
-							source = defaultSource
-						}
-
-						switch strings.ToLower(hmd.Client) {
-						case "ntp":
-							err := tmpl.CreateFileFromTemplate("ntp_linux.tmpl", source, cfg)
-							if err != nil {
-								return fmt.Errorf(
-									"generating NTP client config for host %s: %w",
-									host.Hostname(),
-									err,
-								)
-							}
-
-							node.AddInject(cfg, "/etc/ntp.conf", "", "")
-						case "systemd":
-							err := tmpl.CreateFileFromTemplate(
-								"systemd-timesyncd.tmpl",
-								source,
-								cfg,
-							)
-							if err != nil {
-								return fmt.Errorf(
-									"generating NTP client config for host %s: %w",
-									host.Hostname(),
-									err,
-								)
-							}
-
-							node.AddInject(cfg, "/etc/systemd/timesyncd.conf", "", "")
-						case "windows":
-							err := tmpl.CreateFileFromTemplate("ntp_windows.tmpl", source, cfg)
-							if err != nil {
-								return fmt.Errorf(
-									"generating NTP client config for host %s: %w",
-									host.Hostname(),
-									err,
-								)
-							}
-
-							node.AddInject(cfg, "/phenix/startup/25-ntp.ps1", "0755", "")
-						default:
-							return fmt.Errorf(
-								"unknown NTP client type %s provided for host %s",
-								hmd.Client,
-								host.Hostname(),
-							)
-						}
-
-						continue
-					}
-
-					if hmd.Server != "" {
-						switch strings.ToLower(hmd.Server) {
-						case "ntpd":
-							// It's okay if `source` is an empty string here. If it is, the
-							// template will generate a config for the NTP server that prefers
-							// the host's clock as the source.
-							err := tmpl.CreateFileFromTemplate("ntp_linux.tmpl", source, cfg)
-							if err != nil {
-								return fmt.Errorf(
-									"generating NTP server config for host %s: %w",
-									host.Hostname(),
-									err,
-								)
-							}
-
-							node.AddInject(cfg, "/etc/ntp.conf", "", "")
-						default:
-							return fmt.Errorf(
-								"unknown NTP server type %s provided for host %s",
-								hmd.Server,
-								host.Hostname(),
-							)
-						}
-
-						continue
-					}
-
-					return fmt.Errorf("host %s missing NTP client/server type", host.Hostname())
-				}
-			}
-		}
-
-		return nil
+	// If an ntp-server was specified via a node label, use the legacy node-label
+	// approach for backwards compatibility with existing topology configurations.
+	if len(servers) > 0 {
+		return NTP{}.preStartWithNodeLabels(ctx, exp, ntpDir)
 	}
 
+	return NTP{}.preStartWithAppConfig(ctx, exp, ntpDir)
+}
+
+func (NTP) preStartWithAppConfig(_ context.Context, exp *types.Experiment, ntpDir string) error {
+	ntpClientTypes := map[string]ntpTypeConfig{
+		"ntp":     {"ntp_linux.tmpl", "/etc/ntp.conf", ""},
+		"chrony":  {"chrony_linux.tmpl", "/etc/chrony/chrony.conf", ""},
+		"systemd": {"systemd-timesyncd.tmpl", "/etc/systemd/timesyncd.conf", ""},
+		"windows": {"ntp_windows.tmpl", "/phenix/startup/25-ntp.ps1", "0755"},
+	}
+
+	ntpServerTypes := map[string]ntpTypeConfig{
+		"ntpd": {"ntp_linux.tmpl", "/etc/ntp.conf", ""},
+		// TODO: Using file location /etc/chrony/chrony.conf default on Debian and Ubuntu. Other distros may use /etc/chrony.conf
+		"chronyd": {"chrony_linux.tmpl", "/etc/chrony/chrony.conf", ""},
+	}
+
+	for _, app := range exp.Apps() {
+		if app.Name() != "ntp" {
+			continue
+		}
+
+		var amd NTPAppMetadata
+
+		_ = mapstructure.Decode(app.Metadata(), &amd)
+
+		// Might be an empty string, but that's okay... for now.
+		defaultSource := amd.DefaultSource.IPAddress(exp)
+
+		for _, host := range app.Hosts() {
+			node := exp.Spec.Topology().FindNodeByName(host.Hostname())
+			if node == nil {
+				continue
+			}
+
+			var hmd NTPAppHostMetadata
+
+			_ = mapstructure.Decode(host.Metadata(), &hmd)
+
+			var (
+				source = hmd.Source.IPAddress(exp)
+				cfg    = ntpDir + "/" + node.General().Hostname()
+			)
+
+			if hmd.Client != "" {
+				if source == "" {
+					if defaultSource == "" {
+						return fmt.Errorf("no NTP source configured for host %s (and no default source configured)", host.Hostname())
+					}
+
+					source = defaultSource
+				}
+
+				tc, ok := ntpClientTypes[strings.ToLower(hmd.Client)]
+				if !ok {
+					return fmt.Errorf("unknown NTP client type %s provided for host %s", hmd.Client, host.Hostname())
+				}
+
+				data := NTPTemplateData{Source: source, Server: false}
+				if err := tmpl.CreateFileFromTemplate(tc.tmpl, data, cfg); err != nil {
+					return fmt.Errorf("generating NTP client config for host %s: %w", host.Hostname(), err)
+				}
+				node.AddInject(cfg, tc.dest, tc.mode, "")
+
+				continue
+			}
+
+			// It's okay if `source` is an empty string here. If it is, the
+			// template will generate a config for the NTP server that prefers
+			// the host's clock as the source.
+			if hmd.Server != "" {
+				tc, ok := ntpServerTypes[strings.ToLower(hmd.Server)]
+				if !ok {
+					return fmt.Errorf(
+						"unknown NTP server type %s provided for host %s",
+						hmd.Server,
+						host.Hostname(),
+					)
+				}
+
+				data := NTPTemplateData{Source: source, Server: true}
+				if err := tmpl.CreateFileFromTemplate(tc.tmpl, data, cfg); err != nil {
+					return fmt.Errorf(
+						"generating NTP server config for host %s: %w",
+						host.Hostname(),
+						err,
+					)
+				}
+				node.AddInject(cfg, tc.dest, tc.mode, "")
+
+				continue
+			}
+
+			return fmt.Errorf("host %s missing NTP client/server type", host.Hostname())
+		}
+	}
+
+	return nil
+}
+
+func (NTP) preStartWithNodeLabels(_ context.Context, exp *types.Experiment, ntpDir string) error {
 	var (
-		server     = servers[0] // use first server if more than one present
-		serverAddr string
+		servers = exp.Spec.Topology().FindNodesWithLabels("ntp-server")
+		server  = servers[0] // use first server if more than one present
 	)
 
 	ifaceName := server.Labels()["ntp-server"]
-	serverAddr = server.Network().InterfaceAddress(ifaceName)
+	serverAddr := server.Network().InterfaceAddress(ifaceName)
 
 	if serverAddr == "" {
 		return errors.New("no IP address provided for NTP server")
 	}
 
-	err := os.MkdirAll(ntpDir, 0o750)
-	if err != nil {
+	if err := os.MkdirAll(ntpDir, 0o750); err != nil {
 		return fmt.Errorf("creating experiment NTP directory path: %w", err)
 	}
 
@@ -234,7 +222,8 @@ func (NTP) PreStart(ctx context.Context, exp *types.Experiment) error {
 		ntpFile := ntpDir + "/" + node.General().Hostname() + "_ntp"
 
 		if strings.EqualFold(node.Type(), "router") {
-			err := tmpl.CreateFileFromTemplate("ntp_linux.tmpl", serverAddr, ntpFile)
+			data := NTPTemplateData{Source: serverAddr, Server: false}
+			err := tmpl.CreateFileFromTemplate("ntp_linux.tmpl", data, ntpFile)
 			if err != nil {
 				return fmt.Errorf("generating Router NTP script: %w", err)
 			}
@@ -250,15 +239,17 @@ func (NTP) PreStart(ctx context.Context, exp *types.Experiment) error {
 		}
 
 		switch strings.ToLower(node.Hardware().OSType()) {
-		case "linux", "rhel", "centos":
-			err := tmpl.CreateFileFromTemplate("ntp_linux.tmpl", serverAddr, ntpFile)
+		case osLinux, "rhel", "centos":
+			data := NTPTemplateData{Source: serverAddr, Server: false}
+			err := tmpl.CreateFileFromTemplate("ntp_linux.tmpl", data, ntpFile)
 			if err != nil {
 				return fmt.Errorf("generating Linux NTP script: %w", err)
 			}
 
 			node.AddInject(ntpFile, "/etc/ntp.conf", "", "")
-		case "windows":
-			err := tmpl.CreateFileFromTemplate("ntp_windows.tmpl", serverAddr, ntpFile)
+		case osWindows:
+			data := NTPTemplateData{Source: serverAddr, Server: false}
+			err := tmpl.CreateFileFromTemplate("ntp_windows.tmpl", data, ntpFile)
 			if err != nil {
 				return fmt.Errorf("generating Windows NTP script: %w", err)
 			}

--- a/src/go/app/ntp_test.go
+++ b/src/go/app/ntp_test.go
@@ -1,0 +1,219 @@
+package app_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"phenix/app"
+	"phenix/tmpl"
+)
+
+// TestNTPAppSourceIPAddressDirect verifies that an explicit Address is returned
+// directly without consulting the experiment topology.
+func TestNTPAppSourceIPAddressDirect(t *testing.T) {
+	s := app.NTPAppSource{Address: "192.168.1.1"} //nolint:exhaustruct // test data
+	if got := s.IPAddress(nil); got != "192.168.1.1" {
+		t.Fatalf("expected 192.168.1.1, got %s", got)
+	}
+}
+
+// TestNTPAppSourceIPAddressMissingInterface verifies that an empty string is
+// returned when Interface is not set (nothing to look up).
+func TestNTPAppSourceIPAddressMissingInterface(t *testing.T) {
+	s := app.NTPAppSource{Hostname: "server01"} //nolint:exhaustruct // test data
+	if got := s.IPAddress(nil); got != "" {
+		t.Fatalf("expected empty string, got %s", got)
+	}
+}
+
+// TestNTPLinuxTemplateClient verifies that ntp_linux.tmpl, when given a server
+// address, produces a client config pointing at that address.
+func TestNTPLinuxTemplateClient(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("ntp_linux.tmpl", app.NTPTemplateData{Source: "10.0.0.1", Server: false}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "server 10.0.0.1 iburst prefer") {
+		t.Fatalf("expected upstream server line in client config:\n%s", buf.String())
+	}
+}
+
+// TestNTPLinuxTemplateServer verifies that ntp_linux.tmpl, when given no
+// upstream address, produces a server config that falls back to the local clock.
+func TestNTPLinuxTemplateServer(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("ntp_linux.tmpl", app.NTPTemplateData{Source: "", Server: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "server 127.127.1.1 iburst prefer") {
+		t.Fatalf("expected local clock reference in server config:\n%s", buf.String())
+	}
+}
+
+// TestNTPLinuxTemplateClientNoServe verifies that ntp_linux.tmpl client config
+// includes noserve so the VM does not serve time to other hosts.
+func TestNTPLinuxTemplateClientNoServe(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("ntp_linux.tmpl", app.NTPTemplateData{Source: "10.0.0.1", Server: false}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "noserve") {
+		t.Fatalf("expected noserve in client restrict lines:\n%s", buf.String())
+	}
+}
+
+// TestNTPLinuxTemplateServerServes verifies that ntp_linux.tmpl server config
+// does not include noserve so the VM can serve time to NTP clients.
+func TestNTPLinuxTemplateServerServes(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("ntp_linux.tmpl", app.NTPTemplateData{Source: "10.0.0.1", Server: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(buf.String(), "noserve") {
+		t.Fatalf("unexpected noserve in server restrict lines:\n%s", buf.String())
+	}
+}
+
+// TestChronyLinuxTemplateClient verifies that chrony_linux.tmpl, when given a
+// server address, produces a client config pointing at that address.
+func TestChronyLinuxTemplateClient(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("chrony_linux.tmpl", app.NTPTemplateData{Source: "10.0.0.1", Server: false}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "server 10.0.0.1 iburst prefer") {
+		t.Fatalf("expected upstream server line in client config:\n%s", buf.String())
+	}
+}
+
+// TestChronyLinuxTemplateServer verifies that chrony_linux.tmpl, when given no
+// upstream address, produces a server config that falls back to the local clock.
+func TestChronyLinuxTemplateServer(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("chrony_linux.tmpl", app.NTPTemplateData{Source: "", Server: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "local stratum") {
+		t.Fatalf("expected local stratum reference in server config:\n%s", buf.String())
+	}
+}
+
+// TestChronyLinuxTemplateClientNoAllowAll verifies that chrony_linux.tmpl
+// client config does not include allow all, so the VM does not serve time.
+func TestChronyLinuxTemplateClientNoAllowAll(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("chrony_linux.tmpl", app.NTPTemplateData{Source: "10.0.0.1", Server: false}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(buf.String(), "allow all") {
+		t.Fatalf("unexpected allow all in client config:\n%s", buf.String())
+	}
+}
+
+// TestChronyLinuxTemplateServerAllowAll verifies that chrony_linux.tmpl
+// server config includes allow all so the VM serves time to NTP clients.
+func TestChronyLinuxTemplateServerAllowAll(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("chrony_linux.tmpl", app.NTPTemplateData{Source: "10.0.0.1", Server: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "allow all") {
+		t.Fatalf("expected allow all in server config:\n%s", buf.String())
+	}
+}
+
+// TestChronyLinuxTemplateClientMakestep verifies that chrony_linux.tmpl
+// includes the makestep directive configured for delayed server connectivity.
+func TestChronyLinuxTemplateClientMakestep(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("chrony_linux.tmpl", app.NTPTemplateData{Source: "10.0.0.1", Server: false}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "makestep 1.0 100") {
+		t.Fatalf("expected makestep directive for delayed startup:\n%s", buf.String())
+	}
+}
+
+// TestChronyLinuxTemplateClientMaxpoll verifies that chrony_linux.tmpl
+// includes maxpoll on the server line to limit backoff after failures.
+func TestChronyLinuxTemplateClientMaxpoll(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("chrony_linux.tmpl", app.NTPTemplateData{Source: "10.0.0.1", Server: false}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "maxpoll 6") {
+		t.Fatalf("expected maxpoll directive on server line:\n%s", buf.String())
+	}
+}
+
+// TestChronyLinuxTemplateServerNoUpstreamServer verifies that chrony_linux.tmpl
+// does not emit a server directive when no upstream address is provided.
+func TestChronyLinuxTemplateServerNoUpstreamServer(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("chrony_linux.tmpl", app.NTPTemplateData{Source: "", Server: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check for a directive line (not a comment) starting with "server ".
+	for line := range strings.SplitSeq(buf.String(), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "server ") {
+			t.Fatalf("unexpected server directive in local-clock config: %q", line)
+		}
+	}
+}
+
+// TestNTPLinuxTemplateClientBurst verifies that ntp_linux.tmpl includes
+// iburst and burst on the server line for aggressive startup synchronization.
+func TestNTPLinuxTemplateClientBurst(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate("ntp_linux.tmpl", app.NTPTemplateData{Source: "10.0.0.1", Server: false}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	out := buf.String()
+
+	if !strings.Contains(out, "iburst") || !strings.Contains(out, "burst") {
+		t.Fatalf("expected iburst and burst on server line:\n%s", out)
+	}
+}
+
+// TestSystemdTimesyncdTemplate verifies that systemd-timesyncd.tmpl renders
+// the NTP server address into the correct [Time] section key.
+func TestSystemdTimesyncdTemplate(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := tmpl.GenerateFromTemplate(
+		"systemd-timesyncd.tmpl",
+		app.NTPTemplateData{Source: "10.0.0.1", Server: false},
+		&buf,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "NTP=10.0.0.1") {
+		t.Fatalf("expected NTP= line in timesyncd config:\n%s", buf.String())
+	}
+}

--- a/src/go/app/serial.go
+++ b/src/go/app/serial.go
@@ -31,7 +31,6 @@ func (Serial) Configure(ctx context.Context, exp *types.Experiment) error {
 		}
 
 		// We only care about configuring serial interfaces on Linux VMs.
-		//nolint:godox // TODO
 		// TODO: handle rhel and centos OS types.
 		if node.Hardware().OSType() != osLinux {
 			continue
@@ -81,7 +80,6 @@ func (Serial) PreStart(ctx context.Context, exp *types.Experiment) error {
 		}
 
 		// We only care about configuring serial interfaces on Linux VMs.
-		//nolint:godox // TODO
 		// TODO: handle rhel and centos OS types.
 		if node.Hardware().OSType() != osLinux {
 			continue

--- a/src/go/app/vrouter.go
+++ b/src/go/app/vrouter.go
@@ -147,7 +147,6 @@ func (v Vrouter) Configure(ctx context.Context, exp *types.Experiment) error {
 				node := exp.Spec.Topology().FindNodeByName(host.Hostname())
 
 				if node == nil {
-					//nolint:godox // TODO
 					// TODO: handle this better? Like warn the user perhaps?
 					continue
 				}
@@ -801,7 +800,6 @@ func (Vrouter) processACL(md map[string]any, network ifaces.NodeNetwork) error {
 
 		ruleset, ok := iface.(ifaces.NodeNetworkRuleset)
 		if !ok {
-			//nolint:godox // TODO
 			// TODO: handle this better? Like warn the user perhaps?
 			continue
 		}

--- a/src/go/scheduler/round-robin.go
+++ b/src/go/scheduler/round-robin.go
@@ -42,7 +42,6 @@ func (roundRobin) Schedule(spec ifaces.ExperimentSpec) error {
 
 	cluster.SortByVMs(true)
 
-	//nolint:godox // TODO
 	// TODO: sort VMs by scheduled,memory (??)
 
 	for _, node := range spec.Topology().Nodes() {

--- a/src/go/tmpl/templates/chrony_linux.tmpl
+++ b/src/go/tmpl/templates/chrony_linux.tmpl
@@ -1,0 +1,31 @@
+# /etc/chrony/chrony.conf, configuration for chronyd; see chrony.conf(5) for help
+
+driftfile /var/lib/chrony/chrony.drift
+
+# Step the system clock if offset exceeds 1s, allowing stepping for ~10 min
+# to handle delayed server connectivity after VM startup.
+makestep 1.0 100
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Specify one or more NTP servers.
+
+{{ if .Source -}}
+# Use the specified upstream NTP server
+#  iburst    - Send a burst of 4 packets to speed up initial synchronization.
+#  prefer    - Prefer this source over others with the same stratum.
+#  maxpoll N - limit maximum polling interval to 2^N seconds (default 10, i.e. 1024s)
+server {{ .Source }} iburst prefer maxpoll 6
+{{- else -}}
+# No upstream source; use local clock as time reference.
+local stratum 10
+{{- end }}
+
+{{ if .Server -}}
+# Allow NTP clients to access this server.
+allow all
+{{- end }}

--- a/src/go/tmpl/templates/ntp_linux.tmpl
+++ b/src/go/tmpl/templates/ntp_linux.tmpl
@@ -12,17 +12,16 @@ filegen clockstats file clockstats type day enable
 
 # Specify one or more NTP servers.
 
-{{ if . }}
-server {{ . }} iburst prefer
-server 127.127.1.1
+{{ if .Source }}
+server {{ .Source }} iburst prefer maxpoll 6
 {{- else }}
 server 127.127.1.1 iburst prefer
 {{- end }}
-fudge 127.127.1.1 stratum 8
+fudge 127.127.1.1 stratum 10
 
 # By default, exchange time with everybody, but don't allow configuration.
-restrict -4 default kod notrap nomodify nopeer noquery limited
-restrict -6 default kod notrap nomodify nopeer noquery limited
+restrict -4 default kod notrap nomodify nopeer noquery{{ if not .Server }} noserve{{ end }} limited
+restrict -6 default kod notrap nomodify nopeer noquery{{ if not .Server }} noserve{{ end }} limited
 
 # Local users may interrogate the ntp server more closely.
 restrict 127.0.0.1

--- a/src/go/tmpl/templates/ntp_windows.tmpl
+++ b/src/go/tmpl/templates/ntp_windows.tmpl
@@ -42,7 +42,7 @@ tzutil /s "UTC"
 
 echo "Configuring NTP..."
 
-w32tm /config /manualpeerlist:"{{ . }}" /syncfromflags:manual /reliable:YES /update
+w32tm /config /manualpeerlist:"{{ .Source }}" /syncfromflags:manual /reliable:YES /update
 
 echo "Restart NTP for the changes to take affect..."
 
@@ -54,14 +54,14 @@ net start w32time
 # for the server to settle down and be ready.  The below loop waits for the NTP
 # server to settle and produce a valid stratum number.  Once a valid stratum is
 # received the NTP client can be restarted and forced to resync.
-echo "Wait for NTP server at {{ . }} then resync"
+echo "Wait for NTP server at {{ .Source }} then resync"
 
 Do {
     Start-Sleep -s 10
 
     echo "Get NTP server status"
 
-    $output = w32tm /monitor /computers:{{ . }} # get the output of the w32tm monitor action
+    $output = w32tm /monitor /computers:{{ .Source }} # get the output of the w32tm monitor action
 
     # find stratum number in output
     ForEach ($line in $output) {

--- a/src/go/tmpl/templates/systemd-timesyncd.tmpl
+++ b/src/go/tmpl/templates/systemd-timesyncd.tmpl
@@ -1,2 +1,3 @@
 [Time]
-NTP={{ . }}
+NTP={{ .Source }}
+PollIntervalMaxSec=64

--- a/src/go/tunneler/server.go
+++ b/src/go/tunneler/server.go
@@ -162,7 +162,6 @@ func handleConnection(conn net.Conn) {
 			fmt.Fprintf(os.Stderr, "ERROR: encoding %v message: %v\n", msg.Type, err)
 		}
 	case CREATE, DELETE:
-		//nolint:godox // TODO
 		// TODO: implement
 	}
 }

--- a/src/go/types/config.go
+++ b/src/go/types/config.go
@@ -12,7 +12,6 @@ import (
 )
 
 func NewConfigFromSpec(name string, spec any) (*store.Config, error) {
-	//nolint:godox // TODO
 	// TODO: add more case statements to this as more upgraders are added.
 	switch spec := spec.(type) {
 	case store.Config:

--- a/src/go/types/validate.go
+++ b/src/go/types/validate.go
@@ -44,7 +44,6 @@ func ValidateConfigSpec(c store.Config) error {
 		return fmt.Errorf("getting validator for config: %w", err)
 	}
 
-	//nolint:godox // FIXME
 	// FIXME: using JSON marshal/unmarshal to get Go types converted to JSON
 	// types. This is mainly needed for Go int types, since JSON only has float64.
 	// There's a better way to do this, but it requires an update to the openapi3
@@ -77,7 +76,6 @@ func ValidateConfig(c store.Config) error {
 		return errors.New("no schema definition found for configs")
 	}
 
-	//nolint:godox // FIXME
 	// FIXME: using JSON marshal/unmarshal to get Go types converted to JSON
 	// types. This is mainly needed for Go int types, since JSON only has float64.
 	// There's a better way to do this, but it requires an update to the openapi3

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -229,7 +229,6 @@ func (m Minimega) GetVMInfo(opts ...Option) VMs { //nolint:funlen // complex log
 		vm.RAM, _ = strconv.Atoi(row["memory"])
 		vm.CPUs, _ = strconv.Atoi(row["vcpus"])
 
-		//nolint:godox // TODO
 		// TODO: confirm multiple disks are separated by whitespace.
 		disk := strings.Fields(row["disks"])[0]
 		// diskspec can include multiple settings separated by comma. Path to disk

--- a/src/go/util/printer/events.go
+++ b/src/go/util/printer/events.go
@@ -1,6 +1,5 @@
 package printer
 
-//nolint:godox // TODO
 // TODO: update or delete
 // import (
 // 	"io"

--- a/src/go/web/broker/client.go
+++ b/src/go/web/broker/client.go
@@ -191,7 +191,6 @@ func (c *Client) read() { //nolint:maintidx // complex logic
 
 				continue
 			case "experiment/topology":
-				//nolint:godox // TODO
 				// TODO: check RBAC permissions?
 				switch req.Resource.Action {
 				case "search":
@@ -203,7 +202,6 @@ func (c *Client) read() { //nolint:maintidx // complex logic
 						continue
 					}
 
-					//nolint:godox // TODO
 					// TODO: handle multiple query terms (how? AND or OR?)
 					// Do the same as in web/experiment.go@SearchExperimentTopology
 					term := query["term"]

--- a/src/go/web/common.go
+++ b/src/go/web/common.go
@@ -187,7 +187,6 @@ func startExperiment(name string) ([]byte, error) {
 
 			vms, err := vm.List(name)
 			if err != nil {
-				//nolint:godox // TODO
 				// TODO
 				plog.Error(plog.TypeSystem, "listing VMs in experiment", "exp", name, "err", err)
 			}

--- a/src/go/web/config.go
+++ b/src/go/web/config.go
@@ -136,7 +136,6 @@ func DownloadConfigs(w http.ResponseWriter, r *http.Request) error {
 		return weberror.NewWebError(err, "unable to parse request")
 	}
 
-	//nolint:godox // TODO
 	// TODO: check for len == 0
 
 	if len(configs) == 1 {
@@ -167,7 +166,6 @@ func DownloadConfigs(w http.ResponseWriter, r *http.Request) error {
 			return weberror.NewWebError(err, "unable to get config %s from store", name)
 		}
 
-		//nolint:godox // TODO
 		// TODO: also clear passwords for users
 		if cfg.Kind == kindExperiment {
 			// Clear experiment name... not applicable to end users.
@@ -211,7 +209,6 @@ func DownloadConfigs(w http.ResponseWriter, r *http.Request) error {
 			return weberror.NewWebError(err, "unable to get config %s from store", name)
 		}
 
-		//nolint:godox // TODO
 		// TODO: also clear passwords for users
 		if cfg.Kind == kindExperiment {
 			// Clear experiment name... not applicable to end users.

--- a/src/go/web/experiment.go
+++ b/src/go/web/experiment.go
@@ -105,7 +105,6 @@ func SearchExperimentTopology(w http.ResponseWriter, r *http.Request) {
 		nodes     []int
 	)
 
-	//nolint:godox // TODO
 	// TODO: how to handle multiple terms? AND or OR?
 
 	for term, values := range query {

--- a/src/go/web/forward/forward.go
+++ b/src/go/web/forward/forward.go
@@ -365,7 +365,6 @@ func DeletePortForward(w http.ResponseWriter, r *http.Request) {
 	reapForwards()
 
 	if l, ok := forwards[key]; ok {
-		//nolint:godox // TODO
 		// TODO: how would we go about allowing admins to close all port forwards?
 		if l.Owner != user {
 			http.Error(w, "forbidden", http.StatusForbidden)

--- a/src/go/web/handlers.go
+++ b/src/go/web/handlers.go
@@ -107,7 +107,6 @@ func GetExperiments(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		//nolint:godox // TODO
 		// TODO: limit per-experiment VMs based on RBAC
 
 		vms, err := vm.List(exp.Spec.ExperimentName())

--- a/src/go/web/middleware/auth.go
+++ b/src/go/web/middleware/auth.go
@@ -117,7 +117,6 @@ func Auth(jwtKey, proxyAuthHeader string) mux.MiddlewareFunc {
 			ErrorHandler: func(w http.ResponseWriter, r *http.Request, e string) {
 				plog.Error(plog.TypeSecurity, "validating auth token", "err", e)
 
-				//nolint:godox // TODO
 				// TODO: remove token from user spec?
 
 				http.Error(w, e, http.StatusUnauthorized)

--- a/src/go/web/scorch/handlers.go
+++ b/src/go/web/scorch/handlers.go
@@ -585,7 +585,6 @@ func GetPipelines(w http.ResponseWriter, r *http.Request) error {
 
 	// if Scorch app is running, find out which run is currently being executed
 	if running {
-		//nolint:godox // TODO
 		// TODO: this should never be nil if Scorch is running...
 		if exp.Status.AppStatus() != nil {
 			if status, ok := exp.Status.AppStatus()["scorch"].(map[string]any); ok {
@@ -659,7 +658,6 @@ func GetPipeline(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-//nolint:godox // TODO
 // TODO: change this to `scorch/runs`
 
 // StartPipeline - POST /experiments/{name}/scorch/pipelines/{run}.
@@ -780,7 +778,6 @@ func StartPipeline(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-//nolint:godox // TODO
 // TODO: change this to `scorch/runs`
 
 // CancelPipeline - DELETE /experiments/{name}/scorch/pipelines/{run}.

--- a/src/go/web/workflow.go
+++ b/src/go/web/workflow.go
@@ -307,7 +307,6 @@ func ApplyWorkflow(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		// default is to not override existing tags if no new tags are passed
-		//nolint:godox // TODO
 		// TODO: perhaps sorting tags and only updating those that are passed
 		// while leaving old tags that have not been overridden
 		if tags != "" {
@@ -323,7 +322,6 @@ func ApplyWorkflow(w http.ResponseWriter, r *http.Request) error {
 		// interfaces just in case the topology includes updates changing VLAN alias
 		// names.
 		for _, node := range exp.Spec.Topology().Nodes() {
-			//nolint:godox // TODO
 			// TODO: only consider nodes schedulable by minimega? Or should HIL nodes
 			// be taken into account here still as well?
 			if node.Network() == nil {


### PR DESCRIPTION
# feat(ntp): add chrony support

## Description
* Add support for [chrony](https://chrony-project.org/) (which will be the default in Ubuntu 26.04) in the NTP app.
* set MaxPollInterval to 64s (2^6). This prevents VMs that can not initially reach their NTP (because of startup routing issues, like waiting on the tap app or routes to be exchanged) from backing off to the default maximum of 17 minutes (2^10 seconds) and not synching until many minutes after experiment start.
* set stratum for the hosts own clock to 10 so it is much less preferred vs. the set remote.
* add some test for the NTP app


## Related Issue
[sceptre-phenix-docs#33](https://github.com/sandialabs/sceptre-phenix-docs/pull/33)

## Type of Change
Please select the type of change your pull request introduces:
- ~Bugfix~
- [X] New feature
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Also cleanup linter config to allow TODO|BUG|FIXME notes everywhere, instead of adding nolint directives inline. Remove other unused exclusions.