### PR TITLE
fix(scorch): stream handoff updates

### DIFF
--- a/src/go/.golangci.yml
+++ b/src/go/.golangci.yml
@@ -416,6 +416,7 @@ linters:
           - bodyclose
           - dupl
           - errcheck
+          - exhaustruct
           - funlen
           - goconst
           - gosec

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -84,7 +84,7 @@ lint-clean:
 
 test:
 	$(call check-command,go,Please install Go 1.24+ (https://go.dev/doc/install))
-	go test -v ./...
+	go test -v -race ./...
 
 clean: lint-clean
 	$(RM) bin/phenix

--- a/src/go/api/config/config_test.go
+++ b/src/go/api/config/config_test.go
@@ -12,10 +12,10 @@ import (
 func TestListError(t *testing.T) {
 	configs := store.Configs(
 		[]store.Config{
-			{ //nolint:exhaustruct // test data
+			{
 				Version: "phenix.sandia.gov/v1",
 				Kind:    "Experiment",
-				Metadata: store.ConfigMetadata{ //nolint:exhaustruct // test data
+				Metadata: store.ConfigMetadata{
 					Name: "test-experiment",
 				},
 			},
@@ -41,10 +41,10 @@ func TestListError(t *testing.T) {
 }
 
 func TestCreateEnv(t *testing.T) {
-	expected := store.Config{ //nolint:exhaustruct // test data
+	expected := store.Config{
 		Version: "phenix.sandia.gov/v1",
 		Kind:    "Topology",
-		Metadata: store.ConfigMetadata{ //nolint:exhaustruct // test data
+		Metadata: store.ConfigMetadata{
 			Name: "foobar-test-experiment",
 		},
 	}

--- a/src/go/api/experiment/experiment_test.go
+++ b/src/go/api/experiment/experiment_test.go
@@ -12,10 +12,10 @@ import (
 func TestList(t *testing.T) {
 	configs := store.Configs(
 		[]store.Config{
-			{ //nolint:exhaustruct // mock data
+			{
 				Version: "phenix.sandia.gov/v1",
 				Kind:    "Experiment",
-				Metadata: store.ConfigMetadata{ //nolint:exhaustruct // mock data
+				Metadata: store.ConfigMetadata{
 					Name: "test-experiment",
 				},
 			},

--- a/src/go/api/scorch/user_test.go
+++ b/src/go/api/scorch/user_test.go
@@ -2,8 +2,18 @@
 package scorch
 
 import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
+	"time"
+
+	"phenix/store"
+	"phenix/types"
+	"phenix/util/plog"
 )
 
 func TestProcessLogChannel(t *testing.T) {
@@ -84,4 +94,193 @@ func TestProcessLogChannel(t *testing.T) {
 	mu.Unlock()
 
 	close(ch)
+}
+
+func TestProcessLogChannelAppendsTraceback(t *testing.T) {
+	type logEntry struct {
+		level string
+		msg   string
+	}
+
+	var (
+		captured []logEntry
+		mu       sync.Mutex
+		wg       sync.WaitGroup
+	)
+
+	logFn := func(level, msg string) {
+		mu.Lock()
+		defer mu.Unlock()
+		captured = append(captured, logEntry{level, msg})
+		wg.Done()
+	}
+
+	ch := make(chan []byte)
+	go processLogChannel(ch, logFn)
+
+	wg.Add(1)
+	ch <- []byte(`{"level":"ERROR","msg":"component failed","traceback":"line one\nline two"}`)
+	wg.Wait()
+	close(ch)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(captured))
+	}
+
+	if captured[0].level != levelError {
+		t.Fatalf("expected level %q, got %q", levelError, captured[0].level)
+	}
+
+	want := "component failed\nline one\nline two"
+	if captured[0].msg != want {
+		t.Fatalf("expected message %q, got %q", want, captured[0].msg)
+	}
+}
+
+func TestProcessLogChannelTreatsInvalidJSONAsText(t *testing.T) {
+	type logEntry struct {
+		level string
+		msg   string
+	}
+
+	var (
+		captured []logEntry
+		mu       sync.Mutex
+		wg       sync.WaitGroup
+	)
+
+	logFn := func(level, msg string) {
+		mu.Lock()
+		defer mu.Unlock()
+		captured = append(captured, logEntry{level, msg})
+		wg.Done()
+	}
+
+	ch := make(chan []byte)
+	go processLogChannel(ch, logFn)
+
+	wg.Add(1)
+	ch <- []byte(`{"level":"INFO","msg":`)
+	close(ch)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(captured))
+	}
+
+	if captured[0].level != levelInfo {
+		t.Fatalf("expected level %q, got %q", levelInfo, captured[0].level)
+	}
+
+	if captured[0].msg != `{"level":"INFO","msg":` {
+		t.Fatalf("unexpected message %q", captured[0].msg)
+	}
+}
+
+func TestUserComponentRunRoutesStdoutAndStructuredStderr(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "component.sh")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"printf 'component stdout\\n'",
+		"printf '{\"level\":\"INFO\",\"msg\":\"component stderr\",\"traceback\":\"trace line\"}\\n' >&2",
+		"cat >/dev/null",
+	}, "\n") + "\n"
+
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatalf("writing temp script: %v", err)
+	}
+
+	plog.NewPhenixHandler(io.Discard)
+
+	type logEntry struct {
+		level   string
+		logType string
+		msg     string
+	}
+
+	var (
+		entries []logEntry
+		mu      sync.Mutex
+	)
+
+	handlerName := "test-user-component-run"
+	plog.AddHandler(handlerName, plog.NewUIHandler("DEBUG", func(_ time.Time, level, logType, message string) {
+		mu.Lock()
+		defer mu.Unlock()
+		entries = append(entries, logEntry{level: level, logType: logType, msg: message})
+	}))
+	defer plog.RemoveHandler(handlerName)
+
+	exp := types.NewExperiment(store.ConfigMetadata{Name: "test-exp"})
+	exp.Spec.SetExperimentName("test-exp")
+
+	var u UserComponent
+	if err := u.Init(
+		Name("test-component"),
+		Type("test-type"),
+		Experiment(*exp),
+		RunID(2),
+		CurrentLoop(3),
+		LoopCount(4),
+	); err != nil {
+		t.Fatalf("initializing user component: %v", err)
+	}
+
+	if err := u.run(context.Background(), ActionStart, scriptPath, []byte(`{"input":"value"}`)); err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for {
+		mu.Lock()
+		count := len(entries)
+		mu.Unlock()
+
+		if count >= 2 || time.Now().After(deadline) {
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(entries) < 2 {
+		t.Fatalf("expected at least 2 log entries, got %d", len(entries))
+	}
+
+	var (
+		foundScorchLog bool
+		foundStdoutLog bool
+	)
+
+	for _, entry := range entries {
+		if entry.logType == string(plog.TypeScorch) &&
+			strings.Contains(entry.msg, "component stderr\ntrace line") &&
+			strings.Contains(entry.msg, "component=test-component") {
+			foundScorchLog = true
+		}
+
+		if entry.logType == string(plog.TypePhenixApp) &&
+			strings.Contains(entry.msg, "component stdout") &&
+			strings.Contains(entry.msg, "component=test-component") {
+			foundStdoutLog = true
+		}
+	}
+
+	if !foundScorchLog {
+		t.Fatalf("did not find routed structured stderr log in %+v", entries)
+	}
+
+	if !foundStdoutLog {
+		t.Fatalf("did not find routed stdout log in %+v", entries)
+	}
 }

--- a/src/go/app/ntp_test.go
+++ b/src/go/app/ntp_test.go
@@ -12,7 +12,7 @@ import (
 // TestNTPAppSourceIPAddressDirect verifies that an explicit Address is returned
 // directly without consulting the experiment topology.
 func TestNTPAppSourceIPAddressDirect(t *testing.T) {
-	s := app.NTPAppSource{Address: "192.168.1.1"} //nolint:exhaustruct // test data
+	s := app.NTPAppSource{Address: "192.168.1.1"}
 	if got := s.IPAddress(nil); got != "192.168.1.1" {
 		t.Fatalf("expected 192.168.1.1, got %s", got)
 	}
@@ -21,7 +21,7 @@ func TestNTPAppSourceIPAddressDirect(t *testing.T) {
 // TestNTPAppSourceIPAddressMissingInterface verifies that an empty string is
 // returned when Interface is not set (nothing to look up).
 func TestNTPAppSourceIPAddressMissingInterface(t *testing.T) {
-	s := app.NTPAppSource{Hostname: "server01"} //nolint:exhaustruct // test data
+	s := app.NTPAppSource{Hostname: "server01"}
 	if got := s.IPAddress(nil); got != "" {
 		t.Fatalf("expected empty string, got %s", got)
 	}

--- a/src/go/util/shell/exec.go
+++ b/src/go/util/shell/exec.go
@@ -148,12 +148,12 @@ func (shell) ExecCommand(ctx context.Context, opts ...Option) ([]byte, []byte, e
 		scanner.Split(o.splitter)
 
 		for scanner.Scan() {
-			bytes := scanner.Bytes()
+			line := scanner.Bytes()
 
-			stdoutBytes = append(stdoutBytes, bytes...)
+			stdoutBytes = append(stdoutBytes, line...)
 
 			if o.stdout != nil {
-				o.stdout <- bytes
+				o.stdout <- bytes.Clone(line)
 			}
 		}
 
@@ -176,12 +176,12 @@ func (shell) ExecCommand(ctx context.Context, opts ...Option) ([]byte, []byte, e
 		scanner.Split(bufio.ScanLines)
 
 		for scanner.Scan() {
-			bytes := scanner.Bytes()
+			line := scanner.Bytes()
 
-			stderrBytes = append(stderrBytes, bytes...)
+			stderrBytes = append(stderrBytes, line...)
 
 			if o.stderr != nil {
-				o.stderr <- bytes
+				o.stderr <- bytes.Clone(line)
 			}
 		}
 

--- a/src/go/util/shell/exec_test.go
+++ b/src/go/util/shell/exec_test.go
@@ -1,0 +1,66 @@
+package shell_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"phenix/util/shell"
+)
+
+func TestExecCommandCopiesStreamedBytes(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	tests := []struct {
+		name      string
+		script    string
+		streamOpt func(chan []byte) shell.Option
+		want      []string
+	}{
+		{
+			name:      "stdout",
+			script:    "printf 'alpha\nbravo\ncharl\n'",
+			streamOpt: shell.StreamStdout,
+			want:      []string{"alpha", "bravo", "charl"},
+		},
+		{
+			name:      "stderr",
+			script:    "printf 'alpha\nbravo\ncharl\n' >&2",
+			streamOpt: shell.StreamStderr,
+			want:      []string{"alpha", "bravo", "charl"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := make(chan []byte, len(tt.want))
+
+			_, _, err := shell.ExecCommand(
+				context.Background(),
+				shell.Command("sh"),
+				shell.Args("-c", tt.script),
+				tt.streamOpt(stream),
+			)
+			if err != nil {
+				t.Fatalf("ExecCommand returned error: %v", err)
+			}
+
+			var got [][]byte
+			for line := range stream {
+				got = append(got, line)
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected %d lines, got %d", len(tt.want), len(got))
+			}
+
+			for i, want := range tt.want {
+				if string(got[i]) != want {
+					t.Fatalf("line %d: expected %q, got %q", i, want, string(got[i]))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# fix(shell): stream handoff copies

## Description
Patch the shell stream handoff so both stdout and stderr channel payloads are copied before they leave the scanner loop

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- ~New feature~
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~I have commented my code, particularly in hard-to-understand areas.~
- ~I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [X] I have tested my code.

## Additional Notes
Independently not an issue, but needed for [sceptre-phenix-apps#103](https://github.com/sandialabs/sceptre-phenix-apps/pull/103) which fixes [sceptre-phenix-apps#102](https://github.com/sandialabs/sceptre-phenix-apps/pull/102).