### PR TITLE
feat: add separate file server for uploading experiment files

### DIFF
--- a/src/go/api/config/default/experiment-admin.yml
+++ b/src/go/api/config/default/experiment-admin.yml
@@ -29,6 +29,10 @@ spec:
     verbs:
     - list
   - resources:
+    - "experiments/files"
+    verbs:
+    - create
+  - resources:
     - hosts
     resourceNames:
     - "*"

--- a/src/go/api/config/default/experiment-user.yml
+++ b/src/go/api/config/default/experiment-user.yml
@@ -34,6 +34,10 @@ spec:
     - create
     - update
   - resources:
+    - "experiments/files"
+    verbs:
+    - create
+  - resources:
     - hosts
     resourceNames:
     - "*"

--- a/src/go/cmd/ui.go
+++ b/src/go/cmd/ui.go
@@ -34,6 +34,7 @@ func newUICmd() *cobra.Command {
 			opts := []web.ServerOption{
 				web.ServeOnEndpoint(viper.GetString("ui.listen-endpoint")),
 				web.ServeBasePath(viper.GetString("ui.base-path")),
+				web.ServeFileServerEndpoint(viper.GetString("ui.file-server-endpoint")),
 				web.ServeWithJWTKey(viper.GetString("ui.jwt-signing-key")),
 				web.ServeWithJWTLifetime(viper.GetDuration("ui.jwt-lifetime")),
 				web.ServeWithUsers(viper.GetStringSlice("ui.users")),
@@ -84,6 +85,7 @@ func newUICmd() *cobra.Command {
 	uiCmd.Flags().
 		StringP("jwt-signing-key", "k", "", "Secret key used to sign JWT for authentication")
 	uiCmd.Flags().Duration("jwt-lifetime", defaultJWTLifetime, "Lifetime of JWT authentication tokens")
+	uiCmd.Flags().String("file-server-endpoint", "0", "port or host:port to serve experiment file uploads on; port-only binds 127.0.0.1")
 	uiCmd.Flags().
 		String("proxy-auth-header", "", "header containing username when using proxy authentication")
 	uiCmd.Flags().StringSlice("users", nil, "pipe-delimited list of initial users to add")
@@ -99,6 +101,7 @@ func newUICmd() *cobra.Command {
 	_ = viper.BindPFlag("ui.base-path", uiCmd.Flags().Lookup("base-path"))
 	_ = viper.BindPFlag("ui.jwt-signing-key", uiCmd.Flags().Lookup("jwt-signing-key"))
 	_ = viper.BindPFlag("ui.jwt-lifetime", uiCmd.Flags().Lookup("jwt-lifetime"))
+	_ = viper.BindPFlag("ui.file-server-endpoint", uiCmd.Flags().Lookup("file-server-endpoint"))
 	_ = viper.BindPFlag("ui.proxy-auth-header", uiCmd.Flags().Lookup("proxy-auth-header"))
 	_ = viper.BindPFlag("ui.users", uiCmd.Flags().Lookup("users"))
 	_ = viper.BindPFlag("ui.tls-key", uiCmd.Flags().Lookup("tls-key"))
@@ -112,6 +115,7 @@ func newUICmd() *cobra.Command {
 	_ = viper.BindEnv("ui.base-path")
 	_ = viper.BindEnv("ui.jwt-signing-key")
 	_ = viper.BindEnv("ui.jwt-lifetime")
+	_ = viper.BindEnv("ui.file-server-endpoint")
 	_ = viper.BindEnv("ui.proxy-auth-header")
 	_ = viper.BindEnv("ui.users")
 	_ = viper.BindEnv("ui.tls-key")

--- a/src/go/web/fileserver.go
+++ b/src/go/web/fileserver.go
@@ -1,0 +1,575 @@
+package web
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"phenix/api/experiment"
+	"phenix/types"
+	"phenix/util/plog"
+	"phenix/web/middleware"
+	"phenix/web/rbac"
+)
+
+const maxFileServerUploadMemory = 32 << 20
+const fileServerTokenCookie = "phenix_file_server_token"
+
+const fileServerIndexHTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>phenix file upload</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; max-width: 42rem; }
+    form { display: grid; gap: 1rem; }
+    label { display: grid; gap: .35rem; font-weight: 600; }
+    select, input, button { font: inherit; padding: .5rem; }
+    .message { margin-bottom: 1rem; }
+    .upload-progress { display: grid; gap: .35rem; }
+    .upload-progress[hidden] { display: none; }
+    .upload-error { color: #b00020; }
+    progress { width: 100%; }
+  </style>
+</head>
+<body>
+  <h1>Upload experiment files</h1>
+  {{if and .AuthEnabled .User}}<p>Signed in as {{.User}}. <a href="/logout">Logout</a></p>{{end}}
+  {{if .Message}}<p class="message">{{.Message}}</p>{{end}}
+  {{if .Experiments}}
+  <form id="upload-form" action="/upload" method="post" enctype="multipart/form-data">
+    <label>Experiment
+      <select name="experiment" required>
+        {{range .Experiments}}<option value="{{.}}">{{.}}</option>{{end}}
+      </select>
+    </label>
+    <label>Files
+      <input type="file" name="files" multiple required>
+    </label>
+    <button type="submit">Upload</button>
+    <div id="upload-progress" class="upload-progress" hidden>
+      <progress id="upload-progress-bar" max="100" value="0"></progress>
+      <span id="upload-progress-text">Preparing upload...</span>
+    </div>
+    <p id="upload-error" class="upload-error" hidden></p>
+  </form>
+  {{else}}
+  <p>No experiments found.</p>
+  {{end}}
+  <script>
+    (function() {
+      var form = document.getElementById("upload-form");
+
+      if (!form || !window.XMLHttpRequest || !window.FormData) {
+        return;
+      }
+
+      var button = form.querySelector("button[type='submit']");
+      var progress = document.getElementById("upload-progress");
+      var progressBar = document.getElementById("upload-progress-bar");
+      var progressText = document.getElementById("upload-progress-text");
+      var uploadError = document.getElementById("upload-error");
+
+      form.addEventListener("submit", function(event) {
+        event.preventDefault();
+
+        var request = new XMLHttpRequest();
+        var data = new FormData(form);
+
+        uploadError.hidden = true;
+        uploadError.textContent = "";
+        progress.hidden = false;
+        progressBar.value = 0;
+        progressText.textContent = "Preparing upload...";
+        button.disabled = true;
+
+        request.upload.onprogress = function(progressEvent) {
+          if (!progressEvent.lengthComputable) {
+            progressText.textContent = "Uploading...";
+
+            return;
+          }
+
+          var percent = Math.round((progressEvent.loaded / progressEvent.total) * 100);
+          progressBar.value = percent;
+          progressText.textContent = percent >= 100 ? "Finalizing..." : "Uploading " + percent + "%";
+        };
+
+        request.onload = function() {
+          if (request.responseURL && new URL(request.responseURL).pathname === "/login") {
+            window.location = "/login";
+
+            return;
+          }
+
+          if (request.status >= 200 && request.status < 300) {
+            document.open();
+            document.write(request.responseText);
+            document.close();
+
+            return;
+          }
+
+          uploadError.textContent = request.responseText || "Upload failed.";
+          uploadError.hidden = false;
+          button.disabled = false;
+        };
+
+        request.onerror = function() {
+          uploadError.textContent = "Upload failed.";
+          uploadError.hidden = false;
+          button.disabled = false;
+        };
+
+        request.open(form.method, form.action);
+        request.send(data);
+      });
+    })();
+  </script>
+</body>
+</html>
+`
+
+const fileServerLoginHTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>phenix file upload login</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; max-width: 24rem; }
+    form { display: grid; gap: 1rem; }
+    label { display: grid; gap: .35rem; font-weight: 600; }
+    input, button { font: inherit; padding: .5rem; }
+    .error { color: #b00020; }
+  </style>
+</head>
+<body>
+  <h1>Sign in</h1>
+  {{if .Error}}<p class="error">{{.Error}}</p>{{end}}
+  {{if .Proxy}}
+  <p>Proxy authentication is enabled. Use the button below to continue.</p>
+  <form action="/login" method="get">
+    <button type="submit">Continue</button>
+  </form>
+  {{else}}
+  <form action="/login" method="post">
+    <label>Username
+      <input type="text" name="username" autocomplete="username" required>
+    </label>
+    <label>Password
+      <input type="password" name="password" autocomplete="current-password" required>
+    </label>
+    <button type="submit">Sign in</button>
+  </form>
+  {{end}}
+</body>
+</html>
+`
+
+var fileServerIndexTemplate = template.Must(template.New("fileserver-index").Parse(fileServerIndexHTML)) //nolint:gochecknoglobals // shared parsed template
+var fileServerLoginTemplate = template.Must(template.New("fileserver-login").Parse(fileServerLoginHTML)) //nolint:gochecknoglobals // shared parsed template
+
+type fileServerIndexData struct {
+	User        string
+	Message     string
+	Experiments []string
+	AuthEnabled bool
+}
+
+type fileServerLoginData struct {
+	Error string
+	Proxy bool
+}
+
+type fileServerResponseRecorder struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+// StartFileServer starts an authenticated experiment file upload server.
+func StartFileServer(endpoint string, jwtKey, proxyAuthHeader string) {
+	mux := http.NewServeMux()
+	authEnabled := jwtKey != ""
+	mux.HandleFunc("/", showFileServerIndex(authEnabled))
+	mux.HandleFunc("/login", fileServerLogin(proxyAuthHeader))
+	mux.HandleFunc("/upload", uploadExperimentFiles(authEnabled))
+
+	plog.Info(plog.TypeSystem, "starting file server", "endpoint", endpoint)
+	handler := fileServerCookieAuth(middleware.Auth(jwtKey, proxyAuthHeader)(mux), jwtKey)
+
+	//nolint:gosec // simple opt-in upload server; no timeouts to match UI server style
+	if err := http.ListenAndServe(endpoint, handler); err != nil {
+		plog.Error(plog.TypeSystem, "serving file server", "err", err)
+	}
+}
+
+// fileServerCookieAuth bridges fileserver login cookies to phenix auth headers.
+func fileServerCookieAuth(h http.Handler, jwtKey string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/logout" {
+			clearFileServerTokenCookie(w)
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+
+			return
+		}
+
+		cookie, err := r.Cookie(fileServerTokenCookie)
+		if err == nil && r.Header.Get("X-Phenix-Auth-Token") == "" {
+			token, err := decodeFileServerTokenCookie(cookie.Value)
+			if err != nil {
+				plog.Warn(plog.TypeSecurity, "decoding file server auth cookie", "err", err)
+				clearFileServerTokenCookie(w)
+				http.Redirect(w, r, "/login", http.StatusSeeOther)
+
+				return
+			}
+
+			r.Header.Set("X-Phenix-Auth-Token", "Bearer "+token)
+		}
+
+		if jwtKey != "" && r.URL.Path != "/login" && r.Header.Get("X-Phenix-Auth-Token") == "" {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+
+			return
+		}
+
+		rec := newFileServerResponseRecorder()
+		h.ServeHTTP(rec, r)
+		if rec.status == http.StatusUnauthorized {
+			clearFileServerTokenCookie(w)
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+
+			return
+		}
+
+		rec.writeTo(w)
+	})
+}
+
+// newFileServerResponseRecorder buffers fileserver responses so auth errors can redirect.
+func newFileServerResponseRecorder() *fileServerResponseRecorder {
+	return &fileServerResponseRecorder{header: make(http.Header)}
+}
+
+// Header returns the buffered response headers.
+func (r *fileServerResponseRecorder) Header() http.Header {
+	return r.header
+}
+
+// WriteHeader records the response status code.
+func (r *fileServerResponseRecorder) WriteHeader(status int) {
+	if r.status == 0 {
+		r.status = status
+	}
+}
+
+// Write records the response body.
+func (r *fileServerResponseRecorder) Write(data []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+
+	return r.body.Write(data)
+}
+
+// writeTo copies the buffered response to the real response writer.
+func (r *fileServerResponseRecorder) writeTo(w http.ResponseWriter) {
+	for key, values := range r.header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+
+	w.WriteHeader(r.status)
+	_, _ = w.Write(r.body.Bytes())
+}
+
+// showFileServerIndex renders the experiment file upload form.
+func showFileServerIndex(authEnabled bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		renderFileServerIndex(w, r, "", authEnabled)
+	}
+}
+
+// fileServerLogin renders login and sets the fileserver auth cookie.
+func fileServerLogin(proxyAuthHeader string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if proxyAuthHeader == "" && r.Header.Get("X-Phenix-Auth-Token") == "" {
+				renderFileServerLogin(w, fileServerLoginData{})
+
+				return
+			}
+
+			token, err := loginFileServerUser(r, nil)
+			if err != nil {
+				renderFileServerLogin(w, fileServerLoginData{Error: err.Error(), Proxy: proxyAuthHeader != ""})
+
+				return
+			}
+
+			setFileServerTokenCookie(w, token)
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+		case http.MethodPost:
+			if err := r.ParseForm(); err != nil {
+				renderFileServerLogin(w, fileServerLoginData{Error: err.Error()})
+
+				return
+			}
+
+			req := LoginRequest{Username: r.FormValue("username"), Password: r.FormValue("password")}
+			token, err := loginFileServerUser(r, &req)
+			if err != nil {
+				renderFileServerLogin(w, fileServerLoginData{Error: err.Error()})
+
+				return
+			}
+
+			setFileServerTokenCookie(w, token)
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// loginFileServerUser calls the built-in phenix login handler and returns its token.
+func loginFileServerUser(r *http.Request, req *LoginRequest) (string, error) {
+	var body io.Reader
+	method := http.MethodGet
+
+	if req != nil {
+		data, err := json.Marshal(req)
+		if err != nil {
+			return "", fmt.Errorf("building login request: %w", err)
+		}
+
+		body = bytes.NewReader(data)
+		method = http.MethodPost
+	}
+
+	loginReq := httptest.NewRequest(method, "/login", body)
+	loginReq = loginReq.WithContext(r.Context())
+	loginReq.Header = r.Header.Clone()
+
+	if req != nil {
+		loginReq.Header.Set("Content-Type", "application/json")
+	}
+
+	rec := httptest.NewRecorder()
+	Login(rec, loginReq)
+
+	if rec.Code < http.StatusOK || rec.Code >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("%s", rec.Body.String())
+	}
+
+	var resp LoginResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		return "", fmt.Errorf("parsing login response: %w", err)
+	}
+
+	if resp.Token == "" {
+		return "", fmt.Errorf("missing login token")
+	}
+
+	return resp.Token, nil
+}
+
+// setFileServerTokenCookie stores the phenix auth token for browser form requests.
+func setFileServerTokenCookie(w http.ResponseWriter, token string) {
+	http.SetCookie(w, &http.Cookie{ //nolint:exhaustruct // only relevant cookie fields
+		Name:     fileServerTokenCookie,
+		Value:    encodeFileServerTokenCookie(token),
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// encodeFileServerTokenCookie makes the JWT safe for browser cookie transport.
+func encodeFileServerTokenCookie(token string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(token))
+}
+
+// decodeFileServerTokenCookie restores the JWT stored in the fileserver auth cookie.
+func decodeFileServerTokenCookie(value string) (string, error) {
+	token, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return "", err
+	}
+
+	return string(token), nil
+}
+
+// clearFileServerTokenCookie expires the fileserver auth cookie.
+func clearFileServerTokenCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{ //nolint:exhaustruct // only relevant cookie fields
+		Name:     fileServerTokenCookie,
+		Value:    "",
+		Path:     "/",
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// uploadExperimentFiles stores posted files under the selected experiment files directory.
+func uploadExperimentFiles(authEnabled bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+
+			return
+		}
+
+		if err := r.ParseMultipartForm(maxFileServerUploadMemory); err != nil {
+			http.Error(w, "parsing upload: "+err.Error(), http.StatusBadRequest)
+
+			return
+		}
+
+		exp, err := experiment.Get(r.FormValue("experiment"))
+		if err != nil {
+			http.Error(w, "getting experiment: "+err.Error(), http.StatusBadRequest)
+
+			return
+		}
+
+		role := middleware.RoleFromContext(r.Context())
+		if !role.Allowed("experiments/files", "create", exp.Metadata.Name) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+
+			return
+		}
+
+		files := r.MultipartForm.File["files"]
+		if len(files) == 0 {
+			http.Error(w, "no files uploaded", http.StatusBadRequest)
+
+			return
+		}
+
+		dir := exp.FilesDir()
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			http.Error(w, "creating experiment files directory: "+err.Error(), http.StatusInternalServerError)
+
+			return
+		}
+
+		var uploaded int
+		for _, header := range files {
+			name := filepath.Base(header.Filename)
+			if name == "" || name == "." {
+				http.Error(w, "invalid upload filename", http.StatusBadRequest)
+
+				return
+			}
+
+			clientFile, err := header.Open()
+			if err != nil {
+				http.Error(w, "opening upload: "+err.Error(), http.StatusInternalServerError)
+
+				return
+			}
+
+			target, err := os.OpenFile(filepath.Join(dir, name), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+			if err != nil {
+				_ = clientFile.Close()
+				http.Error(w, "creating target file: "+err.Error(), http.StatusInternalServerError)
+
+				return
+			}
+
+			_, copyErr := io.Copy(target, clientFile)
+			closeClientErr := clientFile.Close()
+			closeTargetErr := target.Close()
+			if copyErr != nil {
+				http.Error(w, "saving upload: "+copyErr.Error(), http.StatusInternalServerError)
+
+				return
+			}
+			if closeClientErr != nil {
+				http.Error(w, "closing upload: "+closeClientErr.Error(), http.StatusInternalServerError)
+
+				return
+			}
+			if closeTargetErr != nil {
+				http.Error(w, "closing target file: "+closeTargetErr.Error(), http.StatusInternalServerError)
+
+				return
+			}
+
+			uploaded++
+		}
+
+		renderFileServerIndex(w, r, fmt.Sprintf("Uploaded %d file(s) to %s.", uploaded, exp.Metadata.Name), authEnabled)
+	}
+}
+
+// renderFileServerIndex writes the upload page with current experiment names.
+func renderFileServerIndex(w http.ResponseWriter, r *http.Request, message string, authEnabled bool) {
+	experiments, err := experiment.List()
+	if err != nil {
+		http.Error(w, "listing experiments: "+err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	role := middleware.RoleFromContext(r.Context())
+	names := experimentNames(experiments, role)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	data := fileServerIndexData{User: middleware.UserFromContext(r.Context()), Message: message, Experiments: names, AuthEnabled: authEnabled}
+	if err := fileServerIndexTemplate.Execute(w, data); err != nil {
+		plog.Error(plog.TypeSystem, "rendering file server index", "err", err)
+	}
+}
+
+// renderFileServerLogin writes the fileserver login page.
+func renderFileServerLogin(w http.ResponseWriter, data fileServerLoginData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	if err := fileServerLoginTemplate.Execute(w, data); err != nil {
+		plog.Error(plog.TypeSystem, "rendering file server login", "err", err)
+	}
+}
+
+// experimentNames returns sorted experiment names the user can upload to.
+func experimentNames(experiments []types.Experiment, role rbac.Role) []string {
+	names := make([]string, 0, len(experiments))
+	for _, exp := range experiments {
+		if !role.Allowed("experiments/files", "create", exp.Metadata.Name) {
+			continue
+		}
+
+		names = append(names, exp.Metadata.Name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}

--- a/src/go/web/fileserver_endpoint.go
+++ b/src/go/web/fileserver_endpoint.go
@@ -1,0 +1,45 @@
+package web
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// normalizeFileServerEndpoint converts the fileserver option into a listen endpoint.
+func normalizeFileServerEndpoint(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "0" {
+		return "", nil
+	}
+
+	if _, err := parseFileServerPort(value); err == nil {
+		return net.JoinHostPort("127.0.0.1", value), nil
+	}
+
+	host, port, err := net.SplitHostPort(value)
+	if err != nil {
+		return "", fmt.Errorf("expected port or host:port")
+	}
+
+	if _, err := parseFileServerPort(port); err != nil {
+		return "", err
+	}
+
+	return net.JoinHostPort(host, port), nil
+}
+
+// parseFileServerPort validates a numeric TCP port.
+func parseFileServerPort(value string) (int, error) {
+	port, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid port %q", value)
+	}
+
+	if port < 0 || port > 65535 {
+		return 0, fmt.Errorf("port %d out of range", port)
+	}
+
+	return port, nil
+}

--- a/src/go/web/fileserver_endpoint_test.go
+++ b/src/go/web/fileserver_endpoint_test.go
@@ -1,0 +1,45 @@
+package web
+
+import "testing"
+
+func TestNormalizeFileServerEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		endpoint string
+		wantErr  bool
+	}{
+		{name: "empty disabled", value: ""},
+		{name: "zero disabled", value: "0"},
+		{name: "port only", value: "8080", endpoint: "127.0.0.1:8080"},
+		{name: "ipv4", value: "127.0.0.1:8080", endpoint: "127.0.0.1:8080"},
+		{name: "hostname", value: "localhost:8080", endpoint: "localhost:8080"},
+		{name: "all interfaces", value: "0.0.0.0:8080", endpoint: "0.0.0.0:8080"},
+		{name: "empty host", value: ":8080", endpoint: ":8080"},
+		{name: "ipv6", value: "[::1]:8080", endpoint: "[::1]:8080"},
+		{name: "invalid bare host", value: "abc", wantErr: true},
+		{name: "missing port", value: "localhost", wantErr: true},
+		{name: "invalid port", value: "127.0.0.1:notaport", wantErr: true},
+		{name: "port out of range", value: "99999", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, err := normalizeFileServerEndpoint(tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if endpoint != tt.endpoint {
+				t.Fatalf("endpoint = %q, want %q", endpoint, tt.endpoint)
+			}
+		})
+	}
+}

--- a/src/go/web/init.go
+++ b/src/go/web/init.go
@@ -26,5 +26,9 @@ func Init() error {
 		return fmt.Errorf("saving updated global-admin role: %w", err)
 	}
 
+	if err := rbac.EnsureExperimentFilesCreatePermission(); err != nil {
+		return fmt.Errorf("ensuring experiment file upload permissions: %w", err)
+	}
+
 	return nil
 }

--- a/src/go/web/middleware/auth.go
+++ b/src/go/web/middleware/auth.go
@@ -172,7 +172,7 @@ func Auth(jwtKey, proxyAuthHeader string) mux.MiddlewareFunc {
 
 			ctx := r.Context()
 
-			userToken := ctx.Value(ContextKeyUser)
+			userToken := userTokenFromContext(ctx)
 			if userToken == nil {
 				plog.Warn(
 					plog.TypeSecurity,
@@ -286,4 +286,13 @@ func Auth(jwtKey, proxyAuthHeader string) mux.MiddlewareFunc {
 
 	// First validate the token itself, then ensure the user in the token is valid.
 	return func(h http.Handler) http.Handler { return tokenMiddleware.Handler(userMiddleware(h)) }
+}
+
+// userTokenFromContext returns the parsed JWT from phenix or JWT middleware context keys.
+func userTokenFromContext(ctx context.Context) any {
+	if token := ctx.Value(ContextKeyUser); token != nil {
+		return token
+	}
+
+	return ctx.Value("user")
 }

--- a/src/go/web/mount.go
+++ b/src/go/web/mount.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"phenix/api/experiment"
 	"phenix/util/file"
 	"phenix/util/mm"
 	"phenix/util/plog"
@@ -553,4 +554,150 @@ func UploadMountFile(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = localFile.Close() }()
 
 	_, _ = io.Copy(localFile, clientFile)
+}
+
+// CopyExperimentFileToMount copies a same-experiment file into a mounted VM directory.
+func CopyExperimentFileToMount(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	basePath := mm.GetLocalMountPath(vars["exp"], vars["name"])
+
+	role, _ := r.Context().Value(middleware.ContextKeyRole).(rbac.Role)
+	if !role.Allowed("vms/mount", "patch", fmt.Sprintf("%s/%s", vars["exp"], vars["name"])) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+
+		return
+	}
+
+	if !role.Allowed("experiments/files", "get", vars["exp"]) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+
+		return
+	}
+
+	activeMountsMu.RLock()
+	mountInfo, exists := activeMounts[basePath]
+	activeMountsMu.RUnlock()
+
+	if !exists {
+		http.Error(w, "No existing mount for "+basePath, http.StatusBadRequest)
+
+		return
+	}
+
+	mountInfo.lock.RLock()
+	defer mountInfo.lock.RUnlock()
+
+	query := r.URL.Query()
+	destDir := filepath.Join(basePath, query.Get("path"))
+	if err := validatePathWithin(destDir, basePath); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	info, err := os.Stat(destDir)
+	if err != nil {
+		http.Error(w, "Error getting path "+destDir+": "+err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	if !info.IsDir() {
+		http.Error(w, "Expected directory not file: "+destDir, http.StatusBadRequest)
+
+		return
+	}
+
+	exp, err := experiment.Get(vars["exp"])
+	if err != nil {
+		http.Error(w, "Error getting experiment: "+err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	source, err := getExperimentFilePath(vars["exp"], query.Get("source"), exp.FilesDir())
+	if err != nil {
+		http.Error(w, "Error getting source file: "+err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	sourceFile, err := os.Open(source) //nolint:gosec // source validated against experiment file list
+	if err != nil {
+		http.Error(w, "Error opening source file: "+err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+	defer func() { _ = sourceFile.Close() }()
+
+	destName := filepath.Base(source)
+	destPath := filepath.Join(destDir, destName)
+	if err := validatePathWithin(destPath, destDir); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	destFile, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600) //nolint:gosec // destination validated against mount path
+	if err != nil {
+		http.Error(w, "Error creating destination file: "+err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+	defer func() { _ = destFile.Close() }()
+
+	if _, err := io.Copy(destFile, sourceFile); err != nil {
+		http.Error(w, "Error copying file: "+err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+}
+
+// getExperimentFilePath returns a source path only when it matches a known experiment file.
+func getExperimentFilePath(expName, source, filesDir string) (string, error) {
+	if source == "" {
+		return "", fmt.Errorf("no source file provided")
+	}
+
+	files, err := experiment.Files(expName, "")
+	if err != nil {
+		return "", fmt.Errorf("listing experiment files: %w", err)
+	}
+
+	for _, f := range files {
+		if source != f.Path {
+			continue
+		}
+
+		headnode, _ := os.Hostname()
+		_ = file.CopyFile(fmt.Sprintf("/%s/files/%s", expName, f.Path), headnode, nil)
+
+		path := filepath.Join(filesDir, f.Path)
+		info, err := os.Stat(path)
+		if err != nil {
+			return "", err
+		}
+
+		if info.IsDir() {
+			return "", fmt.Errorf("source is a directory")
+		}
+
+		return path, nil
+	}
+
+	return "", fmt.Errorf("file not found")
+}
+
+// validatePathWithin returns an error when path escapes base.
+func validatePathWithin(path, base string) error {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
+
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return fmt.Errorf("path is not within base")
+	}
+
+	return nil
 }

--- a/src/go/web/option.go
+++ b/src/go/web/option.go
@@ -29,9 +29,10 @@ type serverOptions struct {
 	logMiddleware string
 	minimegaLogs  string
 
-	unbundled       bool
-	basePath        string
-	minimegaConsole bool
+	unbundled          bool
+	basePath           string
+	fileServerEndpoint string
+	minimegaConsole    bool
 
 	jwtKey      string
 	jwtLifetime time.Duration
@@ -143,6 +144,13 @@ func ServeUnbundled() ServerOption {
 func ServeBasePath(p string) ServerOption {
 	return func(o *serverOptions) {
 		o.basePath = p
+	}
+}
+
+// ServeFileServerEndpoint sets the optional experiment file upload server endpoint.
+func ServeFileServerEndpoint(e string) ServerOption {
+	return func(o *serverOptions) {
+		o.fileServerEndpoint = e
 	}
 }
 

--- a/src/go/web/rbac/migrations.go
+++ b/src/go/web/rbac/migrations.go
@@ -1,0 +1,94 @@
+package rbac
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/activeshadow/structs"
+
+	v1 "phenix/types/version/v1"
+)
+
+const experimentFilesResource = "experiments/files"
+const experimentFilesCreateVerb = "create"
+
+// EnsureExperimentFilesCreatePermission updates existing roles and users for file uploads.
+func EnsureExperimentFilesCreatePermission() error {
+	roles, err := GetRoles()
+	if err != nil {
+		return fmt.Errorf("getting roles: %w", err)
+	}
+
+	for _, role := range roles {
+		if experimentFilesRole(role.Spec.Name) && ensureExperimentFilesCreatePolicy(role.Spec, nil) {
+			if err := role.Save(); err != nil {
+				return fmt.Errorf("saving role %s: %w", role.Spec.Name, err)
+			}
+		}
+	}
+
+	users, err := GetUsers()
+	if err != nil {
+		return fmt.Errorf("getting users: %w", err)
+	}
+
+	for _, user := range users {
+		if user.Spec.Role == nil || !experimentFilesRole(user.Spec.Role.Name) {
+			continue
+		}
+
+		if ensureExperimentFilesCreatePolicy(user.Spec.Role, experimentResourceNames(user.Spec.Role)) {
+			user.config.Spec = structs.MapDefaultCase(user.Spec, structs.CASESNAKE)
+
+			if err := user.Save(); err != nil {
+				return fmt.Errorf("saving user %s: %w", user.Username(), err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// experimentFilesRole returns true for roles that should allow experiment file uploads.
+func experimentFilesRole(name string) bool {
+	return name == "Experiment Admin" || name == "Experiment User"
+}
+
+// ensureExperimentFilesCreatePolicy ensures the role can create experiment files for the given names.
+func ensureExperimentFilesCreatePolicy(role *v1.RoleSpec, names []string) bool {
+	for _, policy := range role.Policies {
+		if !slices.Contains(policy.Resources, experimentFilesResource) {
+			continue
+		}
+
+		var changed bool
+		if !slices.Contains(policy.Verbs, experimentFilesCreateVerb) {
+			policy.Verbs = append(policy.Verbs, experimentFilesCreateVerb)
+			changed = true
+		}
+
+		for _, name := range names {
+			if !slices.Contains(policy.ResourceNames, name) {
+				policy.ResourceNames = append(policy.ResourceNames, name)
+				changed = true
+			}
+		}
+
+		return changed
+	}
+
+	role.Policies = append(role.Policies, &v1.PolicySpec{Resources: []string{experimentFilesResource}, ResourceNames: names, Verbs: []string{experimentFilesCreateVerb}})
+
+	return true
+}
+
+// experimentResourceNames returns resource names from the existing experiments policy.
+func experimentResourceNames(role *v1.RoleSpec) []string {
+	for _, policy := range role.Policies {
+		if slices.Contains(policy.Resources, "experiments") {
+			return slices.Clone(policy.ResourceNames)
+		}
+	}
+
+	return nil
+}

--- a/src/go/web/rbac/migrations_test.go
+++ b/src/go/web/rbac/migrations_test.go
@@ -1,0 +1,123 @@
+package rbac
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/activeshadow/structs"
+
+	"phenix/store"
+	v1 "phenix/types/version/v1"
+)
+
+// TestEnsureExperimentFilesCreatePolicyAddsPolicy verifies missing upload permission is added.
+func TestEnsureExperimentFilesCreatePolicyAddsPolicy(t *testing.T) {
+	role := &v1.RoleSpec{Name: "Experiment Admin", Policies: []*v1.PolicySpec{{Resources: []string{"experiments"}, Verbs: []string{"get"}}}}
+
+	if !ensureExperimentFilesCreatePolicy(role, nil) {
+		t.Fatal("expected role to change")
+	}
+
+	if len(role.Policies) != 2 {
+		t.Fatalf("expected 2 policies, got %d", len(role.Policies))
+	}
+
+	policy := role.Policies[1]
+	if !slices.Contains(policy.Resources, experimentFilesResource) {
+		t.Fatalf("expected resources to include %s", experimentFilesResource)
+	}
+	if len(policy.ResourceNames) != 0 {
+		t.Fatalf("expected nil resource names, got %#v", policy.ResourceNames)
+	}
+	if !slices.Contains(policy.Verbs, experimentFilesCreateVerb) {
+		t.Fatalf("expected verbs to include %s", experimentFilesCreateVerb)
+	}
+}
+
+// TestEnsureExperimentFilesCreatePolicyUpdatesExistingPolicy verifies partial policies are updated.
+func TestEnsureExperimentFilesCreatePolicyUpdatesExistingPolicy(t *testing.T) {
+	role := &v1.RoleSpec{Name: "Experiment User", Policies: []*v1.PolicySpec{{Resources: []string{experimentFilesResource}, ResourceNames: []string{"exp-a"}, Verbs: []string{"get"}}}}
+
+	if !ensureExperimentFilesCreatePolicy(role, []string{"exp-a", "exp-b"}) {
+		t.Fatal("expected role to change")
+	}
+
+	policy := role.Policies[0]
+	if !slices.Contains(policy.ResourceNames, "exp-a") || !slices.Contains(policy.ResourceNames, "exp-b") {
+		t.Fatal("expected resource names to include exp-a and exp-b")
+	}
+	if !slices.Contains(policy.Verbs, experimentFilesCreateVerb) {
+		t.Fatalf("expected verbs to include %s", experimentFilesCreateVerb)
+	}
+}
+
+// TestEnsureExperimentFilesCreatePolicyIdempotent verifies repeated migration does not duplicate values.
+func TestEnsureExperimentFilesCreatePolicyIdempotent(t *testing.T) {
+	role := &v1.RoleSpec{Name: "Experiment User", Policies: []*v1.PolicySpec{{Resources: []string{experimentFilesResource}, ResourceNames: []string{"exp-a"}, Verbs: []string{experimentFilesCreateVerb}}}}
+
+	if ensureExperimentFilesCreatePolicy(role, []string{"exp-a"}) {
+		t.Fatal("expected role to stay unchanged")
+	}
+
+	policy := role.Policies[0]
+	if len(policy.ResourceNames) != 1 {
+		t.Fatalf("expected 1 resource name, got %d", len(policy.ResourceNames))
+	}
+	if len(policy.Verbs) != 1 {
+		t.Fatalf("expected 1 verb, got %d", len(policy.Verbs))
+	}
+}
+
+// TestExperimentResourceNamesPreservesUserScope verifies embedded user experiment scopes are reused.
+func TestExperimentResourceNamesPreservesUserScope(t *testing.T) {
+	role := &v1.RoleSpec{Name: "Experiment User", Policies: []*v1.PolicySpec{{Resources: []string{"experiments"}, ResourceNames: []string{"exp-a"}, Verbs: []string{"get"}}, {Resources: []string{"hosts"}, ResourceNames: []string{"*"}, Verbs: []string{"list"}}}}
+
+	names := experimentResourceNames(role)
+	if len(names) != 1 || names[0] != "exp-a" {
+		t.Fatalf("expected exp-a scope, got %#v", names)
+	}
+}
+
+// TestExperimentResourceNamesDefaultsNil verifies unscoped roles stay unscoped.
+func TestExperimentResourceNamesDefaultsNil(t *testing.T) {
+	role := &v1.RoleSpec{Name: "Experiment Admin", Policies: []*v1.PolicySpec{{Resources: []string{"experiments"}, Verbs: []string{"get"}}}}
+
+	names := experimentResourceNames(role)
+	if len(names) != 0 {
+		t.Fatalf("expected nil scope, got %#v", names)
+	}
+}
+
+// TestExperimentResourceNamesIgnoresOtherPolicyScopes verifies only experiments scope is copied.
+func TestExperimentResourceNamesIgnoresOtherPolicyScopes(t *testing.T) {
+	role := &v1.RoleSpec{Name: "Experiment User", Policies: []*v1.PolicySpec{{Resources: []string{"vms"}, ResourceNames: []string{"vm-a"}, Verbs: []string{"get"}}, {Resources: []string{"hosts"}, ResourceNames: []string{"*"}, Verbs: []string{"list"}}}}
+
+	names := experimentResourceNames(role)
+	if len(names) != 0 {
+		t.Fatalf("expected nil scope, got %#v", names)
+	}
+}
+
+// TestSyncUserSpecForExperimentFilesMigration verifies migrated user RBAC is prepared for saving.
+func TestSyncUserSpecForExperimentFilesMigration(t *testing.T) {
+	user := &User{Spec: &v1.UserSpec{Username: "user-a", Role: &v1.RoleSpec{Name: "Experiment User", Policies: []*v1.PolicySpec{{Resources: []string{"experiments"}, ResourceNames: []string{"exp-a"}, Verbs: []string{"get"}}}}}, config: &store.Config{Spec: map[string]any{}}}
+
+	if !ensureExperimentFilesCreatePolicy(user.Spec.Role, experimentResourceNames(user.Spec.Role)) {
+		t.Fatal("expected user role to change")
+	}
+
+	user.config.Spec = structs.MapDefaultCase(user.Spec, structs.CASESNAKE)
+	rbacSpec, ok := user.config.Spec["rbac"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected rbac spec map, got %#v", user.config.Spec["rbac"])
+	}
+
+	policies, ok := rbacSpec["policies"].([]any)
+	if !ok {
+		t.Fatalf("expected policies slice, got %#v", rbacSpec["policies"])
+	}
+
+	if len(policies) != 2 {
+		t.Fatalf("expected 2 policies, got %d", len(policies))
+	}
+}

--- a/src/go/web/server.go
+++ b/src/go/web/server.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -94,6 +95,14 @@ func ConfigureUsers(users []string) error {
 //nolint:funlen,maintidx // server startup
 func Start(opts ...ServerOption) error {
 	o = newServerOptions(opts...)
+	fileServerEndpoint, err := normalizeFileServerEndpoint(o.fileServerEndpoint)
+	if err != nil {
+		return fmt.Errorf("invalid ui.file-server-endpoint: %w", err)
+	}
+
+	if fileServerEndpoint != "" {
+		o.features["file-server"] = true
+	}
 
 	_ = ConfigureUsers(o.users)
 
@@ -317,6 +326,8 @@ func Start(opts ...ServerOption) error {
 		api.HandleFunc("/experiments/{exp}/vms/{name}/files/upload", UploadMountFile).
 			Methods("PUT", "OPTIONS").
 			Queries("path", "{path}")
+		api.HandleFunc("/experiments/{exp}/vms/{name}/files/copy", CopyExperimentFileToMount).
+			Methods("POST", "OPTIONS")
 	}
 
 	api.HandleFunc("/disks", GetDisks).Methods("GET", "OPTIONS")
@@ -415,6 +426,10 @@ func Start(opts ...ServerOption) error {
 
 	plog.Info(plog.TypeSystem, "using base path", "path", o.basePath)
 	plog.Info(plog.TypeSystem, "using JWT lifetime", "lifetime", o.jwtLifetime)
+
+	if fileServerEndpoint != "" {
+		go StartFileServer(fileServerEndpoint, o.jwtKey, o.proxyAuthHeader)
+	}
 
 	if common.UnixSocket != "" {
 		var (

--- a/src/js/src/components/RunningExperiment.vue
+++ b/src/js/src/components/RunningExperiment.vue
@@ -143,7 +143,7 @@
     </div>
   </b-modal>
   <b-modal :active.sync="portForwardModal.active" :on-cancel="resetPortForwardModal" has-modal-card>
-    <div class="modal-card" style="width:30em">
+    <div class="modal-card port-forward-modal" style="width:30em">
       <header class="modal-card-head">
         <p class="modal-card-title">Create New Port Forward</p>
       </header>
@@ -3474,6 +3474,9 @@ div.autocomplete >>> a.dropdown-item {
 
   >>> .label {
     color: white;
+  }
+  .port-forward-modal >>> .label {
+    color: #363636;
   }
   >>> .field-label {
     flex-grow: 3;

--- a/src/js/src/components/VMMountBrowserModal.vue
+++ b/src/js/src/components/VMMountBrowserModal.vue
@@ -35,12 +35,20 @@
                   :disabled="currentUploadProgress !== null">
             <span class="file-cta">
                 <b-icon class="file-icon" icon="upload"></b-icon>
-                <span class="file-label" :disabled="currentUploadProgress !== null">Upload File</span>
+                <span class="file-label" :disabled="currentUploadProgress !== null">Upload Local File</span>
             </span>
         </b-upload>
       </b-field>
+      <b-field v-show="fileServerEnabled && roleAllowed('vms/mount', 'patch', targetExp + '/' + targetVm) && roleAllowed('experiments/files', 'get', targetExp)" class="ml-3" style="margin-bottom: 0;">
+        <b-select v-model="selectedExperimentFile" :disabled="copyingExperimentFile || currentUploadProgress !== null || experimentFiles.length === 0" placeholder="Copy experiment file" @input="copyExperimentFile" expanded>
+          <option v-for="file in experimentFiles" :key="file.path" :value="file.path">{{ file.path }}</option>
+        </b-select>
+      </b-field>
       <b-progress class="progress mx-3" v-show="currentUploadProgress !== null" :value="currentUploadProgress" :max="100" show-value>
         {{this.currentUploadFileName}} : {{parseFloat(this.currentUploadProgress).toFixed(2)}}%
+      </b-progress>
+      <b-progress class="progress mx-3" v-show="copyingExperimentFile" indeterminate>
+        Copying {{this.currentCopyFileName}}
       </b-progress>
     </footer>
   </div>
@@ -48,6 +56,8 @@
 </template>
 
 <script>
+
+import { mapState } from 'vuex'
 
 export default {
   props: [
@@ -62,7 +72,11 @@ export default {
       filesLoading: false,
       currentPath: "/",
       currentUploadProgress: null,
-      currentUploadFileName: ""
+      currentUploadFileName: "",
+      experimentFiles: [],
+      selectedExperimentFile: null,
+      copyingExperimentFile: false,
+      currentCopyFileName: ""
     }
   },
 
@@ -72,8 +86,11 @@ export default {
 
   beforeMount() {
     this.$http.post(`experiments/${this.targetExp}/vms/${this.targetVm}/mount`).then(_ => {
-     this.getFiles();
-      
+      this.getFiles();
+      if (this.fileServerEnabled) {
+        this.getExperimentFiles();
+      }
+
     }, err => {
       this.errorDialog('Error mounting vm ' + this.targetVm + ": " + err.body);
       this.$parent.close();
@@ -94,7 +111,15 @@ export default {
       // prepend special entry for returning to base of mount
       p.unshift({part: 'mnt', upTo: '/'})
       return p
-    }
+    },
+
+    fileServerEnabled() {
+      return this.features.includes('file-server')
+    },
+
+    ...mapState({
+      features: 'features'
+    })
   },
 
   watch : {
@@ -119,6 +144,15 @@ export default {
         });
     },
 
+    // getExperimentFiles loads files available to copy from this experiment.
+    getExperimentFiles() {
+      this.$http.get(`experiments/${this.targetExp}/files`).then(resp => {
+        this.experimentFiles = resp.body.files === null ? [] : resp.body.files;
+      }, err => {
+        this.errorDialog(`Error getting experiment files: ${err.body}`)
+      });
+    },
+
     downloadFile(path) {
       this.$buefy.dialog.confirm({
         type: "is-info",
@@ -127,6 +161,27 @@ export default {
           window.open(`${process.env.BASE_URL}api/v1/experiments/${this.targetExp}/vms/${this.targetVm}/files/download?token=${this.$store.state.token}&path=${encodeURIComponent(path)}`, '_blank');
         }
       });
+    },
+
+    // copyExperimentFile copies the selected experiment file into the current VM path.
+    copyExperimentFile(path) {
+      if (!path) {
+        return;
+      }
+
+      this.currentCopyFileName = path.substring(path.lastIndexOf('/') + 1);
+      this.copyingExperimentFile = true;
+      this.$http.post(`experiments/${this.targetExp}/vms/${this.targetVm}/files/copy`, null, {
+          params: { 'path': this.currentPath, 'source': path }
+        }).then(_ => {
+          this.selectedExperimentFile = null;
+          this.copyingExperimentFile = false;
+          this.getFiles();
+        }, err => {
+          this.errorDialog(`Error copying experiment file: ${err.body}`)
+          this.selectedExperimentFile = null;
+          this.copyingExperimentFile = false;
+        });
     },
 
     handleUpload(file) {


### PR DESCRIPTION
# feat: add separate file server for uploading experiment files

## Description
This PR adds a file server listening on a port separate from the main phenix server that allows users to upload files to an experiment. It has a dead-simple user interface that simply allows the user to select the experiment to upload a file to. When the file server is enabled, the VM Mount modal now includes an option for copying existing experiment files into the VM (in addition to uploading from the user's local file system).

These two additions have been added to support a specific use case where the phenix UI is only available on a private network but users needed a way to get files (e.g., application installers and configurations) into experiment environments from a public network.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
When authn/authz is enabled for the main phenix UI, it's also automatically enabled for the file server. This means anyone wanting to upload files to an experiment environment must already have credentials within phenix. It also adds file upload permissions to the default roles for Experiment Admins and Experiment Users, and updates any existing users with those roles.
