### PR TITLE
ci: revert image builds to docker driver

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Get short SHA
         run: |
           echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
@@ -43,7 +41,6 @@ jobs:
             type=ref,event=tag
             type=sha
       - name: Build container image
-        id: build-main
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -54,15 +51,9 @@ jobs:
             PHENIX_TAG=${{ steps.meta.outputs.version }}
             APPS_REPO=github.com/${{ github.event_name == 'repository_dispatch' && github.event.client_payload.repo || 'sandialabs/sceptre-phenix-apps' }}
             APPS_BRANCH=main
+          push: ${{ github.event_name != 'pull_request' }}
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
-          provenance: false
-          cache-from: type=gha,scope=phenix
-          cache-to: type=gha,mode=max,scope=phenix
-          # docker = load to dockerd for the deb step; oci = JIT FROM source; registry = push on non-PR only.
-          outputs: |
-            type=docker
-            type=oci,dest=/tmp/phenix-oci,tar=false
-            ${{ github.event_name != 'pull_request' && 'type=registry' || '' }}
 
       - name: Build Debian Package
         env:
@@ -100,14 +91,7 @@ jobs:
             PHENIX_REPO=${{ github.event.pull_request.head.repo.full_name || github.repository }}
             PHENIX_IMG=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
             PHENIX_BRANCH=${{ github.head_ref || github.ref_name }}
-          # Resolve FROM from the on-disk OCI layout so PR builds work without the parent in ghcr.
-          build-contexts: |
-            ${{ fromJSON(steps.meta.outputs.json).tags[0] }}=oci-layout:///tmp/phenix-oci@${{ steps.build-main.outputs.digest }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-jit.outputs.tags }}
-          provenance: false
-          cache-from: type=gha,scope=phenix-jit
-          cache-to: type=gha,mode=max,scope=phenix-jit
-          outputs: |
-            ${{ github.event_name != 'pull_request' && 'type=registry' || 'type=cacheonly' }}
     outputs:
       image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}


### PR DESCRIPTION
## Description
Revert the #313 Buildx switch. The container driver can't resolve a locally-loaded `FROM`, so the JIT build pointed at an on-disk OCI layout; on push/dispatch that layout is incomplete. Back to the default docker driver. Action versions kept current. Drops the `type=gha` layer cache.

## Related Issue
* closes #317

## Type of Change
- [X] Bugfix

## Testing
Verified on a fork **push** run (the non-PR path PR checks don't exercise): main + deb + JIT all build and push.
