### PR TITLE
chore: docker warnings, tag during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all build check clean deb docker examples example-go example-python format generate help help-all install-dev install-wrapper uninstall-wrapper lint run-examples test tunneler ui version
 .DEFAULT_GOAL := help
 
+DOCKER_TAG ?= latest
+
 # Define a helper for checking command existence
 check-command = @if ! command -v $(1) > /dev/null; then \
 		echo "Error: '$(1)' not found. $(2)"; \
@@ -50,7 +52,7 @@ deb:
 docker:
 	$(call check-command,docker,Please install Docker (https://docs.docker.com/get-docker/))
 	@docker info > /dev/null 2>&1 || { echo "Docker daemon is not running"; exit 1; }
-	docker build -t phenix -f docker/Dockerfile .
+	docker build -t phenix:$(DOCKER_TAG) -f docker/Dockerfile .
 
 clean:
 	$(RM) bin/phenix

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,5 @@
+# check=skip=SecretsUsedInArgOrEnv
+
 # Update GitHub workflow config to change the minimum version of minimega
 # required for use with phenix. This build stage is needed for making sure the
 # latest version of the minimega Python module is installed.
@@ -27,8 +29,8 @@ WORKDIR /phenix/src/js
 ARG PHENIX_WEB_AUTH=disabled
 ARG PHENIX_BASE_PATH=/
 
-ENV VUE_APP_AUTH ${PHENIX_WEB_AUTH}
-ENV VUE_BASE_PATH ${PHENIX_BASE_PATH}
+ENV VUE_APP_AUTH=${PHENIX_WEB_AUTH}
+ENV VUE_BASE_PATH=${PHENIX_BASE_PATH}
 
 RUN make dist/index.html
 


### PR DESCRIPTION
# chore: docker warnings, tag during build

## Description

- Fix warnings during build (if buildkit is enabled)
- Add `DOCKER_TAG` variable to Makefile to change the tag built with `make docker`

## Related Issue

N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
~~- [ ] I have made corresponding changes to the documentation.~~
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
