### PR TITLE
fix(vrouter): config system DNS for VyOS

### DIFF
--- a/src/go/api/disk/disk.go
+++ b/src/go/api/disk/disk.go
@@ -186,7 +186,10 @@ func resolveImage(path string) []Details {
 	}
 
 	if !knownFormat {
-		plog.Debug(plog.TypeSystem, "file didn't match know image extensions: %s", "path", path)
+		// Only log non-snapshot files
+		if !strings.Contains(path, "_snapshot") {
+			plog.Debug(plog.TypeSystem, "file didn't match known image extensions", "path", path, "knownExtensions", knownImageExtensions)
+		}
 
 		return imageDetails
 	}

--- a/src/go/tmpl/templates/vyatta.tmpl
+++ b/src/go/tmpl/templates/vyatta.tmpl
@@ -257,6 +257,11 @@ set service snmp trap-target {{ $target }} community '{{ $community.Name }}'
     {{- end }}
 # --------------------------------- System --------------------------------
 set system host-name {{ $node.RouterName }}
+{{- range $idx, $iface := $node.Network.Interfaces }}
+    {{- range $dnsServer := $iface.DNS }}
+set system name-server {{ $dnsServer }}
+    {{- end }}
+{{- end }}
 commit
 save
 exit


### PR DESCRIPTION
# fix(vrouter): config system DNS for VyOS

## Description
This fixes system DNS not being configured for VyOS if `dns:` field is set for interfaces. The fix has been tested.

This also includes a minor fix for excessive logging messages when opening the "Disks" tab when there are snapshot files in the images directory.

## Related Issue
If applicable, please link to the issue here (e.g., #123).

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

Note that this is NOT applied to Vyatta, as I don't have a easy way to test that. If needed someone still using Vyatta can backport and test the fix.
