### PR TITLE
feat(experiments-ui): change scorch button(s) destination to scorchru…

### DIFF
--- a/src/js/src/components/Experiments.vue
+++ b/src/js/src/components/Experiments.vue
@@ -186,15 +186,21 @@
             {{ props.row.vlan_min }} - {{ props.row.vlan_max}} ({{ props.row.vlan_count }})
           </b-table-column>
           <b-table-column label="Actions" width="125" centered v-slot="props">
-            <button v-if="roleAllowed('experiments', 'delete', props.row.name)" class="button is-light is-small action" :disabled="updating( props.row.status )" @click="del( props.row.name, props.row.running )">
-              <b-icon icon="trash"></b-icon>
-            </button>
-            <router-link v-if="roleAllowed('experiments', 'get', props.row.name)" class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'soh', params: { id: props.row.name }}">
-              <b-icon icon="heartbeat"></b-icon>
-            </router-link>
-            <router-link v-if="roleAllowed('experiments', 'get', props.row.name)" class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'scorch', params: { id: props.row.name }}">
-              <b-icon icon="fire"></b-icon>
-            </router-link>
+            <b-tooltip v-if="roleAllowed('experiments', 'delete', props.row.name)" label="Delete experiment" type="is-dark">
+              <button class="button is-light is-small action" :disabled="updating( props.row.status )" @click="del( props.row.name, props.row.running )">
+                <b-icon icon="trash"></b-icon>
+              </button>
+            </b-tooltip>
+            <b-tooltip v-if="roleAllowed('experiments', 'get', props.row.name)" label="View system health" type="is-dark">
+              <router-link class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'soh', params: { id: props.row.name }}">
+                <b-icon icon="heartbeat"></b-icon>
+              </router-link>
+            </b-tooltip>
+            <b-tooltip v-if="roleAllowed('experiments', 'get', props.row.name)" label="View scorch runs" type="is-dark">
+              <router-link class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'scorchruns', params: { id: props.row.name }}">
+                <b-icon icon="fire"></b-icon>
+              </router-link>
+            </b-tooltip>
           </b-table-column>
         </b-table>
         <br>

--- a/src/js/src/components/Experiments.vue
+++ b/src/js/src/components/Experiments.vue
@@ -186,15 +186,21 @@
             {{ props.row.vlan_min }} - {{ props.row.vlan_max}} ({{ props.row.vlan_count }})
           </b-table-column>
           <b-table-column label="Actions" width="125" centered v-slot="props">
-            <button v-if="roleAllowed('experiments', 'delete', props.row.name)" class="button is-light is-small action" :disabled="updating( props.row.status )" @click="del( props.row.name, props.row.running )">
-              <b-icon icon="trash"></b-icon>
-            </button>
-            <router-link v-if="roleAllowed('experiments', 'get', props.row.name)" class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'soh', params: { id: props.row.name }}">
-              <b-icon icon="heartbeat"></b-icon>
-            </router-link>
-            <router-link v-if="roleAllowed('experiments', 'get', props.row.name)" class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'scorch', params: { id: props.row.name }}">
-              <b-icon icon="fire"></b-icon>
-            </router-link>
+            <b-tooltip v-if="roleAllowed('experiments', 'delete', props.row.name)" label="Delete experiment" type="is-dark">
+              <button class="button is-light is-small action" :disabled="updating( props.row.status )" @click="del( props.row.name, props.row.running )">
+                <b-icon icon="trash"></b-icon>
+              </button>
+            </b-tooltip>
+            <b-tooltip v-if="roleAllowed('experiments', 'get', props.row.name)" label="View soh" type="is-dark">
+              <router-link class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'soh', params: { id: props.row.name }}">
+                <b-icon icon="heartbeat"></b-icon>
+              </router-link>
+            </b-tooltip>
+            <b-tooltip v-if="roleAllowed('experiments', 'get', props.row.name)" label="View scorch runs" type="is-dark">
+              <router-link class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'scorchruns', params: { id: props.row.name }}">
+                <b-icon icon="fire"></b-icon>
+              </router-link>
+            </b-tooltip>
           </b-table-column>
         </b-table>
         <br>

--- a/src/js/src/components/Experiments.vue
+++ b/src/js/src/components/Experiments.vue
@@ -192,7 +192,7 @@
             <router-link v-if="roleAllowed('experiments', 'get', props.row.name)" class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'soh', params: { id: props.row.name }}">
               <b-icon icon="heartbeat"></b-icon>
             </router-link>
-            <router-link v-if="roleAllowed('experiments', 'get', props.row.name)" class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'scorch', params: { id: props.row.name }}">
+            <router-link v-if="roleAllowed('experiments', 'get', props.row.name)" class="button is-light is-small action" :disabled="updating( props.row.status )" :to="{ name: 'scorchruns', params: { id: props.row.name }}">
               <b-icon icon="fire"></b-icon>
             </router-link>
           </b-table-column>

--- a/src/js/src/components/RunningExperiment.vue
+++ b/src/js/src/components/RunningExperiment.vue
@@ -545,7 +545,7 @@
               <b-icon icon="heartbeat"></b-icon>
             </router-link>
             &nbsp;
-            <router-link v-if="roleAllowed('experiments', 'get', experiment.name)" class="button is-light" :to="{ name: 'scorch', params: { id: this.$route.params.id }}">
+            <router-link v-if="roleAllowed('experiments', 'get', experiment.name)" class="button is-light" :to="{ name: 'scorchruns', params: { id: this.$route.params.id }}">
               <b-icon icon="fire"></b-icon>
             </router-link>
           </p>
@@ -701,23 +701,6 @@
               </template>
               <template v-else>
                 {{  props.row.networks | stringify | lowercase }}
-              </template>
-            </b-table-column>
-            <b-table-column field="taps"  label="Taps" v-slot="props">
-              <template v-if="roleAllowed('vms/captures', 'create', experiment.name + '/' + props.row.name) && props.row.running && !props.row.busy">
-                <b-tooltip  :label="updateCaptureLabel(props.row)" type="is-dark">
-                  <div class="field">
-                    <div  v-for="( t, index ) in props.row.taps" 
-                      :class="tapDecorator( props.row.captures, index )" 
-                      :key="index" 
-                      @click="handlePcap( props.row, index )">
-                      {{ t | lowercase }}
-                    </div>
-                  </div>
-                </b-tooltip>
-              </template>
-              <template v-else>
-                {{  props.row.taps | stringify | lowercase }}
               </template>
             </b-table-column>
             <b-table-column field="uptime"  label="Uptime" v-slot="props">


### PR DESCRIPTION
# feat(experiments-ui): change scorch button(s) destination to scorchruns and remove VM taps column

## Description

General UI improvements based on use.

- Update scorch action buttons route to go directly to an experiments scorch runs in both experiment list and running experiment views. Before this change, clicking the fire icon opened the scorch overview page; now it opens the scorch runs for that same experiment.
- Remove the Taps column from the running experiment VM table to reduce clutter. Taps can be found on a VM's modal card when clicked, alongside other VM details including port forwards.

## Related Issue
#287 

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [ ] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [ ] I have included no proprietary/sensitive information in my code. 
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
