### PR TITLE
feat(image)!: bump default image distro to noble, add trixie forkie

### DIFF
--- a/src/go/api/image/constants.go
+++ b/src/go/api/image/constants.go
@@ -162,6 +162,13 @@ var DefaultPackages = []string{ //nolint:gochecknoglobals // global constant
 
 var DebianComponents = []string{ //nolint:gochecknoglobals // global constant
 	"main",
+	"contrib",
+	"non-free",
+	"non-free-firmware",
+}
+
+var UbuntuComponents = []string{ //nolint:gochecknoglobals // global constant
+	"main",
 	"restricted",
 	"universe",
 	"multiverse",

--- a/src/go/api/image/image.go
+++ b/src/go/api/image/image.go
@@ -45,7 +45,7 @@ const protonuke = "protonuke"
 // returned if the variant value is not valid (acceptable values are `minbase`
 // or `mingui`).
 func SetupImage(img *v1.Image) error { //nolint:funlen // complex logic
-	debian := []string{"jessie", "stretch", "buster", "bullseye", "bookworm"}
+	debian := []string{"jessie", "stretch", "buster", "bullseye", "bookworm", "trixie", "forky"}
 	kali := []string{"kali-dev", "kali-rolling", "kali-last-snapshot", "kali-bleeding-edge"}
 
 	// If mirror is the default value, make sure it is correct based on the Release
@@ -63,8 +63,10 @@ func SetupImage(img *v1.Image) error { //nolint:funlen // complex logic
 		switch {
 		case slices.Contains(kali, img.Release):
 			img.Components = append(img.Components, KaliComponents...)
-		default:
+		case slices.Contains(debian, img.Release):
 			img.Components = append(img.Components, DebianComponents...)
+		default:
+			img.Components = append(img.Components, UbuntuComponents...)
 		}
 	}
 
@@ -81,7 +83,7 @@ func SetupImage(img *v1.Image) error { //nolint:funlen // complex logic
 			img.Packages = append(img.Packages, KaliPackages...)
 		case slices.Contains(debian, img.Release):
 			img.Packages = append(img.Packages, DebianPackages...)
-		default: // "xenial", "bionic", "focal", "jammy", "noble" ...
+		default: // "xenial", "bionic", "focal", "jammy", "noble", "oracular", "plucky", "questing", "resolute" ...
 			img.Packages = append(img.Packages, UbuntuPackages...)
 		}
 	case "mingui":
@@ -94,7 +96,7 @@ func SetupImage(img *v1.Image) error { //nolint:funlen // complex logic
 			img.Packages = append(img.Packages, DebianPackages...)
 			img.Packages = append(img.Packages, DebianMinGUIPackages...)
 			_ = addScriptToImage(img, "POSTBUILD_GUI", PostbuildGUI)
-		default: // "xenial", "bionic", "focal", "jammy", "noble" ...
+		default: // "xenial", "bionic", "focal", "jammy", "noble", "oracular", "plucky", "questing", "resolute" ...
 			img.Packages = append(img.Packages, UbuntuPackages...)
 			img.Packages = append(img.Packages, UbuntuMinGUIPackages...)
 			_ = addScriptToImage(img, "POSTBUILD_GUI", PostbuildGUI)

--- a/src/go/api/image/image_test.go
+++ b/src/go/api/image/image_test.go
@@ -1,0 +1,194 @@
+package image_test
+
+import (
+	"slices"
+	"testing"
+
+	"phenix/api/image"
+	v1 "phenix/types/version/v1"
+)
+
+const defaultUbuntuMirror = "http://us.archive.ubuntu.com/ubuntu"
+
+func TestSetupImage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		img            v1.Image
+		wantErr        bool
+		wantMirror     string
+		wantComponents []string
+		wantHasPkgs    []string
+		wantNoPkgs     []string
+		wantScripts    []string
+		wantNoScripts  []string
+	}{
+		{
+			name: "ubuntu noble keeps default mirror and uses ubuntu components",
+			img: v1.Image{
+				Variant: "minbase",
+				Release: "noble",
+				Mirror:  defaultUbuntuMirror,
+			},
+			wantMirror:     defaultUbuntuMirror,
+			wantComponents: image.UbuntuComponents,
+			wantHasPkgs:    []string{"linux-image-generic", "curl"},
+			wantNoPkgs:     []string{"linux-image-amd64"},
+		},
+		{
+			name: "ubuntu resolute falls through to ubuntu defaults",
+			img: v1.Image{
+				Variant: "minbase",
+				Release: "resolute",
+				Mirror:  defaultUbuntuMirror,
+			},
+			wantMirror:     defaultUbuntuMirror,
+			wantComponents: image.UbuntuComponents,
+			wantHasPkgs:    []string{"linux-image-generic"},
+		},
+		{
+			name: "debian trixie swaps mirror and uses debian components",
+			img: v1.Image{
+				Variant: "minbase",
+				Release: "trixie",
+				Mirror:  defaultUbuntuMirror,
+			},
+			wantMirror:     "http://ftp.us.debian.org/debian",
+			wantComponents: image.DebianComponents,
+			wantHasPkgs:    []string{"linux-image-amd64"},
+			wantNoPkgs:     []string{"linux-image-generic"},
+		},
+		{
+			name: "kali rolling swaps mirror and uses kali components",
+			img: v1.Image{
+				Variant: "minbase",
+				Release: "kali-rolling",
+				Mirror:  defaultUbuntuMirror,
+			},
+			wantMirror:     "http://http.kali.org/kali",
+			wantComponents: image.KaliComponents,
+			wantHasPkgs:    []string{"linux-image-amd64", "default-jdk"},
+		},
+		{
+			name: "user-provided mirror is preserved for debian release",
+			img: v1.Image{
+				Variant: "minbase",
+				Release: "trixie",
+				Mirror:  "http://my.local.mirror/debian",
+			},
+			wantMirror:     "http://my.local.mirror/debian",
+			wantComponents: image.DebianComponents,
+		},
+		{
+			name: "user-provided components are preserved",
+			img: v1.Image{
+				Variant:    "minbase",
+				Release:    "noble",
+				Mirror:     defaultUbuntuMirror,
+				Components: []string{"main", "universe"},
+			},
+			wantComponents: []string{"main", "universe"},
+		},
+		{
+			name: "mingui ubuntu adds gui packages and postbuild gui script",
+			img: v1.Image{
+				Variant: "mingui",
+				Release: "noble",
+				Mirror:  defaultUbuntuMirror,
+			},
+			wantHasPkgs: []string{"xubuntu-desktop", "xdotool", "linux-image-generic"},
+			wantScripts: []string{"POSTBUILD_GUI"},
+		},
+		{
+			name: "mingui kali uses kali gui script",
+			img: v1.Image{
+				Variant: "mingui",
+				Release: "kali-rolling",
+				Mirror:  defaultUbuntuMirror,
+			},
+			wantHasPkgs:   []string{"kali-desktop-xfce"},
+			wantScripts:   []string{"POSTBUILD_KALI_GUI"},
+			wantNoScripts: []string{"POSTBUILD_GUI"},
+		},
+		{
+			name: "skip-default-packages omits default package set",
+			img: v1.Image{
+				Variant:             "minbase",
+				Release:             "noble",
+				Mirror:              defaultUbuntuMirror,
+				SkipDefaultPackages: true,
+			},
+			wantHasPkgs: []string{"linux-image-generic"},
+			wantNoPkgs:  []string{"curl", "vim", "openssh-server"},
+		},
+		{
+			name: "invalid variant returns error",
+			img: v1.Image{
+				Variant: "bogus",
+				Release: "noble",
+				Mirror:  defaultUbuntuMirror,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			img := tt.img
+			err := image.SetupImage(&img)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantMirror != "" && img.Mirror != tt.wantMirror {
+				t.Errorf("mirror: got %q, want %q", img.Mirror, tt.wantMirror)
+			}
+
+			if tt.wantComponents != nil && !slices.Equal(img.Components, tt.wantComponents) {
+				t.Errorf("components: got %v, want %v", img.Components, tt.wantComponents)
+			}
+
+			for _, p := range tt.wantHasPkgs {
+				if !slices.Contains(img.Packages, p) {
+					t.Errorf("expected package %q in %v", p, img.Packages)
+				}
+			}
+
+			for _, p := range tt.wantNoPkgs {
+				if slices.Contains(img.Packages, p) {
+					t.Errorf("did not expect package %q in %v", p, img.Packages)
+				}
+			}
+
+			for _, s := range tt.wantScripts {
+				if _, ok := img.Scripts[s]; !ok {
+					t.Errorf("expected script %q in %v", s, keys(img.Scripts))
+				}
+			}
+
+			for _, s := range tt.wantNoScripts {
+				if _, ok := img.Scripts[s]; ok {
+					t.Errorf("did not expect script %q in %v", s, keys(img.Scripts))
+				}
+			}
+		})
+	}
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/src/go/cmd/image.go
+++ b/src/go/cmd/image.go
@@ -162,7 +162,7 @@ func newImageCreateCmd() *cobra.Command {
 
 	cmd.Flags().StringP("size", "s", "10G", "Image size to use")
 	cmd.Flags().StringP("variant", "v", "minbase", "Image variant to use")
-	cmd.Flags().StringP("release", "r", "jammy", "OS release codename")
+	cmd.Flags().StringP("release", "r", "noble", "OS release codename")
 	cmd.Flags().
 		StringP("mirror", "m", "http://us.archive.ubuntu.com/ubuntu", "Debootstrap mirror (must match release)")
 	cmd.Flags().


### PR DESCRIPTION
# feat(image)!: bump default image distro to noble, add trixie forkie

## Description

> [!WARNING]
> This is a breaking change. Future image creation with `phenix image create ... ` will default to **noble** instead of jammy. Jammy can still be built by passing the `-r jammy` flag.

* Change the default image distro from jammy (22.04) to **noble (24.04)**.
* Add support for debian releases trixie and forkie
* Fix a minor issue to differentiate debian components from ubuntu
* Add a few tests

## Related Issue
If applicable, please link to the issue here (e.g., #123).

## Type of Change
Please select the type of change your pull request introduces:
- ~Bugfix~
- [X] New feature
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~I have commented my code, particularly in hard-to-understand areas.~
- ~I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
N/A