### PR TITLE
fix: remove deprecated 'inject-miniccc' command

### DIFF
--- a/src/go/cmd/image.go
+++ b/src/go/cmd/image.go
@@ -542,25 +542,6 @@ func newImageUpdateCmd() *cobra.Command {
 	return cmd
 }
 
-func newImageInjectMinicccCmd() *cobra.Command {
-	desc := `Inject the miniccc agent into a disk image
-
-	This subcommand has been DEPRECATED. Please use inject-miniexe instead.`
-
-	cmd := &cobra.Command{
-		Use:   "inject-miniccc <path to miniccc> <path to disk>",
-		Short: "Inject the miniccc agent into a disk image (DEPRECATED)",
-		Long:  desc,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New(
-				"inject-miniccc has been deprecated - please use inject-miniexe instead",
-			)
-		},
-	}
-
-	return cmd
-}
-
 func newImageInjectMiniExeCmd() *cobra.Command {
 	desc := `Inject a minimega executable into a disk image
 
@@ -638,7 +619,6 @@ func init() { //nolint:gochecknoinits // cobra command
 	imageCmd.AddCommand(newImageAppendCmd())
 	imageCmd.AddCommand(newImageRemoveCmd())
 	imageCmd.AddCommand(newImageUpdateCmd())
-	imageCmd.AddCommand(newImageInjectMinicccCmd())
 	imageCmd.AddCommand(newImageInjectMiniExeCmd())
 
 	rootCmd.AddCommand(imageCmd)


### PR DESCRIPTION
## Description
Remove the deprecated 'inject-miniccc' command, which has been obsolete [since 2021](https://github.com/sandialabs/sceptre-phenix/commit/b3ffd9f723008882982c881c96e8a8ec66a3a634). This change simplifies the command set by eliminating outdated functionality.

## Related Issue
N/A

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- ~~[ ] I have commented my code, particularly in hard-to-understand areas.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Not updating CHANGELOG.md because I *think* the workflow for that is to update the changelog when a release is created.
