### PR TITLE
feat: include labels in VM info

### DIFF
--- a/src/go/util/mm/types.go
+++ b/src/go/util/mm/types.go
@@ -231,6 +231,7 @@ type VM struct {
 	CdRom           string            `json:"cdRom"`
 	Tags            map[string]string `json:"tags"`
 	Snapshot        bool              `json:"snapshot"`
+	Labels          map[string]string `json:"labels"`
 
 	// Used internally to track network <--> IP relationship, since
 	// network ordering from minimega may not be the same as network
@@ -238,9 +239,8 @@ type VM struct {
 	Interfaces map[string]string `json:"-"`
 
 	// Used internally for showing VM details.
-	Metadata    map[string]any    `json:"-"`
-	Labels      map[string]string `json:"-"`
-	Annotations map[string]any    `json:"-"`
+	Metadata    map[string]any `json:"-"`
+	Annotations map[string]any `json:"-"`
 
 	// Used internally to check for active CC agent.
 	UUID string `json:"-"`

--- a/src/go/util/printer/printer.go
+++ b/src/go/util/printer/printer.go
@@ -142,6 +142,7 @@ func buildSingleVMTable(table *tablewriter.Table, vm mm.VM) {
 		ifaces   = make([]string, 0, len(vm.Networks))
 		uptime   string
 		metadata []byte
+		labels   []string
 	)
 
 	for idx, nw := range vm.Networks {
@@ -156,6 +157,12 @@ func buildSingleVMTable(table *tablewriter.Table, vm mm.VM) {
 		metadata, _ = json.MarshalIndent(vm.Metadata, "", "  ")
 	}
 
+	if len(vm.Labels) > 0 {
+		for lbl, val := range vm.Labels {
+			labels = append(labels, fmt.Sprintf("%s: %s", lbl, val))
+		}
+	}
+
 	table.Append([]string{"Host", vm.Host})
 	table.Append([]string{"Name", vm.Name})
 	table.Append([]string{"Running", strconv.FormatBool(vm.Running)})
@@ -165,6 +172,7 @@ func buildSingleVMTable(table *tablewriter.Table, vm mm.VM) {
 	table.Append([]string{"VCPUs", strconv.Itoa(vm.CPUs)})
 	table.Append([]string{"Memory", strconv.Itoa(vm.RAM)})
 	table.Append([]string{"OS Type", vm.OSType})
+	table.Append([]string{"Labels", strings.Join(labels, ", ")})
 	table.Append([]string{"Metadata", string(metadata)})
 }
 


### PR DESCRIPTION
# feat: include labels in VM info

## Description

Include the labels for a VM in the output from `phenix vm info`.

## Related Issue

N/A

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes

Tangentially related to https://github.com/sandialabs/sceptre-phenix/pull/302

## Examples

VM with two labels:

```
$ phenix vm info helloworld test1                        
+------------+-----------------------------------------+
|  SETTING   |                  VALUE                  |
+------------+-----------------------------------------+
| Host       | node1                                   |                              
| Name       | test1                                   |                      
| Running    | true                                    |                                                                                                                           | Disk       | /phenix/images/jammy.qc2                |
| Interfaces | ID: 0, IP: 192.168.1.1, VLAN: SW1 (101) |                                                                                                                           
| Uptime     | 6s                                      |                                                                                                                           
| VCPUs      | 1                                       |                                                                                                                           
| Memory     | 512                                     |                      
| OS Type    | linux                                   |                                                                                                                           
| Labels     | groupalpha: true, testvm: true          |                                                                                                                           
| Metadata   |                                         |                                                                                                                           
+------------+-----------------------------------------+ 
```

VM with no labels:

```
$ phenix vm info helloworld unlabelled
+------------+-----------------------------------------+
|  SETTING   |                  VALUE                  |
+------------+-----------------------------------------+
| Host       | node1                                   |
| Name       | unlabelled                              |
| Running    | true                                    |
| Disk       | /phenix/images/jammy.qc2                |
| Interfaces | ID: 0, IP: 192.168.1.3, VLAN: SW1 (101) |
| Uptime     | 1m28s                                   |
| VCPUs      | 1                                       |
| Memory     | 512                                     |
| OS Type    | linux                                   |
| Labels     |                                         |
| Metadata   |                                         |
+------------+-----------------------------------------+
```