### PR TITLE
fix(deb): parse clean version tags for debian package

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -48,7 +48,7 @@ jobs:
           build-args: |
             MM_MIN_REV=${{ env.MM_REV }}
             PHENIX_COMMIT=${{ env.sha }}
-            PHENIX_TAG=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+            PHENIX_TAG=${{ steps.meta.outputs.version }}
             APPS_REPO=github.com/${{ github.event_name == 'repository_dispatch' && github.event.client_payload.repo || 'sandialabs/sceptre-phenix-apps' }}
             APPS_BRANCH=main
           push: ${{ github.event_name != 'pull_request' }}

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -114,18 +114,41 @@ cp -a ${ARTIFACTS_DIR}/python_pkgs/. ${DEBIAN_DIR}/usr/lib/python3/dist-packages
 cp -a ${ARTIFACTS_DIR}/vmdb2_repo/. ${DEBIAN_DIR}/opt/vmdb2/
 ln -s /opt/vmdb2/vmdb2 ${DEBIAN_DIR}/usr/bin/vmdb2
 
+# Get the latest git tag to use as a fallback/prefix, defaulting to 1.0.0
+LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "1.0.0")
+LATEST_TAG=${LATEST_TAG#v}
+
 # Create DEBIAN/control file
-VERSION=$(docker run --rm ${BUILD_IMAGE} phenix version 2>/dev/null | grep "Version:" | awk '{print $2}' || echo "1.0.0")
-VERSION=${VERSION:-1.0.0}
+VERSION_STR=$(docker run --rm ${BUILD_IMAGE} phenix version 2>/dev/null || echo "${LATEST_TAG}")
+VERSION=$(echo "$VERSION_STR" | awk '{print $1}')
+# Extract just the tag/version part if it contains a colon (e.g. from a docker image name)
+VERSION="${VERSION##*:}"
+# Extract just the tag/version part if it contains a slash (e.g. from a github ref)
+VERSION="${VERSION##*/}"
+if [ "$VERSION" = "tag" ] || [ -z "$VERSION" ]; then
+    VERSION="${LATEST_TAG}"
+fi
+VERSION=${VERSION:-${LATEST_TAG}}
 # Strip leading 'v' if present
 VERSION=${VERSION#v}
+
+# Ensure the version starts with a digit (required by Debian packaging)
+if [[ ! "$VERSION" =~ ^[0-9] ]]; then
+    VERSION="${LATEST_TAG}~${VERSION}"
+fi
+
+# Replace any invalid characters (like underscores) with hyphens
+VERSION=$(echo "$VERSION" | tr '_' '-')
 
 # If we are in a git repository, append the short commit hash to the version
 # to distinguish builds, especially useful for forks and CI/CD.
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    SHORT_SHA=$(git rev-parse --short HEAD)
-    # Use ~ to denote a pre-release or + for build metadata in debian versions
-    VERSION="${VERSION}+git${SHORT_SHA}"
+    # Only append the git commit if we are NOT on a tag.
+    if ! git describe --exact-match --tags HEAD >/dev/null 2>&1; then
+        SHORT_SHA=$(git rev-parse --short HEAD)
+        # Use ~ to denote a pre-release or + for build metadata in debian versions
+        VERSION="${VERSION}+git${SHORT_SHA}"
+    fi
 fi
 
 cat <<EOF > ${DEBIAN_DIR}/DEBIAN/control


### PR DESCRIPTION
# Fix deb package versioning parsing

## Description
This PR fixes an issue where building a debian package on a tag (like ``v2026.04.17``) resulted in invalid version strings (e.g., ``1.0.0``) and incorrectly appended git commit hashes. 

- Updated the `PHENIX_TAG` argument in the GitHub Action workflow to use the actual ``github.ref_name`` instead of the full Docker image path.
- Enhanced version parsing in ``scripts/build-deb.sh`` to cleanly strip off Docker registry prefixes, slashes, and colons.
- Fixed ``build-deb.sh`` so that it skips appending the git commit hash if the script is being run on an exact git tag.

## Related Issue
Fixes #293.

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
@cmulk Since this is a very simple update, instead of creating a new tag/release, you can update the existing one like this after you download the `.deb` from the workflow build:

```bash
gh release upload v2026.04.17 path/to/new/phenix_2026.04.17_amd64.deb --clobber
```