### PR TITLE
fix: remove 'phenix vm set' command

### DIFF
--- a/src/go/cmd/vm.go
+++ b/src/go/cmd/vm.go
@@ -501,25 +501,6 @@ func newVMKillCmd() *cobra.Command {
 	return cmd
 }
 
-func newVMSetCmd() *cobra.Command {
-	desc := `Set configuration value for a VM
-
-  Used to set a configuration value for a virtual machine in a stopped
-  experiment. This command is not yet implemented. For now, you can edit the
-  experiment directly with 'phenix config edit'`
-
-	cmd := &cobra.Command{
-		Use:   "set",
-		Short: "Set configuration value for a VM",
-		Long:  desc,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
-		},
-	}
-
-	return cmd
-}
-
 func newVMNetConnectCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:               "connect <experiment name> <vm name> <iface index> <vlan id>",
@@ -960,7 +941,6 @@ func init() { //nolint:gochecknoinits // cobra command
 	vmCmd.AddCommand(newVMRedeployCmd())
 	vmCmd.AddCommand(newVMShutdownCmd())
 	vmCmd.AddCommand(newVMKillCmd())
-	vmCmd.AddCommand(newVMSetCmd())
 	vmCmd.AddCommand(newVMNetCmd())
 	vmCmd.AddCommand(newVMCaptureCmd())
 	vmCmd.AddCommand(newVMMemorySnapshotCmd())


### PR DESCRIPTION
# fix: remove 'phenix vm set' command

## Description

This command was added 5 years ago as a stub and never implemented. Removing it reduces maintainence burden and user confusion.

## Related Issue

N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- ~~[ ] I have commented my code, particularly in hard-to-understand areas.~~
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
N/A
