### PR TITLE
fix: add additional wmi retry to windows startup

### DIFF
--- a/src/go/tmpl/templates/windows_startup.tmpl
+++ b/src/go/tmpl/templates/windows_startup.tmpl
@@ -87,13 +87,22 @@ if (Phenix-StartupStatusIs('running')) {
 {{ end }}
 
 echo 'Configuring network interfaces...'
-
-$wmi = $null
-Do {
-    Start-Sleep -Milliseconds 1000
-    $wmi = gwmi win32_NetworkAdapterConfiguration -Filter 'ipenabled = "true"' | sort -Property Description
-} While ($wmi -eq $null)
 {{ $length := len .Node.Network.Interfaces }}
+
+$wmi = $null  
+$maxRetries = 100 
+$retryCount = 0 
+Do {  
+    Start-Sleep -Milliseconds 1000  
+    $wmi = gwmi win32_NetworkAdapterConfiguration -Filter 'ipenabled = "true"' | sort -Property Description  
+    $retryCount++  
+      
+    if ($retryCount -ge $maxRetries) {  
+        Write-Host "Timeout waiting for IP-enabled network adapters"  
+        exit 1  
+    }  
+} While ($wmi -eq $null -or @($wmi).Count -lt {{ $length }})  
+
 {{ range $idx, $iface := .Node.Network.Interfaces }}
     {{ if and (eq $iface.Proto "static") (not $iface.QinQ) }}
 Do {


### PR DESCRIPTION
# Add additional wmi retry to windows startup

## Description
If VM is slow to initialize, WMI query may return empty array instead of null. Adding additional logic to the retry loop to wait for fully initialized network adapters.  

## Related Issue
NA

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
NA