### PR TITLE
fix(mm): close connection on command timeout

### DIFF
--- a/src/go/util/mm/mmcli/client.go
+++ b/src/go/util/mm/mmcli/client.go
@@ -220,10 +220,9 @@ func Run(c *Command) chan *miniclient.Response {
 	case <-done:
 		return <-resp
 	case <-time.After(c.Timeout):
-		// Dispatch is stuck (the connection's internal lock is likely held by a
-		// previous unresponsive command). Flag this connection for replacement so
-		// the next call redials, rather than nil-ing out a shared pointer that
-		// live readers may still reference.
+		// Dispatch is stuck, close it so the goroutine fails
+		active.Close()
+		// Flag it so the next call redials
 		markDead(active)
 
 		return wrapErr(ErrTimeout)


### PR DESCRIPTION
## Description
On a command timeout, close the minimega connection before flagging it for replacement. The goroutine still blocked on the connection's internal lock then fails its write rather than replaying a stale command once the lock frees.

## Related Issue
Fixes a new error in #313. That PR added some checks for mm but did not take into account multiple concurrent experiments,

## Type of Change
- [x] Bugfix
- ~New feature~
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [ ] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [x] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
N/A