### PR TITLE
fix(mm): add stability for minimega commands across hosts

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -18,14 +18,16 @@ jobs:
       contents: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Get short SHA
         run: |
           echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -33,7 +35,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/phenix
           tags: |
@@ -41,7 +43,8 @@ jobs:
             type=ref,event=tag
             type=sha
       - name: Build container image
-        uses: docker/build-push-action@v3
+        id: build-main
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
@@ -51,9 +54,15 @@ jobs:
             PHENIX_TAG=${{ steps.meta.outputs.version }}
             APPS_REPO=github.com/${{ github.event_name == 'repository_dispatch' && github.event.client_payload.repo || 'sandialabs/sceptre-phenix-apps' }}
             APPS_BRANCH=main
-          push: ${{ github.event_name != 'pull_request' }}
-          load: true
           tags: ${{ steps.meta.outputs.tags }}
+          provenance: false
+          cache-from: type=gha,scope=phenix
+          cache-to: type=gha,mode=max,scope=phenix
+          # docker = load to dockerd for the deb step; oci = JIT FROM source; registry = push on non-PR only.
+          outputs: |
+            type=docker
+            type=oci,dest=/tmp/phenix-oci,tar=false
+            ${{ github.event_name != 'pull_request' && 'type=registry' || '' }}
 
       - name: Build Debian Package
         env:
@@ -75,7 +84,7 @@ jobs:
 
       - name: Docker meta for JIT UI
         id: meta-jit
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/phenix-jit-ui
           tags: |
@@ -83,7 +92,7 @@ jobs:
             type=ref,event=tag
             type=sha
       - name: Build JIT container image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: docker/jit
           file: docker/jit/Dockerfile
@@ -91,7 +100,14 @@ jobs:
             PHENIX_REPO=${{ github.event.pull_request.head.repo.full_name || github.repository }}
             PHENIX_IMG=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
             PHENIX_BRANCH=${{ github.head_ref || github.ref_name }}
-          push: ${{ github.event_name != 'pull_request' }}
+          # Resolve FROM from the on-disk OCI layout so PR builds work without the parent in ghcr.
+          build-contexts: |
+            ${{ fromJSON(steps.meta.outputs.json).tags[0] }}=oci-layout:///tmp/phenix-oci@${{ steps.build-main.outputs.digest }}
           tags: ${{ steps.meta-jit.outputs.tags }}
+          provenance: false
+          cache-from: type=gha,scope=phenix-jit
+          cache-to: type=gha,mode=max,scope=phenix-jit
+          outputs: |
+            ${{ github.event_name != 'pull_request' && 'type=registry' || 'type=cacheonly' }}
     outputs:
       image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}

--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -19,7 +19,6 @@ import (
 	"phenix/types"
 	ifaces "phenix/types/interfaces"
 	"phenix/types/version"
-	"phenix/util/common"
 	"phenix/util/mm"
 	"phenix/util/plog"
 )
@@ -1548,8 +1547,9 @@ func (s SOH) customTest( //nolint:funlen // complex logic
 		script += ".ps1"
 	}
 
-	path := fmt.Sprintf("%s/images/%s/%s", common.PhenixBase, ns, script)
-
+	// All three paths below must agree on the same minimega-relative path
+	relPath := fmt.Sprintf("%s/%s", ns, script)
+	path := mm.GetMMFullPath(relPath)
 	err := os.WriteFile(path, []byte(test.TestScript), 0o600)
 	if err != nil {
 		wg.AddError(fmt.Errorf("unable to write test script to file: %w", err), meta)
@@ -1557,11 +1557,11 @@ func (s SOH) customTest( //nolint:funlen // complex logic
 		return
 	}
 
-	command := fmt.Sprintf("%s /tmp/miniccc/files/%s", executor, script)
+	command := fmt.Sprintf("%s /tmp/miniccc/files/%s", executor, relPath)
 	opts := []mm.C2Option{
 		mm.C2NS(ns),
 		mm.C2VM(host),
-		mm.C2SendFile(script),
+		mm.C2SendFile(relPath),
 		mm.C2Command(command),
 		mm.C2Timeout(s.md.c2Timeout),
 	}

--- a/src/go/util/mm/minimega.go
+++ b/src/go/util/mm/minimega.go
@@ -229,15 +229,16 @@ func (m Minimega) GetVMInfo(opts ...Option) VMs { //nolint:funlen // complex log
 		vm.RAM, _ = strconv.Atoi(row["memory"])
 		vm.CPUs, _ = strconv.Atoi(row["vcpus"])
 
-		// TODO: confirm multiple disks are separated by whitespace.
-		disk := strings.Fields(row["disks"])[0]
-		// diskspec can include multiple settings separated by comma. Path to disk
-		// will always be first setting.
-		disk = strings.Split(disk, ",")[0]
+		var disk string
+		// Multiple disks are space-separated (minimega DiskConfigs.String).
+		if fields := strings.Fields(row["disks"]); len(fields) > 0 {
+			// Each diskspec is comma-separated (path,interface,cache); path is first.
+			disk = strings.Split(fields[0], ",")[0]
+		}
 
 		snapshot, _ := strconv.ParseBool(row["snapshot"])
 
-		if snapshot {
+		if snapshot && disk != "" {
 			cmd = mmcli.NewCommand()
 			cmd.Command = "disk info " + disk
 
@@ -806,10 +807,18 @@ func (Minimega) GetExperimentCaptures(opts ...Option) []Capture {
 		}
 
 		// `interface` column will be in the form of <vm_name>:<iface_idx>
-		iface := strings.Split(row["interface"], ":")
+		vm, idxStr, ok := strings.Cut(row["interface"], ":")
+		if !ok {
+			plog.Warn(
+				plog.TypeSystem,
+				"unexpected capture interface format",
+				"interface", row["interface"],
+			)
 
-		vm := iface[0]
-		idx, _ := strconv.Atoi(iface[1])
+			continue
+		}
+
+		idx, _ := strconv.Atoi(idxStr)
 
 		capture := Capture{
 			VM:        vm,
@@ -934,7 +943,31 @@ func (m Minimega) IsHeadnode(node string) bool {
 	// Docker containers by Docker Compose config.
 	node = common.TrimHostnameSuffixes(node)
 
-	return node == m.Headnode()
+	head := m.Headnode()
+
+	// If we can't determine the headnode, assume the local node
+	if head == "" {
+		plog.Warn(
+			plog.TypeSystem,
+			"headnode unknown; assuming local to avoid mesh-send-to-self",
+			"node", node,
+		)
+
+		return true
+	}
+
+	if node == head {
+		return true
+	}
+
+	// Fall back to the local hostname
+	if local, err := os.Hostname(); err == nil {
+		if node == common.TrimHostnameSuffixes(local) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (m Minimega) GetMMArgs() (map[string]string, error) {
@@ -1482,7 +1515,7 @@ func waitForResponse(ctx context.Context, ns, id string, timeout time.Duration) 
 	// Multiple rows will come back for each command ID, one row per cluster host.
 	// Because the `ExecC2Command` sets the filter to a specific VM, only one of
 	// the rows will have a response since a VM can only run on a single cluster
-	// host.
+	// host. A valid row from any one host is sufficient.
 
 	after := time.After(timeout)
 
@@ -1493,18 +1526,9 @@ func waitForResponse(ctx context.Context, ns, id string, timeout time.Duration) 
 		case <-after:
 			return fmt.Errorf("timeout waiting for response for command %s", id)
 		default:
-			rows := mmcli.RunTabular(cmd)
-
-			if len(rows) == 0 {
-				return fmt.Errorf("no commands returned for ID %s", id)
-			}
-
-			if rid := rows[0]["id"]; rid != id {
-				return fmt.Errorf("wrong command returned: %s", rid)
-			}
-
-			for _, row := range rows {
-				if row["responses"] != "0" {
+			// Only the host running the VM has a response; scan all rows.
+			for _, row := range mmcli.RunTabular(cmd) {
+				if row["id"] == id && row["responses"] != "0" {
 					return nil
 				}
 			}

--- a/src/go/util/mm/mmcli/client.go
+++ b/src/go/util/mm/mmcli/client.go
@@ -19,8 +19,9 @@ import (
 var ErrTimeout = errors.New("timeout running command")
 
 var (
-	mu sync.Mutex       //nolint:gochecknoglobals // global lock
-	mm *miniclient.Conn //nolint:gochecknoglobals // global connection
+	mu     sync.Mutex       //nolint:gochecknoglobals // global lock
+	mm     *miniclient.Conn //nolint:gochecknoglobals // global connection
+	mmDead bool             //nolint:gochecknoglobals // flags mm for replacement
 )
 
 func wrapErr(err error) chan *miniclient.Response {
@@ -136,55 +137,94 @@ func SingleDataResponse(responses chan *miniclient.Response) (any, error) {
 	return data, err
 }
 
+// conn returns a usable connection to minimega, dialing or redialing as needed.
+// The caller must hold mu.
+func conn() (*miniclient.Conn, error) {
+	if mm == nil || mmDead {
+		c, err := miniclient.Dial(common.MinimegaBase)
+		if err != nil {
+			return nil, fmt.Errorf("unable to dial: %w", err)
+		}
+
+		mm, mmDead = c, false
+	}
+
+	// If the connection is already in a broken state, redial.
+	if err := mm.Error(); err != nil {
+		s := err.Error()
+
+		if strings.Contains(s, "broken pipe") || strings.Contains(s, "no such file or directory") {
+			c, err := miniclient.Dial(common.MinimegaBase)
+			if err != nil {
+				return nil, fmt.Errorf("unable to redial: %w", err)
+			}
+
+			mm, mmDead = c, false
+		} else {
+			return nil, fmt.Errorf("minimega error: %w", err)
+		}
+	}
+
+	return mm, nil
+}
+
+// markDead flags the given connection for replacement on the next call, but only
+// if it is still the current connection. The identity check stops a stale
+// timeout from clobbering a connection that a later call already redialed.
+func markDead(c *miniclient.Conn) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if mm == c {
+		mmDead = true
+	}
+}
+
 // Run dials the minimega Unix socket and runs the given command, automatically
 // redialing if disconnected. Any errors encountered will be returned as part of
 // the response channel.
 func Run(c *Command) chan *miniclient.Response {
 	mu.Lock()
-	defer mu.Unlock()
 
-	var err error
+	active, err := conn()
+	if err != nil {
+		mu.Unlock()
 
-	if mm == nil {
-		if mm, err = miniclient.Dial(common.MinimegaBase); err != nil {
-			return wrapErr(fmt.Errorf("unable to dial: %w", err))
-		}
+		return wrapErr(err)
 	}
 
-	// check if there's already an error and try to redial
-	if err := mm.Error(); err != nil {
-		s := err.Error()
+	// Build the command string and release mu before waiting on the response.
+	// The connection's own internal lock serializes the actual exchange, so we
+	// don't need to (and must not) hold mu across a potentially slow command --
+	// doing so would serialize all minimega traffic behind one slow command.
+	cmdStr := c.String()
 
-		if strings.Contains(s, "broken pipe") || strings.Contains(s, "no such file or directory") {
-			if mm, err = miniclient.Dial(common.MinimegaBase); err != nil {
-				return wrapErr(fmt.Errorf("unable to redial: %w", err))
-			}
-		} else {
-			return wrapErr(fmt.Errorf("minimega error: %w", err))
-		}
-	}
+	mu.Unlock()
 
 	if c.Timeout == 0 {
-		return mm.Run(c.String())
+		return active.Run(cmdStr)
 	}
 
 	var (
-		resp chan *miniclient.Response
+		resp = make(chan chan *miniclient.Response, 1)
 		done = make(chan struct{})
 	)
 
 	go func() {
-		resp = mm.Run(c.String())
+		resp <- active.Run(cmdStr)
 
 		close(done)
 	}()
 
 	select {
 	case <-done:
-		return resp
+		return <-resp
 	case <-time.After(c.Timeout):
-		// Reset mm since the miniclient has a lock that is likely still activated.
-		mm = nil
+		// Dispatch is stuck (the connection's internal lock is likely held by a
+		// previous unresponsive command). Flag this connection for replacement so
+		// the next call redials, rather than nil-ing out a shared pointer that
+		// live readers may still reference.
+		markDead(active)
 
 		return wrapErr(ErrTimeout)
 	}


### PR DESCRIPTION
# fix(mm): add stability for minimega commands across hosts

## Description
Several stability fixes for interacting with `mm`:
* minimega commands now wait for a response and scan across rows returned by multiple hosts. Each host in the mesh returns a response, all except for 1 are expected to be an error where the VM was not found on that host. We scan across all rows just needing one valid response.
* The minimega client no longer holds its global lock across a command's timeout and no longer races on the shared connection when one times out.
* VM-info and capture parsing are guarded against index-out-of-range panics
* headnode detection is hardened to avoid "cannot mesh send yourself" messages
* Custom SOH test scripts now use one consistent minimega-relative path for the write, `cc send`, and execution

> [!NOTE]
> I have 2 commits here, intentionally not squashed. The second is to update some CI actions that were preventing builds.

## Related Issue
* In coordination with XXX
* Replaces #309 / [sceptre-phenix-apps#109](https://github.com/sandialabs/sceptre-phenix-apps/pull/109)'
* Closes #274 

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- ~New feature~
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [X] I have tested my code.

## Additional Notes
N/A