### PR TITLE
fix: make phenix config case-insensitive

### DIFF
--- a/src/go/cmd/config.go
+++ b/src/go/cmd/config.go
@@ -48,11 +48,13 @@ func configKindArgsValidator(multi, allowAll bool) cobra.PositionalArgs {
 				kinds = append(kinds, "all")
 			}
 
-			if kind := tokens[0]; !util.StringSliceContains(kinds, kind) {
+			kind := strings.ToLower(tokens[0])
+
+			if !util.StringSliceContains(kinds, kind) {
 				return fmt.Errorf(
 					"expects the configuration kind to be one of %v, received %s",
 					kinds,
-					kind,
+					tokens[0],
 				)
 			}
 		}

--- a/src/go/store/types.go
+++ b/src/go/store/types.go
@@ -41,6 +41,17 @@ type ConfigMetadata struct {
 	Annotations Annotations `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
+// Performs case-insensitive lookup of a config kind.
+func canonicalKind(kind string) string {
+	for k := range version.StoredVersion {
+		if strings.EqualFold(k, kind) {
+			return k
+		}
+	}
+
+	return ""
+}
+
 func NewConfig(name string) (*Config, error) {
 	n := strings.Split(name, "/")
 
@@ -48,8 +59,10 @@ func NewConfig(name string) (*Config, error) {
 		return nil, fmt.Errorf("invalid config name provided: %s", name)
 	}
 
-	kind, name := n[0], n[1]
-	kind = strings.ToUpper(kind[:1]) + kind[1:]
+	kind, name := canonicalKind(n[0]), n[1]
+	if kind == "" {
+		return nil, fmt.Errorf("invalid config kind provided: %s", n[0])
+	}
 
 	version := version.StoredVersion[kind]
 	version = APIGroup + "/" + version
@@ -179,9 +192,19 @@ func ConfigFullName(name ...string) string {
 			return ""
 		}
 
-		return strings.ToUpper(n[0][:1]) + n[0][1:] + "/" + n[1]
+		kind := canonicalKind(n[0])
+		if kind == "" {
+			return ""
+		}
+
+		return kind + "/" + n[1]
 	} else if len(name) == configNameParts {
-		return strings.ToUpper(name[0][:1]) + name[0][1:] + "/" + name[1]
+		kind := canonicalKind(name[0])
+		if kind == "" {
+			return ""
+		}
+
+		return kind + "/" + name[1]
 	}
 
 	return ""

--- a/src/go/store/types_test.go
+++ b/src/go/store/types_test.go
@@ -1,0 +1,57 @@
+package store
+
+import "testing"
+
+func TestNewConfigKindCaseInsensitive(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		expectKind string
+	}{
+		{name: "lowercase", input: "topology/test-topo", expectKind: "Topology"},
+		{name: "capitalized", input: "Topology/test-topo", expectKind: "Topology"},
+		{name: "uppercase", input: "TOPOLOGY/test-topo", expectKind: "Topology"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := NewConfig(tt.input)
+			if err != nil {
+				t.Fatalf("NewConfig(%q) returned error: %v", tt.input, err)
+			}
+
+			if cfg.Kind != tt.expectKind {
+				t.Fatalf("NewConfig(%q) kind = %q, want %q", tt.input, cfg.Kind, tt.expectKind)
+			}
+		})
+	}
+}
+
+func TestConfigFullNameKindCaseInsensitive(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []string
+		expect string
+	}{
+		{name: "single-arg lowercase", input: []string{"topology/test-topo"}, expect: "Topology/test-topo"},
+		{name: "single-arg uppercase", input: []string{"TOPOLOGY/test-topo"}, expect: "Topology/test-topo"},
+		{name: "two-arg lowercase", input: []string{"topology", "test-topo"}, expect: "Topology/test-topo"},
+		{name: "two-arg uppercase", input: []string{"TOPOLOGY", "test-topo"}, expect: "Topology/test-topo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConfigFullName(tt.input...)
+			if got != tt.expect {
+				t.Fatalf("ConfigFullName(%v) = %q, want %q", tt.input, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestNewConfigRejectsUnknownKind(t *testing.T) {
+	_, err := NewConfig("notakind/test")
+	if err == nil {
+		t.Fatal("NewConfig should reject unknown kinds")
+	}
+}


### PR DESCRIPTION
# fix: make phenix config case-insensitive

## Description

Change `phenix config` to do case-insensitive lookups and checks for the kind of config, e.g. `Topology`, `topology`, `TOPOLOGY`. 

The following command will now work: `phenix config delete Topology/mytopo`

## Related Issue

Fixes #92

Blocked by lint config change in #302 

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

Only took 4 years for me to finally fix this :smile:
