### PR TITLE
chore(soh): ignore 'mirror' VLAN in SOH graph view

### DIFF
--- a/src/go/api/soh/soh.go
+++ b/src/go/api/soh/soh.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -121,14 +122,19 @@ func Get(expName, statusFilter string) (*Network, error) { //nolint:funlen // co
 
 		network.Nodes = append(network.Nodes, node)
 
-		// Look at the VM's interface and create an interface node, ignoring MGMT
-		// VLAN
+		// Look at the VM's interface and create an interface node
+		// Unless it is a member of the ignore list
+		var vlanIgnoreList = []string{
+			"MGMT",
+			"MIRROR", // default in mirror app https://github.com/sandialabs/sceptre-phenix-apps/blob/main/src/go/cmd/phenix-app-mirror/types.go#L56
+		}
+
 		for _, vmIface := range vm.Networks {
 			if match := vlanAliasRegex.FindStringSubmatch(vmIface); match != nil {
 				vmIface = match[1]
 			}
 
-			if strings.ToUpper(vmIface) == "MGMT" {
+			if slices.Contains(vlanIgnoreList, strings.ToUpper(vmIface)) {
 				continue
 			}
 


### PR DESCRIPTION
# chore(soh): ignore 'mirror' VLAN in SOH graph view

## Description

We currently ignore the `MGMT` VLAN in the SoH web view (graph).  Adding the `mirror` VLAN as well, which is the (undocumented) default for the mirror app.

## Related Issue
N/A


## Type of Change
Please select the type of change your pull request introduces:
- ~Bugfix~
- ~New feature~
- ~Documentation update~
- Other (please describe): chore

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A