### PR TITLE
fix(scorch-ui): reset SCORCH pipeline state on experiment start

### DIFF
--- a/src/go/api/scorch/scorch.go
+++ b/src/go/api/scorch/scorch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"phenix/api/config"
+	"phenix/api/experiment"
 	"phenix/store"
 	"phenix/web/scorch"
 )
@@ -80,5 +81,9 @@ func init() { //nolint:gochecknoinits // config hook
 		}
 
 		return nil
+	})
+
+	experiment.RegisterHook("start", func(_ string, name string) { // clear SCORCH pipeline on experiment start
+		scorch.DeletePipeline(name, -1, -1, false)
 	})
 }

--- a/src/go/web/common.go
+++ b/src/go/web/common.go
@@ -19,6 +19,7 @@ import (
 	"phenix/web/broker"
 	bt "phenix/web/broker/brokertypes"
 	"phenix/web/cache"
+	"phenix/web/scorch"
 	"phenix/web/util"
 	"phenix/web/weberror"
 )
@@ -45,6 +46,9 @@ func startExperiment(name string) ([]byte, error) {
 	}
 
 	defer cache.UnlockExperiment(name)
+
+	// Clear previous SCORCH pipeline runtime state before experiment start
+	scorch.DeletePipeline(name, -1, -1, false)
 
 	broker.Broadcast(
 		bt.NewRequestPolicy("experiments/start", "update", name),
@@ -284,6 +288,9 @@ func stopExperiment(name string) ([]byte, error) {
 
 		return nil, err.SetStatus(http.StatusBadRequest)
 	}
+
+	// Clear previous SCORCH pipeline runtime state after successful experiment stop
+	scorch.DeletePipeline(name, -1, -1, false)
 
 	exp, err := experiment.Get(name)
 	if err != nil {

--- a/src/go/web/common.go
+++ b/src/go/web/common.go
@@ -47,9 +47,6 @@ func startExperiment(name string) ([]byte, error) {
 
 	defer cache.UnlockExperiment(name)
 
-	// Clear previous SCORCH pipeline runtime state before experiment start
-	scorch.DeletePipeline(name, -1, -1, false)
-
 	broker.Broadcast(
 		bt.NewRequestPolicy("experiments/start", "update", name),
 		bt.NewResource("experiment", name, "starting"),
@@ -168,6 +165,9 @@ func startExperiment(name string) ([]byte, error) {
 
 				return nil, err.SetStatus(http.StatusBadRequest)
 			}
+
+			// Clear previous SCORCH pipeline runtime state after successful experiment start.
+			scorch.DeletePipeline(name, -1, -1, false)
 
 			// We don't want to use the HTTP request's context here.
 			ctx, cancel := context.WithCancel(context.Background())
@@ -288,9 +288,6 @@ func stopExperiment(name string) ([]byte, error) {
 
 		return nil, err.SetStatus(http.StatusBadRequest)
 	}
-
-	// Clear previous SCORCH pipeline runtime state after successful experiment stop
-	scorch.DeletePipeline(name, -1, -1, false)
 
 	exp, err := experiment.Get(name)
 	if err != nil {

--- a/src/js/src/components/ScorchRuns.vue
+++ b/src/js/src/components/ScorchRuns.vue
@@ -330,6 +330,12 @@
             }
 
             switch ( msg.resource.action ) {
+              case 'start':
+              case 'stop': {
+                this.runsView(this.exp.name);
+                break;
+              }
+
               case 'delete': {
                 this.$router.replace({name: 'scorch'});
               

--- a/src/js/src/components/ScorchRuns.vue
+++ b/src/js/src/components/ScorchRuns.vue
@@ -139,6 +139,11 @@
           }
 
           default: {
+            if ( comp.status === 'unknown' ) { // clear stale UI for unknown status
+              this.exitOutput();
+              this.resetTerminal(true);
+              return;
+            }
             let endpoint = `experiments/${comp.exp}/scorch/components/${comp.run}/${comp.loop}/${comp.stage}/${comp.name}`;
 
             this.$http.get(
@@ -330,8 +335,9 @@
             }
 
             switch ( msg.resource.action ) {
-              case 'start':
-              case 'stop': {
+              case 'start':{ 
+                this.exitOutput();
+                this.resetTerminal(true);
                 this.runsView(this.exp.name);
                 break;
               }


### PR DESCRIPTION
# fix(scorch-ui): reset SCORCH pipeline state on experiment start 

## Description
Reset SCORCH pipeline state on experiment start to avoid carrying stale data between experiment runs. This includes clearing the ui component info (what you see when you click the little bubbles). Previously, when you restarted an experiment, the SCORCH pipeline kept all its green bubbles. 

## Related Issue
First part of #286 

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

- **Scope**: This fix applies exclusively to the Web UI.
- **Behavior**: When users interact with the application via the web interface, the fix is applied. However, the CLI remains unimpacted and does not receive this UI update.