### PR TITLE
fix(mm): add stability for minimega commands across hosts

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -18,14 +18,16 @@ jobs:
       contents: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Get short SHA
         run: |
           echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -33,7 +35,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/phenix
           tags: |
@@ -41,7 +43,7 @@ jobs:
             type=ref,event=tag
             type=sha
       - name: Build container image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
@@ -54,6 +56,9 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           load: true
           tags: ${{ steps.meta.outputs.tags }}
+          provenance: false
+          cache-from: type=gha,scope=phenix
+          cache-to: type=gha,mode=max,scope=phenix
 
       - name: Build Debian Package
         env:
@@ -75,7 +80,7 @@ jobs:
 
       - name: Docker meta for JIT UI
         id: meta-jit
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/phenix-jit-ui
           tags: |
@@ -83,7 +88,7 @@ jobs:
             type=ref,event=tag
             type=sha
       - name: Build JIT container image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: docker/jit
           file: docker/jit/Dockerfile
@@ -93,5 +98,8 @@ jobs:
             PHENIX_BRANCH=${{ github.head_ref || github.ref_name }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-jit.outputs.tags }}
+          provenance: false
+          cache-from: type=gha,scope=phenix-jit
+          cache-to: type=gha,mode=max,scope=phenix-jit
     outputs:
       image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}

--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -1548,17 +1548,6 @@ func (s SOH) customTest( //nolint:funlen // complex logic
 	}
 
 	// All three paths below must agree on the same minimega-relative path
-	// (<ns>/<script>): the file is written under minimega's files directory,
-	// `cc send` resolves it relative to that same directory and delivers it to
-	// the VM preserving the relative path (so it lands at
-	// /tmp/miniccc/files/<ns>/<script>), and the executor must invoke it from
-	// that same location. Keeping these in sync via a single relPath avoids the
-	// mismatch where the file is delivered to the <ns>/ subdir but executed from
-	// the root, which makes every custom test fail.
-	//
-	// The write base is resolved from minimega's configured files directory
-	// (GetMMFullPath) rather than assuming PhenixBase/images, so it tracks
-	// whatever MM_FILEPATH the deployment uses.
 	relPath := fmt.Sprintf("%s/%s", ns, script)
 
 	path := mm.GetMMFullPath(relPath)

--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -19,7 +19,6 @@ import (
 	"phenix/types"
 	ifaces "phenix/types/interfaces"
 	"phenix/types/version"
-	"phenix/util/common"
 	"phenix/util/mm"
 	"phenix/util/plog"
 )
@@ -1548,7 +1547,21 @@ func (s SOH) customTest( //nolint:funlen // complex logic
 		script += ".ps1"
 	}
 
-	path := fmt.Sprintf("%s/images/%s/%s", common.PhenixBase, ns, script)
+	// All three paths below must agree on the same minimega-relative path
+	// (<ns>/<script>): the file is written under minimega's files directory,
+	// `cc send` resolves it relative to that same directory and delivers it to
+	// the VM preserving the relative path (so it lands at
+	// /tmp/miniccc/files/<ns>/<script>), and the executor must invoke it from
+	// that same location. Keeping these in sync via a single relPath avoids the
+	// mismatch where the file is delivered to the <ns>/ subdir but executed from
+	// the root, which makes every custom test fail.
+	//
+	// The write base is resolved from minimega's configured files directory
+	// (GetMMFullPath) rather than assuming PhenixBase/images, so it tracks
+	// whatever MM_FILEPATH the deployment uses.
+	relPath := fmt.Sprintf("%s/%s", ns, script)
+
+	path := mm.GetMMFullPath(relPath)
 
 	err := os.WriteFile(path, []byte(test.TestScript), 0o600)
 	if err != nil {
@@ -1557,11 +1570,11 @@ func (s SOH) customTest( //nolint:funlen // complex logic
 		return
 	}
 
-	command := fmt.Sprintf("%s /tmp/miniccc/files/%s", executor, script)
+	command := fmt.Sprintf("%s /tmp/miniccc/files/%s", executor, relPath)
 	opts := []mm.C2Option{
 		mm.C2NS(ns),
 		mm.C2VM(host),
-		mm.C2SendFile(script),
+		mm.C2SendFile(relPath),
 		mm.C2Command(command),
 		mm.C2Timeout(s.md.c2Timeout),
 	}

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -229,11 +229,7 @@ func (m Minimega) GetVMInfo(opts ...Option) VMs { //nolint:funlen // complex log
 		vm.RAM, _ = strconv.Atoi(row["memory"])
 		vm.CPUs, _ = strconv.Atoi(row["vcpus"])
 
-		// The disks column can be empty (e.g. a VM that was queued but never fully
-		// configured, or a malformed/partial response from a mesh node). Guard the
-		// slice access so a missing disk doesn't panic with an index out of range.
 		var disk string
-
 		// TODO: confirm multiple disks are separated by whitespace.
 		if fields := strings.Fields(row["disks"]); len(fields) > 0 {
 			// diskspec can include multiple settings separated by comma. Path to
@@ -950,10 +946,7 @@ func (m Minimega) IsHeadnode(node string) bool {
 
 	head := m.Headnode()
 
-	// If we can't determine the headnode, fail safe by assuming the command
-	// targets the local node. Returning false here would make callers build a
-	// `mesh send <node> ...` that minimega rejects with "cannot mesh send
-	// yourself" when <node> is in fact the headnode.
+	// If we can't determine the headnode, assume the local node
 	if head == "" {
 		plog.Warn(
 			plog.TypeSystem,
@@ -968,8 +961,7 @@ func (m Minimega) IsHeadnode(node string) bool {
 		return true
 	}
 
-	// Fall back to the local hostname to cover FQDN vs. short-name mismatches
-	// between what minimega reports as the headnode and what a caller passes in.
+	// Fall back to the local hostname
 	if local, err := os.Hostname(); err == nil {
 		if node == common.TrimHostnameSuffixes(local) {
 			return true
@@ -1056,13 +1048,9 @@ func (Minimega) IsC2ClientActive(opts ...C2Option) error {
 			return ErrC2ClientNotActive
 		default:
 			rows, err := mmcli.RunTabularErr(cmd)
+			// For transient mesh error, poll within the timeout budget
 			if err != nil {
 				if mmcli.IsTransientErr(err) {
-					// A swallowed transient mesh/connection error looks identical
-					// to "no client". Keep polling within the timeout budget
-					// instead of falsely concluding the client is not active --
-					// that false negative is what fails SOH on multi-node
-					// reservations.
 					plog.Warn(
 						plog.TypeSystem,
 						"transient error checking C2 client; retrying",
@@ -1542,12 +1530,10 @@ func waitForResponse(ctx context.Context, ns, id string, timeout time.Duration) 
 	cmd.Columns = []string{"id", "responses"}
 	cmd.Filters = []string{"id=" + id}
 
-	// On a multi-node cluster `cc commands` returns one row per cluster host.
-	// Because `ExecC2Command` sets the filter to a specific VM, only the host
-	// running that VM will report a response; the others report zero responses
-	// and a host that doesn't know the command may even return an error. So a
-	// valid row from any one host is sufficient, and a sibling host's error is
-	// noise unless no host returned a row at all.
+	// Multiple rows will come back for each command ID, one row per cluster host.
+	// Because the `ExecC2Command` sets the filter to a specific VM, only one of
+	// the rows will have a response since a VM can only run on a single cluster
+	// host. A valid row from any one host is sufficient.
 
 	after := time.After(timeout)
 
@@ -1559,10 +1545,6 @@ func waitForResponse(ctx context.Context, ns, id string, timeout time.Duration) 
 			return fmt.Errorf("timeout waiting for response for command %s", id)
 		default:
 			rows, err := mmcli.RunTabularErr(cmd)
-
-			// Only act on the error when no host returned a usable row -- a valid
-			// row elsewhere means the command exists and the error is just a
-			// sibling host that isn't running the VM.
 			if err != nil && len(rows) == 0 && !mmcli.IsTransientErr(err) {
 				return fmt.Errorf("waiting for response for command %s: %w", id, err)
 			}
@@ -1573,12 +1555,7 @@ func waitForResponse(ctx context.Context, ns, id string, timeout time.Duration) 
 				}
 			}
 
-			// The command may not be visible in `cc commands` the instant after
-			// it's issued (id assignment vs. mesh propagation), and the response
-			// may not have arrived yet. Keep polling within the timeout instead of
-			// failing the moment the row or response is absent -- that race is
-			// what intermittently fails networking/reachability checks on
-			// multi-node reservations.
+			//  Keep polling within the timeout
 			time.Sleep(responseWaitInterval)
 		}
 	}

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -229,15 +229,21 @@ func (m Minimega) GetVMInfo(opts ...Option) VMs { //nolint:funlen // complex log
 		vm.RAM, _ = strconv.Atoi(row["memory"])
 		vm.CPUs, _ = strconv.Atoi(row["vcpus"])
 
+		// The disks column can be empty (e.g. a VM that was queued but never fully
+		// configured, or a malformed/partial response from a mesh node). Guard the
+		// slice access so a missing disk doesn't panic with an index out of range.
+		var disk string
+
 		// TODO: confirm multiple disks are separated by whitespace.
-		disk := strings.Fields(row["disks"])[0]
-		// diskspec can include multiple settings separated by comma. Path to disk
-		// will always be first setting.
-		disk = strings.Split(disk, ",")[0]
+		if fields := strings.Fields(row["disks"]); len(fields) > 0 {
+			// diskspec can include multiple settings separated by comma. Path to
+			// disk will always be first setting.
+			disk = strings.Split(fields[0], ",")[0]
+		}
 
 		snapshot, _ := strconv.ParseBool(row["snapshot"])
 
-		if snapshot {
+		if snapshot && disk != "" {
 			cmd = mmcli.NewCommand()
 			cmd.Command = "disk info " + disk
 
@@ -806,10 +812,18 @@ func (Minimega) GetExperimentCaptures(opts ...Option) []Capture {
 		}
 
 		// `interface` column will be in the form of <vm_name>:<iface_idx>
-		iface := strings.Split(row["interface"], ":")
+		vm, idxStr, ok := strings.Cut(row["interface"], ":")
+		if !ok {
+			plog.Warn(
+				plog.TypeSystem,
+				"unexpected capture interface format",
+				"interface", row["interface"],
+			)
 
-		vm := iface[0]
-		idx, _ := strconv.Atoi(iface[1])
+			continue
+		}
+
+		idx, _ := strconv.Atoi(idxStr)
 
 		capture := Capture{
 			VM:        vm,
@@ -934,7 +948,35 @@ func (m Minimega) IsHeadnode(node string) bool {
 	// Docker containers by Docker Compose config.
 	node = common.TrimHostnameSuffixes(node)
 
-	return node == m.Headnode()
+	head := m.Headnode()
+
+	// If we can't determine the headnode, fail safe by assuming the command
+	// targets the local node. Returning false here would make callers build a
+	// `mesh send <node> ...` that minimega rejects with "cannot mesh send
+	// yourself" when <node> is in fact the headnode.
+	if head == "" {
+		plog.Warn(
+			plog.TypeSystem,
+			"headnode unknown; assuming local to avoid mesh-send-to-self",
+			"node", node,
+		)
+
+		return true
+	}
+
+	if node == head {
+		return true
+	}
+
+	// Fall back to the local hostname to cover FQDN vs. short-name mismatches
+	// between what minimega reports as the headnode and what a caller passes in.
+	if local, err := os.Hostname(); err == nil {
+		if node == common.TrimHostnameSuffixes(local) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (m Minimega) GetMMArgs() (map[string]string, error) {
@@ -1013,7 +1055,28 @@ func (Minimega) IsC2ClientActive(opts ...C2Option) error {
 		case <-after:
 			return ErrC2ClientNotActive
 		default:
-			rows := mmcli.RunTabular(cmd)
+			rows, err := mmcli.RunTabularErr(cmd)
+			if err != nil {
+				if mmcli.IsTransientErr(err) {
+					// A swallowed transient mesh/connection error looks identical
+					// to "no client". Keep polling within the timeout budget
+					// instead of falsely concluding the client is not active --
+					// that false negative is what fails SOH on multi-node
+					// reservations.
+					plog.Warn(
+						plog.TypeSystem,
+						"transient error checking C2 client; retrying",
+						"vm", o.vm,
+						"err", err,
+					)
+
+					time.Sleep(c2ActiveCheckInterval)
+
+					continue
+				}
+
+				return fmt.Errorf("checking C2 client for %s: %w", o.vm, err)
+			}
 
 			if len(rows) != 0 {
 				return nil
@@ -1479,10 +1542,12 @@ func waitForResponse(ctx context.Context, ns, id string, timeout time.Duration) 
 	cmd.Columns = []string{"id", "responses"}
 	cmd.Filters = []string{"id=" + id}
 
-	// Multiple rows will come back for each command ID, one row per cluster host.
-	// Because the `ExecC2Command` sets the filter to a specific VM, only one of
-	// the rows will have a response since a VM can only run on a single cluster
-	// host.
+	// On a multi-node cluster `cc commands` returns one row per cluster host.
+	// Because `ExecC2Command` sets the filter to a specific VM, only the host
+	// running that VM will report a response; the others report zero responses
+	// and a host that doesn't know the command may even return an error. So a
+	// valid row from any one host is sufficient, and a sibling host's error is
+	// noise unless no host returned a row at all.
 
 	after := time.After(timeout)
 
@@ -1493,22 +1558,27 @@ func waitForResponse(ctx context.Context, ns, id string, timeout time.Duration) 
 		case <-after:
 			return fmt.Errorf("timeout waiting for response for command %s", id)
 		default:
-			rows := mmcli.RunTabular(cmd)
+			rows, err := mmcli.RunTabularErr(cmd)
 
-			if len(rows) == 0 {
-				return fmt.Errorf("no commands returned for ID %s", id)
-			}
-
-			if rid := rows[0]["id"]; rid != id {
-				return fmt.Errorf("wrong command returned: %s", rid)
+			// Only act on the error when no host returned a usable row -- a valid
+			// row elsewhere means the command exists and the error is just a
+			// sibling host that isn't running the VM.
+			if err != nil && len(rows) == 0 && !mmcli.IsTransientErr(err) {
+				return fmt.Errorf("waiting for response for command %s: %w", id, err)
 			}
 
 			for _, row := range rows {
-				if row["responses"] != "0" {
+				if row["id"] == id && row["responses"] != "0" {
 					return nil
 				}
 			}
 
+			// The command may not be visible in `cc commands` the instant after
+			// it's issued (id assignment vs. mesh propagation), and the response
+			// may not have arrived yet. Keep polling within the timeout instead of
+			// failing the moment the row or response is absent -- that race is
+			// what intermittently fails networking/reachability checks on
+			// multi-node reservations.
 			time.Sleep(responseWaitInterval)
 		}
 	}

--- a/src/go/util/mm/mmcli/classify.go
+++ b/src/go/util/mm/mmcli/classify.go
@@ -1,0 +1,77 @@
+package mmcli
+
+import (
+	"errors"
+	"strings"
+)
+
+// transientSubstrings are matched (case-insensitively) against an error's text.
+// These represent conditions that commonly clear on a retry, especially when a
+// command is fanned out to remote nodes over minimega's mesh (meshage).
+var transientSubstrings = []string{ //nolint:gochecknoglobals // lookup table
+	"broken pipe",
+	"use of closed network connection",
+	"connection refused",
+	"connection reset",
+	"server disconnected", // miniclient EOF
+	"i/o timeout",
+	"meshage", // generic meshage transport errors
+	"timeout",
+}
+
+// permanentSubstrings are matched (case-insensitively) and ALWAYS win over a
+// transient match. These are genuine logic/usage errors that will never clear
+// on retry. Notably "cannot mesh send yourself" contains no transient token but
+// must never be retried.
+var permanentSubstrings = []string{ //nolint:gochecknoglobals // lookup table
+	"cannot mesh send yourself",
+	"vm not found",
+	"vm not running",
+	"namespace must be active",
+	"invalid command",
+	"expected", // minicli syntax errors ("expected ...")
+	"no such handler",
+}
+
+// isPermanentErr reports whether err is a permanent error that must not be
+// retried.
+func isPermanentErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	s := strings.ToLower(err.Error())
+
+	for _, p := range permanentSubstrings {
+		if strings.Contains(s, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsTransientErr reports whether err is transient -- i.e. worth re-polling
+// rather than treating as a hard failure. Permanent matches short-circuit to
+// false so they are never mistaken for a recoverable blip. It is exported so
+// callers outside this package (the mm package's C2/response polling loops) can
+// make the same transient-vs-permanent distinction.
+func IsTransientErr(err error) bool {
+	if err == nil || isPermanentErr(err) {
+		return false
+	}
+
+	if errors.Is(err, ErrTimeout) {
+		return true
+	}
+
+	s := strings.ToLower(err.Error())
+
+	for _, t := range transientSubstrings {
+		if strings.Contains(s, t) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/src/go/util/mm/mmcli/classify.go
+++ b/src/go/util/mm/mmcli/classify.go
@@ -6,8 +6,7 @@ import (
 )
 
 // transientSubstrings are matched (case-insensitively) against an error's text.
-// These represent conditions that commonly clear on a retry, especially when a
-// command is fanned out to remote nodes over minimega's mesh (meshage).
+// These represent conditions that can clear on a retry.
 var transientSubstrings = []string{ //nolint:gochecknoglobals // lookup table
 	"broken pipe",
 	"use of closed network connection",
@@ -21,8 +20,7 @@ var transientSubstrings = []string{ //nolint:gochecknoglobals // lookup table
 
 // permanentSubstrings are matched (case-insensitively) and ALWAYS win over a
 // transient match. These are genuine logic/usage errors that will never clear
-// on retry. Notably "cannot mesh send yourself" contains no transient token but
-// must never be retried.
+// on retry.
 var permanentSubstrings = []string{ //nolint:gochecknoglobals // lookup table
 	"cannot mesh send yourself",
 	"vm not found",
@@ -51,11 +49,7 @@ func isPermanentErr(err error) bool {
 	return false
 }
 
-// IsTransientErr reports whether err is transient -- i.e. worth re-polling
-// rather than treating as a hard failure. Permanent matches short-circuit to
-// false so they are never mistaken for a recoverable blip. It is exported so
-// callers outside this package (the mm package's C2/response polling loops) can
-// make the same transient-vs-permanent distinction.
+// IsTransientErr reports whether err is transient rather than treating as a hard failure.
 func IsTransientErr(err error) bool {
 	if err == nil || isPermanentErr(err) {
 		return false

--- a/src/go/util/mm/mmcli/classify_test.go
+++ b/src/go/util/mm/mmcli/classify_test.go
@@ -1,0 +1,43 @@
+package mmcli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsTransientErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"broken pipe", errors.New("write unix: broken pipe"), true},
+		{"closed conn", errors.New("read tcp: use of closed network connection"), true},
+		{"connection reset", errors.New("connection reset by peer"), true},
+		{"meshage", errors.New("meshage: timed out waiting for ACK"), true},
+		{"wrapped ErrTimeout", fmt.Errorf("running cmd: %w", ErrTimeout), true},
+		{"case insensitive", errors.New("BROKEN PIPE"), true},
+
+		{"mesh send yourself", errors.New("cannot mesh send yourself"), false},
+		{"vm not found", errors.New("vm not found: foo"), false},
+		{"syntax", errors.New("expected one of: ..."), false},
+		{"unknown", errors.New("something else entirely"), false},
+
+		// permanent classification wins even when a transient token is present.
+		{"permanent beats transient", errors.New("namespace must be active: connection reset by peer"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := IsTransientErr(tc.err); got != tc.want {
+				t.Errorf("IsTransientErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/go/util/mm/mmcli/client.go
+++ b/src/go/util/mm/mmcli/client.go
@@ -19,8 +19,9 @@ import (
 var ErrTimeout = errors.New("timeout running command")
 
 var (
-	mu sync.Mutex       //nolint:gochecknoglobals // global lock
-	mm *miniclient.Conn //nolint:gochecknoglobals // global connection
+	mu     sync.Mutex       //nolint:gochecknoglobals // global lock
+	mm     *miniclient.Conn //nolint:gochecknoglobals // global connection
+	mmDead bool             //nolint:gochecknoglobals // flags mm for replacement
 )
 
 func wrapErr(err error) chan *miniclient.Response {
@@ -136,55 +137,94 @@ func SingleDataResponse(responses chan *miniclient.Response) (any, error) {
 	return data, err
 }
 
+// conn returns a usable connection to minimega, dialing or redialing as needed.
+// The caller must hold mu.
+func conn() (*miniclient.Conn, error) {
+	if mm == nil || mmDead {
+		c, err := miniclient.Dial(common.MinimegaBase)
+		if err != nil {
+			return nil, fmt.Errorf("unable to dial: %w", err)
+		}
+
+		mm, mmDead = c, false
+	}
+
+	// If the connection is already in a broken state, redial.
+	if err := mm.Error(); err != nil {
+		s := err.Error()
+
+		if strings.Contains(s, "broken pipe") || strings.Contains(s, "no such file or directory") {
+			c, err := miniclient.Dial(common.MinimegaBase)
+			if err != nil {
+				return nil, fmt.Errorf("unable to redial: %w", err)
+			}
+
+			mm, mmDead = c, false
+		} else {
+			return nil, fmt.Errorf("minimega error: %w", err)
+		}
+	}
+
+	return mm, nil
+}
+
+// markDead flags the given connection for replacement on the next call, but only
+// if it is still the current connection. The identity check stops a stale
+// timeout from clobbering a connection that a later call already redialed.
+func markDead(c *miniclient.Conn) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if mm == c {
+		mmDead = true
+	}
+}
+
 // Run dials the minimega Unix socket and runs the given command, automatically
 // redialing if disconnected. Any errors encountered will be returned as part of
 // the response channel.
 func Run(c *Command) chan *miniclient.Response {
 	mu.Lock()
-	defer mu.Unlock()
 
-	var err error
+	active, err := conn()
+	if err != nil {
+		mu.Unlock()
 
-	if mm == nil {
-		if mm, err = miniclient.Dial(common.MinimegaBase); err != nil {
-			return wrapErr(fmt.Errorf("unable to dial: %w", err))
-		}
+		return wrapErr(err)
 	}
 
-	// check if there's already an error and try to redial
-	if err := mm.Error(); err != nil {
-		s := err.Error()
+	// Build the command string and release mu before waiting on the response.
+	// The connection's own internal lock serializes the actual exchange, so we
+	// don't need to (and must not) hold mu across a potentially slow command --
+	// doing so would serialize all minimega traffic behind one slow command.
+	cmdStr := c.String()
 
-		if strings.Contains(s, "broken pipe") || strings.Contains(s, "no such file or directory") {
-			if mm, err = miniclient.Dial(common.MinimegaBase); err != nil {
-				return wrapErr(fmt.Errorf("unable to redial: %w", err))
-			}
-		} else {
-			return wrapErr(fmt.Errorf("minimega error: %w", err))
-		}
-	}
+	mu.Unlock()
 
 	if c.Timeout == 0 {
-		return mm.Run(c.String())
+		return active.Run(cmdStr)
 	}
 
 	var (
-		resp chan *miniclient.Response
+		resp = make(chan chan *miniclient.Response, 1)
 		done = make(chan struct{})
 	)
 
 	go func() {
-		resp = mm.Run(c.String())
+		resp <- active.Run(cmdStr)
 
 		close(done)
 	}()
 
 	select {
 	case <-done:
-		return resp
+		return <-resp
 	case <-time.After(c.Timeout):
-		// Reset mm since the miniclient has a lock that is likely still activated.
-		mm = nil
+		// Dispatch is stuck (the connection's internal lock is likely held by a
+		// previous unresponsive command). Flag this connection for replacement so
+		// the next call redials, rather than nil-ing out a shared pointer that
+		// live readers may still reference.
+		markDead(active)
 
 		return wrapErr(ErrTimeout)
 	}

--- a/src/go/util/mm/mmcli/tabular.go
+++ b/src/go/util/mm/mmcli/tabular.go
@@ -3,6 +3,7 @@
 package mmcli
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/activeshadow/libminimega/minicli"
@@ -50,10 +51,16 @@ func tabularToMapCols(columns []string) tabularToMapper {
 	}
 }
 
-// RunTabular is used to run the given command when the response is expected to
-// be in tabular form. A slice of maps is returned, with each map representing a
-// row in the tabular response and each map key representing the column.
-func RunTabular(cmd *Command) []map[string]string {
+// RunTabularErr is used to run the given command when the response is expected
+// to be in tabular form. It returns a slice of maps (each map a row, keyed by
+// column) along with the FIRST error encountered in any response. Rows that
+// were parsed before the error are still returned so the caller can decide how
+// to treat partial data.
+//
+// Callers that need to distinguish a transient failure (e.g. a mesh node
+// hiccup) from a genuinely empty result should use this instead of RunTabular,
+// which discards errors.
+func RunTabularErr(cmd *Command) ([]map[string]string, error) {
 	// copy all fields in header order
 	mapper := tabularToMap
 
@@ -64,17 +71,14 @@ func RunTabular(cmd *Command) []map[string]string {
 
 	res := []map[string]string{}
 
+	var firstErr error
+
 	for resps := range Run(cmd) {
 		for _, resp := range resps.Resp {
 			if resp.Error != "" {
-				plog.Error(
-					plog.TypeSystem,
-					"error running mm cmd",
-					"cmd",
-					cmd.Command,
-					"error",
-					resp.Error,
-				)
+				if firstErr == nil {
+					firstErr = errors.New(resp.Error)
+				}
 
 				continue
 			}
@@ -85,5 +89,26 @@ func RunTabular(cmd *Command) []map[string]string {
 		}
 	}
 
-	return res
+	return res, firstErr
+}
+
+// RunTabular is used to run the given command when the response is expected to
+// be in tabular form. A slice of maps is returned, with each map representing a
+// row in the tabular response and each map key representing the column. Any
+// error encountered is logged and discarded; callers that need to act on the
+// error should use RunTabularErr.
+func RunTabular(cmd *Command) []map[string]string {
+	rows, err := RunTabularErr(cmd)
+	if err != nil {
+		plog.Error(
+			plog.TypeSystem,
+			"error running mm cmd",
+			"cmd",
+			cmd.Command,
+			"error",
+			err.Error(),
+		)
+	}
+
+	return rows
 }


### PR DESCRIPTION
# fix(mm): add stability for minimega commands across hosts

## Description
 Several new patterns to stablize mm commands in mutli-host clusters:
* C2 and command-response checks now poll within their timeout instead of failing the instant a client or command row isn't yet visible across the mesh
* `RunTabular` no longer silently swallows minimega errors. A new `RunTabularErr` lets callers tell a transient mesh hiccup apart from an empty result
* The minimega client no longer holds its global lock across a command's timeout and no longer races on the shared connection when one times out.
* VM-info and capture parsing are guarded against index-out-of-range panics
* headnode detection is hardened to avoid "cannot mesh send yourself" messages
* Custom SOH test scripts now use one consistent minimega-relative path for the write, `cc send`, and execution

> [!NOTE]
> I have 2 commits here, intentionally not squashed. The second is to update some CI actions that were preventing builds.

## Related Issue
* closes #274

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- ~New feature~
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [ ] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
* Stability in the python apps needs to be addressed there [sceptre-phenix-apps#109](https://github.com/sandialabs/sceptre-phenix-apps/pull/109)
* I want to do some heavy testing before marking ready, don't hold your breath