### PR TITLE
fix: improve CLI help message verbosity

### DIFF
--- a/src/go/cmd/completion.go
+++ b/src/go/cmd/completion.go
@@ -71,5 +71,5 @@ PowerShell:
 }
 
 func init() { //nolint:gochecknoinits // cobra command
-	rootCmd.AddCommand(newCompletionCmd())
+	addCommandToRoot(newCompletionCmd(), true)
 }

--- a/src/go/cmd/config.go
+++ b/src/go/cmd/config.go
@@ -513,5 +513,5 @@ func init() { //nolint:gochecknoinits // cobra command
 	configCmd.AddCommand(newConfigEditCmd())
 	configCmd.AddCommand(deleteCmd)
 
-	rootCmd.AddCommand(configCmd)
+	addCommandToRoot(configCmd, true)
 }

--- a/src/go/cmd/experiment.go
+++ b/src/go/cmd/experiment.go
@@ -1000,5 +1000,5 @@ func init() { //nolint:gochecknoinits // cobra command
 	experimentCmd.AddCommand(newExperimentTriggerRunningCmd())
 	experimentCmd.AddCommand(newExperimentScorchCmd())
 
-	rootCmd.AddCommand(experimentCmd)
+	addCommandToRoot(experimentCmd, true)
 }

--- a/src/go/cmd/image.go
+++ b/src/go/cmd/image.go
@@ -621,5 +621,5 @@ func init() { //nolint:gochecknoinits // cobra command
 	imageCmd.AddCommand(newImageUpdateCmd())
 	imageCmd.AddCommand(newImageInjectMiniExeCmd())
 
-	rootCmd.AddCommand(imageCmd)
+	addCommandToRoot(imageCmd, true)
 }

--- a/src/go/cmd/mm.go
+++ b/src/go/cmd/mm.go
@@ -75,7 +75,5 @@ func newMMCmd() *cobra.Command {
 }
 
 func init() { //nolint:gochecknoinits // cobra command
-	mmCmd := newMMCmd()
-
-	rootCmd.AddCommand(mmCmd)
+	addCommandToRoot(newMMCmd(), true)
 }

--- a/src/go/cmd/root.go
+++ b/src/go/cmd/root.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"phenix/api/config"
@@ -531,4 +532,32 @@ func getEffectiveSettings() map[string]any {
 	}
 
 	return vMerge.AllSettings()
+}
+
+// hideInheritedPersistentFlags marks all inherited persistent flags as hidden
+// for the provided command.
+func hideInheritedPersistentFlags(cmd *cobra.Command) {
+	cmd.InheritedFlags().VisitAll(func(f *pflag.Flag) {
+		_ = cmd.Flags().MarkHidden(f.Name)
+		_ = cmd.InheritedFlags().MarkHidden(f.Name)
+	})
+}
+
+// hideInheritedHelp wraps the default help behavior so inherited
+// persistent flags are hidden when help is generated.
+func hideInheritedHelp(cmd *cobra.Command) {
+	defaultHelp := cmd.HelpFunc()
+
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		hideInheritedPersistentFlags(c)
+		defaultHelp(c, args)
+	})
+}
+
+func addCommandToRoot(cmd *cobra.Command, excludeGlobalFlags bool) {
+	if excludeGlobalFlags {
+		hideInheritedHelp(cmd)
+	}
+
+	rootCmd.AddCommand(cmd)
 }

--- a/src/go/cmd/root_help_test.go
+++ b/src/go/cmd/root_help_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newTestRootWithGlobalFlag builds a standalone root command with a
+// persistent ("global") flag, mimicking rootCmd's global flags without
+// touching the package-level rootCmd used by the rest of the CLI.
+func newTestRootWithGlobalFlag() *cobra.Command {
+	root := &cobra.Command{
+		Use:          "phenix",
+		SilenceUsage: true,
+	}
+
+	root.PersistentFlags().String("log.level", "info", "level to log messages at")
+
+	return root
+}
+
+func runHelp(cmd *cobra.Command, args []string) string {
+	var output bytes.Buffer
+
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs(append(args, "--help"))
+
+	_ = cmd.Execute()
+
+	return output.String()
+}
+
+func TestHideInheritedHelpHidesGlobalFlags(t *testing.T) {
+	root := newTestRootWithGlobalFlag()
+
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	hideInheritedHelp(child)
+	root.AddCommand(child)
+
+	got := runHelp(root, []string{"child"})
+
+	if strings.Contains(got, "Global Flags") {
+		t.Fatalf("expected 'Global Flags' section to be hidden, got:\n%s", got)
+	}
+
+	if strings.Contains(got, "log.level") {
+		t.Fatalf("expected inherited --log.level flag to be hidden, got:\n%s", got)
+	}
+}
+
+func TestHideInheritedHelpKeepsGlobalFlagsWhenNotHidden(t *testing.T) {
+	root := newTestRootWithGlobalFlag()
+
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	// No hideInheritedHelp call: global flags should still show up.
+	root.AddCommand(child)
+
+	got := runHelp(root, []string{"child"})
+
+	if !strings.Contains(got, "Global Flags") {
+		t.Fatalf("expected 'Global Flags' section to be present, got:\n%s", got)
+	}
+
+	if !strings.Contains(got, "log.level") {
+		t.Fatalf("expected inherited --log.level flag to be listed, got:\n%s", got)
+	}
+}
+
+func TestHideInheritedHelpAppliesToNestedSubcommands(t *testing.T) {
+	root := newTestRootWithGlobalFlag()
+
+	child := &cobra.Command{Use: "child"}
+	hideInheritedHelp(child)
+
+	grandchild := &cobra.Command{
+		Use: "grandchild",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	// grandchild does not set its own help func, so it should inherit the
+	// hiding behavior from its parent via cobra's HelpFunc() chain.
+	child.AddCommand(grandchild)
+	root.AddCommand(child)
+
+	got := runHelp(root, []string{"child", "grandchild"})
+
+	if strings.Contains(got, "Global Flags") {
+		t.Fatalf("expected 'Global Flags' section to be hidden on nested subcommand, got:\n%s", got)
+	}
+}
+
+func TestHideInheritedHelpDoesNotBreakFlagParsing(t *testing.T) {
+	root := newTestRootWithGlobalFlag()
+
+	var seen string
+
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			seen, _ = cmd.Flags().GetString("log.level")
+			return nil
+		},
+	}
+
+	hideInheritedHelp(child)
+	root.AddCommand(child)
+
+	root.SetArgs([]string{"child", "--log.level", "debug"})
+
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error executing command: %v", err)
+	}
+
+	if seen != "debug" {
+		t.Fatalf("expected hidden --log.level flag to still be parsed, got %q", seen)
+	}
+}

--- a/src/go/cmd/settings.go
+++ b/src/go/cmd/settings.go
@@ -538,21 +538,6 @@ func flattenSettingsMap(prefix string, src map[string]any, dst map[string]any) {
 	}
 }
 
-func init() { //nolint:gochecknoinits // cobra command
-	settingsCmd := newSettingsCmd()
-
-	dbCmd := newSettingsDBCmd()
-	dbCmd.AddCommand(newSettingsDBListCmd())
-	dbCmd.AddCommand(newSettingsDBEditCmd())
-	settingsCmd.AddCommand(dbCmd)
-
-	settingsCmd.AddCommand(newSettingsSetCmd())
-	settingsCmd.AddCommand(newSettingsListCmd())
-	settingsCmd.AddCommand(newSettingsGetCmd())
-	settingsCmd.AddCommand(newSettingsUnsetCmd())
-	rootCmd.AddCommand(settingsCmd)
-}
-
 func inferType(s string) any {
 	// Check for boolean
 	if strings.ToLower(s) == "true" {
@@ -574,4 +559,20 @@ func inferType(s string) any {
 	}
 
 	return s
+}
+
+func init() { //nolint:gochecknoinits // cobra command
+	settingsCmd := newSettingsCmd()
+
+	dbCmd := newSettingsDBCmd()
+	dbCmd.AddCommand(newSettingsDBListCmd())
+	dbCmd.AddCommand(newSettingsDBEditCmd())
+	settingsCmd.AddCommand(dbCmd)
+
+	settingsCmd.AddCommand(newSettingsSetCmd())
+	settingsCmd.AddCommand(newSettingsListCmd())
+	settingsCmd.AddCommand(newSettingsGetCmd())
+	settingsCmd.AddCommand(newSettingsUnsetCmd())
+
+	addCommandToRoot(settingsCmd, true)
 }

--- a/src/go/cmd/ui.go
+++ b/src/go/cmd/ui.go
@@ -140,5 +140,5 @@ func newUICmd() *cobra.Command {
 }
 
 func init() { //nolint:gochecknoinits // cobra command
-	rootCmd.AddCommand(newUICmd())
+	addCommandToRoot(newUICmd(), false)
 }

--- a/src/go/cmd/util.go
+++ b/src/go/cmd/util.go
@@ -142,5 +142,5 @@ func init() { //nolint:gochecknoinits // cobra command
 	utilCmd.AddCommand(newUtilAppJSONCmd())
 	utilCmd.AddCommand(newUtilRoleTableCmd())
 
-	rootCmd.AddCommand(utilCmd)
+	addCommandToRoot(utilCmd, true)
 }

--- a/src/go/cmd/version.go
+++ b/src/go/cmd/version.go
@@ -24,5 +24,5 @@ func newVersionCmd() *cobra.Command {
 }
 
 func init() { //nolint:gochecknoinits // cobra command
-	rootCmd.AddCommand(newVersionCmd())
+	addCommandToRoot(newVersionCmd(), true)
 }

--- a/src/go/cmd/vlan.go
+++ b/src/go/cmd/vlan.go
@@ -187,5 +187,5 @@ func init() { //nolint:gochecknoinits // cobra command
 	vlanCmd.AddCommand(newVlanAliasCmd())
 	vlanCmd.AddCommand(newVlanRangeCmd())
 
-	rootCmd.AddCommand(vlanCmd)
+	addCommandToRoot(vlanCmd, true)
 }

--- a/src/go/cmd/vm.go
+++ b/src/go/cmd/vm.go
@@ -1084,5 +1084,5 @@ func init() { //nolint:gochecknoinits // cobra command
 	vmCmd.AddCommand(newVMCaptureCmd())
 	vmCmd.AddCommand(newVMMemorySnapshotCmd())
 
-	rootCmd.AddCommand(vmCmd)
+	addCommandToRoot(vmCmd, true)
 }


### PR DESCRIPTION
# fix: improve CLI help message verbosity

## Description

Remove listing of 'Global Flags' from most phenix subcommands. These clutter up the output and usually result in needing to scroll up to read the actual command invocation and arguments, which is cumbersome. Most of the global flags aren't used by typical invocations, with the exception of `--log.level`, and they can still be used, they just aren't included in help output.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe): enhancement

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
~~- [ ] I have made corresponding changes to the documentation.~~
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A
