### PR TITLE
feat: filter 'phenix vm' commands by labels

### DIFF
--- a/src/go/.golangci.yml
+++ b/src/go/.golangci.yml
@@ -115,7 +115,6 @@ linters:
 #   - tagliatelle # checks the struct tags
     - testableexamples # checks if examples are testable (have an expected output)
     - testifylint # checks usage of github.com/stretchr/testify
-    - testpackage # makes you use a separate _test package
     - thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
     - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
     - unconvert # removes unnecessary type conversions

--- a/src/go/cmd/vm.go
+++ b/src/go/cmd/vm.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -66,6 +68,170 @@ func vmArgsCompletion(_ *cobra.Command, args []string, toComplete string) ([]str
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
+func addVMLabelFlag(cmd *cobra.Command) {
+	cmd.Flags().StringArrayP(
+		"label",
+		"l",
+		nil,
+		"Label to filter VMs (supports glob patterns); use 'all' to select every VM",
+	)
+}
+
+func normalizeVMLabels(labels []string) []string {
+	var normalized []string
+
+	for _, label := range labels {
+		for piece := range strings.SplitSeq(label, ",") {
+			piece = strings.TrimSpace(piece)
+			if piece == "" {
+				continue
+			}
+
+			normalized = append(normalized, piece)
+		}
+	}
+
+	return normalized
+}
+
+func vmLabelMatchesLabel(label, expected string) (bool, error) {
+	if strings.EqualFold(label, expected) {
+		return true, nil
+	}
+
+	if strings.ContainsAny(expected, "*?[") {
+		matched, err := path.Match(strings.ToLower(expected), strings.ToLower(label))
+		if err != nil {
+			return false, err
+		}
+
+		if matched {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func vmMatchesAnyLabel(vmInfo mm.VM, labels []string) (bool, error) {
+	if len(labels) == 0 {
+		return false, nil
+	}
+
+	if slices.ContainsFunc(labels, func(label string) bool { return strings.EqualFold(label, "all") }) {
+		return true, nil
+	}
+
+	for label := range vmInfo.Tags {
+		for _, expected := range labels {
+			matched, err := vmLabelMatchesLabel(label, expected)
+			if err != nil {
+				return false, fmt.Errorf("invalid label %q: %w", expected, err)
+			}
+
+			if matched {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func listVMsByLabel(expName string, labels []string) ([]mm.VM, error) {
+	allVMs, err := vm.List(expName)
+	if err != nil {
+		return nil, err
+	}
+
+	if slices.ContainsFunc(labels, func(label string) bool { return strings.EqualFold(label, "all") }) {
+		return allVMs, nil
+	}
+
+	var matchedVMs []mm.VM
+
+	for _, vmInfo := range allVMs {
+		matched, matchErr := vmMatchesAnyLabel(vmInfo, labels)
+		if matchErr != nil {
+			return nil, matchErr
+		}
+
+		if matched {
+			matchedVMs = append(matchedVMs, vmInfo)
+		}
+	}
+
+	if len(matchedVMs) == 0 {
+		return nil, fmt.Errorf("no VMs matched label(s): %s", strings.Join(labels, ", "))
+	}
+
+	return matchedVMs, nil
+}
+
+func vmTargetNamesForCommand(cmd *cobra.Command, args []string) (string, []string, error) {
+	if len(args) < 1 {
+		return "", nil, errors.New("must provide an experiment name")
+	}
+
+	expName := args[0]
+
+	if !cmd.Flags().Changed("label") {
+		if len(args) != pauseArgs {
+			return "", nil, errors.New("must provide an experiment and VM name (or use --label)")
+		}
+
+		return expName, []string{args[1]}, nil
+	}
+
+	flagLabels, err := cmd.Flags().GetStringArray("label")
+	if err != nil {
+		return "", nil, fmt.Errorf("getting vm label values: %w", err)
+	}
+
+	labels := normalizeVMLabels(append(flagLabels, args[1:]...))
+	if len(labels) == 0 {
+		return "", nil, errors.New("must provide at least one VM label filter")
+	}
+
+	vms, err := listVMsByLabel(expName, labels)
+	if err != nil {
+		return "", nil, err
+	}
+
+	names := make([]string, 0, len(vms))
+	for _, vmInfo := range vms {
+		names = append(names, vmInfo.Name)
+	}
+
+	return expName, names, nil
+}
+
+// Calls the appropriate VM API function for a command with one or more VMs specified by the user and handles error humanization and logging for the command
+// This function assumes that the function passed to fn accepts two string arguments for the experiment name and VM name and returns an error if the operation was unsuccessful.
+func processVariableVMsArgument(fn func(expName, vmName string) error, cmd *cobra.Command, args []string, opDesc, opPast string) error {
+	expName, vmNames, err := vmTargetNamesForCommand(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	for _, vmName := range vmNames {
+		err := fn(expName, vmName)
+		if err != nil {
+			err := util.HumanizeError(err, "%s", "Unable to "+opDesc+" the "+vmName+" VM")
+
+			return err.Humanized()
+		}
+
+		plog.Info(plog.TypeSystem, "vm "+opPast, "vm", vmName, "exp", expName)
+	}
+
+	return nil
+}
+
+/*
+---------- VM Command Definitions ----------
+*/
+
 func newVMCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vm",
@@ -79,19 +245,42 @@ func newVMCmd() *cobra.Command {
 }
 
 func newVMInfoCmd() *cobra.Command {
-	desc := `Table of virtual machine(s)
+	desc := `Table of VM(s)
 
   Used to display a table of virtual machine(s) for a specific experiment;
-  virtual machine name is optional, when included will display only that VM.`
+  VM name is optional, when included will display only that VM.`
 
 	cmd := &cobra.Command{
-		Use:               "info <experiment name> <vm name>",
+		Use:               "info <experiment name> [vm name]",
 		Short:             "Table of virtual machine(s)",
 		Long:              desc,
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("must provide an experiment name")
+			}
+
+			if cmd.Flags().Changed("label") {
+				flagLabels, err := cmd.Flags().GetStringArray("label")
+				if err != nil {
+					return fmt.Errorf("getting vm label values: %w", err)
+				}
+
+				labels := normalizeVMLabels(append(flagLabels, args[1:]...))
+				if len(labels) == 0 {
+					return errors.New("must provide at least one VM label filter")
+				}
+
+				vms, err := listVMsByLabel(args[0], labels)
+				if err != nil {
+					err := util.HumanizeError(err, "Unable to get a filtered list of VMs")
+
+					return err.Humanized()
+				}
+
+				printer.PrintTableOfVMs(os.Stdout, vms...)
+
+				return nil
 			}
 
 			switch len(args) {
@@ -125,135 +314,73 @@ func newVMInfoCmd() *cobra.Command {
 		},
 	}
 
+	addVMLabelFlag(cmd)
+
 	return cmd
 }
 
 func newVMPauseCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "pause <experiment name> <vm name>",
-		Short:             "Pause a running VM for a specific experiment",
+		Use:               "pause <experiment name> [vm name]",
+		Short:             "Pause running VM(s) for a specific experiment",
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != pauseArgs {
-				return errors.New("must provide an experiment and VM name")
-			}
-
-			var (
-				expName = args[0]
-				vmName  = args[1]
-			)
-
-			err := vm.Pause(expName, vmName)
-			if err != nil {
-				err := util.HumanizeError(err, "%s", "Unable to pause the "+vmName+" VM")
-
-				return err.Humanized()
-			}
-
-			plog.Info(plog.TypeSystem, "vm paused", "vm", vmName, "exp", expName)
-
-			return nil
+			return processVariableVMsArgument(vm.Pause, cmd, args, "pause", "paused")
 		},
 	}
+
+	addVMLabelFlag(cmd)
 
 	return cmd
 }
 
 func newVMResumeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "resume <experiment name> <vm name>",
-		Short:             "Resume a paused VM for a specific experiment",
+		Use:               "resume <experiment name> [vm name]",
+		Short:             "Resume paused VM(s) for a specific experiment",
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != pauseArgs {
-				return errors.New("must provide an experiment and VM name")
-			}
-
-			var (
-				expName = args[0]
-				vmName  = args[1]
-			)
-
-			err := vm.Resume(expName, vmName)
-			if err != nil {
-				err := util.HumanizeError(err, "%s", "Unable to resume the "+vmName+" VM")
-
-				return err.Humanized()
-			}
-
-			plog.Info(plog.TypeSystem, "vm resumed", "vm", vmName, "exp", expName)
-
-			return nil
+			return processVariableVMsArgument(vm.Resume, cmd, args, "resume", "resumed")
 		},
 	}
+
+	addVMLabelFlag(cmd)
 
 	return cmd
 }
 
 func newVMRestartCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "restart <experiment name> <vm name>",
-		Short:             "Restart a running, paused, or powered off VM",
+		Use:               "restart <experiment name> [vm name]",
+		Short:             "Restart running, paused, or powered off VM(s) for a specific experiment",
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != pauseArgs {
-				return errors.New("must provide an experiment and VM name")
-			}
-
-			var (
-				expName = args[0]
-				vmName  = args[1]
-			)
-
-			err := vm.Restart(expName, vmName)
-			if err != nil {
-				err := util.HumanizeError(err, "%s", "Unable to restart the "+vmName+" VM")
-
-				return err.Humanized()
-			}
-
-			plog.Info(plog.TypeSystem, "vm restarted", "vm", vmName, "exp", expName)
-
-			return nil
+			return processVariableVMsArgument(vm.Restart, cmd, args, "restart", "restarted")
 		},
 	}
+
+	addVMLabelFlag(cmd)
 
 	return cmd
 }
 
 func newVMResetDiskCmd() *cobra.Command {
-	desc := `Resets the disk state to the initial pre-boot disk state for a running or powered off VM
+	desc := `Resets the disk state to the initial pre-boot disk state for running or powered off VM(s)
 
-  Used to reset the disk state for the first disk for a running or powered off virtual machine for a specific
+  Used to reset the disk state for the first disk for running or powered off virtual machine(s) for a specific
   experiment.  The VM's snapshot flag must be set to true in order to use this command.`
 
 	cmd := &cobra.Command{
-		Use:               "reset-disk <experiment name> <vm name>",
-		Short:             "Resets the disk state for a running or powered off VM",
+		Use:               "reset-disk <experiment name> [vm name]",
+		Short:             "Resets the disk state for running or powered off VM(s)",
 		Long:              desc,
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != pauseArgs {
-				return errors.New("must provide an experiment and VM name")
-			}
-
-			var (
-				expName = args[0]
-				vmName  = args[1]
-			)
-
-			err := vm.ResetDiskState(expName, vmName)
-			if err != nil {
-				err := util.HumanizeError(err, "%s", "Unable to reset disk for "+vmName+" VM")
-
-				return err.Humanized()
-			}
-
-			plog.Info(plog.TypeSystem, "vm disk reset", "vm", vmName, "exp", expName)
-
-			return nil
+			return processVariableVMsArgument(vm.ResetDiskState, cmd, args, "reset disk", "disk reset")
 		},
 	}
+
+	addVMLabelFlag(cmd)
 
 	return cmd
 }
@@ -265,26 +392,25 @@ func newVMRedeployCmd() *cobra.Command {
 		part int
 	)
 
-	desc := `Redeploy a running experiment VM
+	desc := `Redeploy running experiment VM(s)
 
-  Used to redeploy a running virtual machine for a specific experiment; several
+  Used to redeploy running virtual machine(s) for a specific experiment; several redeploy
   values can be modified`
 
 	cmd := &cobra.Command{
-		Use:               "redeploy <experiment name> <vm name>",
-		Short:             "Redeploy a running experiment VM",
+		Use:               "redeploy <experiment name> [vm name]",
+		Short:             "Redeploy running experiment VM(s)",
 		Long:              desc,
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != redeployArgs {
-				return errors.New("must provide an experiment and VM name")
+			expName, vmNames, err := vmTargetNamesForCommand(cmd, args)
+			if err != nil {
+				return err
 			}
 
 			var (
-				expName = args[0]
-				vmName  = args[1]
-				disk    = MustGetString(cmd.Flags(), "disk")
-				inject  = MustGetBool(cmd.Flags(), "replicate-injects")
+				disk   = MustGetString(cmd.Flags(), "disk")
+				inject = MustGetBool(cmd.Flags(), "replicate-injects")
 			)
 
 			if cpu != 0 && (cpu < 1 || cpu > 8) {
@@ -305,14 +431,16 @@ func newVMRedeployCmd() *cobra.Command {
 				vm.InjectPartition(part),
 			}
 
-			err := vm.Redeploy(expName, vmName, opts...)
-			if err != nil {
-				err := util.HumanizeError(err, "%s", "Unable to redeploy the "+vmName+" VM")
+			for _, vmName := range vmNames {
+				err := vm.Redeploy(expName, vmName, opts...)
+				if err != nil {
+					err := util.HumanizeError(err, "%s", "Unable to redeploy the "+vmName+" VM")
 
-				return err.Humanized()
+					return err.Humanized()
+				}
+
+				plog.Info(plog.TypeSystem, "vm redeployed", "vm", vmName, "exp", expName)
 			}
-
-			plog.Info(plog.TypeSystem, "vm redeployed", "vm", vmName, "exp", expName)
 
 			return nil
 		},
@@ -326,80 +454,49 @@ func newVMRedeployCmd() *cobra.Command {
 	cmd.Flags().BoolP("replicate-injects", "r", false, "Recreate disk snapshot and VM injections")
 	cmd.Flags().
 		IntVarP(&part, "partition", "p", 1, "Partition of disk to inject files into (only used if disk option is specified)")
+	addVMLabelFlag(cmd)
 
 	return cmd
 }
 
 func newVMShutdownCmd() *cobra.Command {
-	desc := `Shuts down or powers off a running or paused VM
+	desc := `Shuts down or powers off running or paused VM(s)
 
-  Used to shutdown or power off a running or paused virtual machine for a specific
+  Used to shutdown or power off running or paused virtual machine(s) for a specific
   experiment.  The shutdown is not graceful and is equivalent to pulling the power cord`
 
 	cmd := &cobra.Command{
-		Use:               "shutdown <experiment name> <vm name>",
+		Use:               "shutdown <experiment name> [vm name]",
 		Short:             "Shutdown a running or paused VM",
 		Long:              desc,
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != shutdownArgs {
-				return errors.New("must provide an experiment and VM name")
-			}
-
-			var (
-				expName = args[0]
-				vmName  = args[1]
-			)
-
-			err := vm.Shutdown(expName, vmName)
-			if err != nil {
-				err := util.HumanizeError(err, "%s", "Unable to shutdown the "+vmName+" VM")
-
-				return err.Humanized()
-			}
-
-			plog.Info(plog.TypeSystem, "vm shutdown", "vm", vmName, "exp", expName)
-
-			return nil
+			return processVariableVMsArgument(vm.Shutdown, cmd, args, "shutdown", "shutdown")
 		},
 	}
+
+	addVMLabelFlag(cmd)
 
 	return cmd
 }
 
 func newVMKillCmd() *cobra.Command {
-	desc := `Kill a running or paused VM
+	desc := `Kill running or paused VM(s)
 
-  Used to kill or delete a running or paused virtual machine for a specific
+  Used to kill or delete running or paused virtual machine(s) for a specific
   experiment`
 
 	cmd := &cobra.Command{
-		Use:               "kill <experiment name> <vm name>",
+		Use:               "kill <experiment name> [vm name]",
 		Short:             "Kill a running or pause VM",
 		Long:              desc,
 		ValidArgsFunction: vmArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != killArgs {
-				return errors.New("must provide an experiment and VM name")
-			}
-
-			var (
-				expName = args[0]
-				vmName  = args[1]
-			)
-
-			err := vm.Kill(expName, vmName)
-			if err != nil {
-				err := util.HumanizeError(err, "%s", "Unable to kill the "+vmName+" VM")
-
-				return err.Humanized()
-			}
-
-			plog.Info(plog.TypeSystem, "vm killed", "vm", vmName, "exp", expName)
-
-			return nil
+			return processVariableVMsArgument(vm.Kill, cmd, args, "kill", "killed")
 		},
 	}
+
+	addVMLabelFlag(cmd)
 
 	return cmd
 }

--- a/src/go/cmd/vm_filter_test.go
+++ b/src/go/cmd/vm_filter_test.go
@@ -1,0 +1,373 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"phenix/util/mm"
+)
+
+// ---------------------------------------------------------------------------
+// normalizeVMLabels
+// ---------------------------------------------------------------------------
+
+func TestNormalizeVMLabels_Empty(t *testing.T) {
+	if got := normalizeVMLabels(nil); got != nil {
+		t.Fatalf("expected nil slice for nil input, got %v", got)
+	}
+}
+
+func TestNormalizeVMLabels_SingleItem(t *testing.T) {
+	got := normalizeVMLabels([]string{"app-label"})
+	if len(got) != 1 || got[0] != "app-label" {
+		t.Fatalf("unexpected result: %v", got)
+	}
+}
+
+func TestNormalizeVMLabels_CommaSeparatedExpandsToMultiple(t *testing.T) {
+	got := normalizeVMLabels([]string{"label-a,label-b"})
+	if len(got) != 2 || got[0] != "label-a" || got[1] != "label-b" {
+		t.Fatalf("unexpected result: %v", got)
+	}
+}
+
+func TestNormalizeVMLabels_MultipleEntriesMerged(t *testing.T) {
+	got := normalizeVMLabels([]string{"label-a", "label-b", "label-c"})
+	if len(got) != 3 {
+		t.Fatalf("expected 3 items, got %d: %v", len(got), got)
+	}
+}
+
+func TestNormalizeVMLabels_TrimsWhitespace(t *testing.T) {
+	got := normalizeVMLabels([]string{" label-a , label-b "})
+	if len(got) != 2 || got[0] != "label-a" || got[1] != "label-b" {
+		t.Fatalf("unexpected result after trimming: %v", got)
+	}
+}
+
+func TestNormalizeVMLabels_EmptyPiecesSkipped(t *testing.T) {
+	// e.g. trailing comma or double comma
+	got := normalizeVMLabels([]string{"label-a,,label-b"})
+	if len(got) != 2 || got[0] != "label-a" || got[1] != "label-b" {
+		t.Fatalf("expected empty pieces to be skipped, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// vmLabelMatchesLabel
+// ---------------------------------------------------------------------------
+
+func TestVMLabelMatchesLabel_ExactMatch(t *testing.T) {
+	matched, err := vmLabelMatchesLabel("my-app", "my-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected exact match")
+	}
+}
+
+func TestVMLabelMatchesLabel_CaseInsensitiveExact(t *testing.T) {
+	matched, err := vmLabelMatchesLabel("My-App", "MY-APP")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected case-insensitive exact match")
+	}
+}
+
+func TestVMLabelMatchesLabel_NoMatch(t *testing.T) {
+	matched, err := vmLabelMatchesLabel("my-app", "other-label")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if matched {
+		t.Fatal("expected no match")
+	}
+}
+
+func TestVMLabelMatchesLabel_GlobSuffixWildcard(t *testing.T) {
+	matched, err := vmLabelMatchesLabel("app-controller", "app-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected suffix wildcard glob match")
+	}
+}
+
+func TestVMLabelMatchesLabel_GlobPrefixWildcard(t *testing.T) {
+	matched, err := vmLabelMatchesLabel("sceptre-app", "*-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected prefix wildcard glob match")
+	}
+}
+
+func TestVMLabelMatchesLabel_GlobMiddleWildcard(t *testing.T) {
+	matched, err := vmLabelMatchesLabel("sceptre-ot-app", "sceptre-*-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected middle wildcard glob match")
+	}
+}
+
+func TestVMLabelMatchesLabel_GlobNoMatch(t *testing.T) {
+	matched, err := vmLabelMatchesLabel("my-label", "app-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if matched {
+		t.Fatal("expected no glob match")
+	}
+}
+
+func TestVMLabelMatchesLabel_GlobCaseInsensitive(t *testing.T) {
+	matched, err := vmLabelMatchesLabel("App-Controller", "app-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected case-insensitive glob match")
+	}
+}
+
+func TestVMLabelMatchesLabel_SingleCharWildcard(t *testing.T) {
+	matched, err := vmLabelMatchesLabel("vm1", "vm?")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected single-char wildcard match")
+	}
+}
+
+func TestVMLabelMatchesLabel_InvalidGlobReturnsError(t *testing.T) {
+	// path.Match returns an error for malformed bracket expressions
+	_, err := vmLabelMatchesLabel("any-label", "[invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid glob pattern")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// vmMatchesAnyLabel
+// ---------------------------------------------------------------------------
+
+func makeVM(tags map[string]string) mm.VM {
+	return mm.VM{
+		Name: "vm-1",
+		Tags: tags,
+	}
+}
+
+func TestVMMatchesAnyLabel_EmptyFilters(t *testing.T) {
+	v := makeVM(map[string]string{"app": "true"})
+
+	matched, err := vmMatchesAnyLabel(v, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if matched {
+		t.Fatal("expected no match for empty filters")
+	}
+}
+
+func TestVMMatchesAnyLabel_AllKeyword(t *testing.T) {
+	v := makeVM(map[string]string{"app": "true"})
+
+	matched, err := vmMatchesAnyLabel(v, []string{"all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected 'all' to match any VM")
+	}
+}
+
+func TestVMMatchesAnyLabel_AllKeywordCaseInsensitive(t *testing.T) {
+	v := makeVM(map[string]string{})
+
+	matched, err := vmMatchesAnyLabel(v, []string{"ALL"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected 'ALL' to match any VM")
+	}
+}
+
+func TestVMMatchesAnyLabel_AllKeywordMatchesVMWithNoLabels(t *testing.T) {
+	v := makeVM(map[string]string{})
+
+	matched, err := vmMatchesAnyLabel(v, []string{"all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected 'all' to match VM even with no labels")
+	}
+}
+
+func TestVMMatchesAnyLabel_ExactLabelMatch(t *testing.T) {
+	v := makeVM(map[string]string{"sceptre-app": "true"})
+
+	matched, err := vmMatchesAnyLabel(v, []string{"sceptre-app"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected exact label to match")
+	}
+}
+
+func TestVMMatchesAnyLabel_NoMatchingLabel(t *testing.T) {
+	v := makeVM(map[string]string{"sceptre-app": "true"})
+
+	matched, err := vmMatchesAnyLabel(v, []string{"other-label"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if matched {
+		t.Fatal("expected no match when label is absent")
+	}
+}
+
+func TestVMMatchesAnyLabel_MultipleFiltersOrSemantics(t *testing.T) {
+	v := makeVM(map[string]string{"label-b": "true"})
+
+	// VM has label-b; filter includes both label-a and label-b, should match.
+	matched, err := vmMatchesAnyLabel(v, []string{"label-a", "label-b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected OR-semantics match when any filter matches")
+	}
+}
+
+func TestVMMatchesAnyLabel_NoLabelsOnVM(t *testing.T) {
+	v := makeVM(nil)
+
+	matched, err := vmMatchesAnyLabel(v, []string{"some-label"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if matched {
+		t.Fatal("expected no match for VM with no labels")
+	}
+}
+
+func TestVMMatchesAnyLabel_GlobMatchesLabel(t *testing.T) {
+	v := makeVM(map[string]string{"sceptre-ot-sim": "true"})
+
+	matched, err := vmMatchesAnyLabel(v, []string{"sceptre-*"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected glob to match label")
+	}
+}
+
+func TestVMMatchesAnyLabel_GlobMatchesOneOfMultipleLabels(t *testing.T) {
+	v := makeVM(map[string]string{
+		"unrelated":   "true",
+		"sceptre-app": "true",
+	})
+
+	matched, err := vmMatchesAnyLabel(v, []string{"sceptre-*"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !matched {
+		t.Fatal("expected glob to match when at least one label matches")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// vmTargetNamesForCommand
+// ---------------------------------------------------------------------------
+
+func newTestRestartCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use: "restart",
+	}
+	addVMLabelFlag(c)
+
+	return c
+}
+
+func TestVMTargetNamesForCommand_MissingExperimentName(t *testing.T) {
+	c := newTestRestartCmd()
+
+	_, _, err := vmTargetNamesForCommand(c, nil)
+	if err == nil {
+		t.Fatal("expected error when no args provided")
+	}
+}
+
+func TestVMTargetNamesForCommand_SingleVMByPositionalArg(t *testing.T) {
+	c := newTestRestartCmd()
+
+	expName, names, err := vmTargetNamesForCommand(c, []string{"my-exp", "vm-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expName != "my-exp" {
+		t.Fatalf("expected experiment 'my-exp', got %q", expName)
+	}
+
+	if len(names) != 1 || names[0] != "vm-1" {
+		t.Fatalf("expected [vm-1], got %v", names)
+	}
+}
+
+func TestVMTargetNamesForCommand_MissingVMNameWithoutFlag(t *testing.T) {
+	c := newTestRestartCmd()
+
+	// Only experiment name, no vm name, no --label flag → error
+	_, _, err := vmTargetNamesForCommand(c, []string{"my-exp"})
+	if err == nil {
+		t.Fatal("expected error when VM name is missing and --label not set")
+	}
+}
+
+func TestVMTargetNamesForCommand_EmptyLabelFlagReturnsError(t *testing.T) {
+	c := newTestRestartCmd()
+	// Set flag but provide no value items (empty string that normalizes away)
+	if err := c.Flags().Set("label", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := vmTargetNamesForCommand(c, []string{"my-exp"})
+	if err == nil {
+		t.Fatal("expected error when --label flag set but produces no filters after normalization")
+	}
+}


### PR DESCRIPTION
# feat: filter 'phenix vm' commands by labels

## Description

Add the `-l`/`--label` flag t `phenix vm` commands. This will apply the given command (e.g. `phenix vm restart`) to VMs that have one or more labels. 

## Related Issue

#299

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

Removed the `testpackage` lint rule, which forces tests to be in a separate package with `_test` appended. This makes it much harder to test private functions without a lot of annoying boilerplate, with little gain.

Also, I need to update docs with this change, will make a PR for that soon.