### PR TITLE
fix(scenario): include disabled and runPeriodically when merging fromScenario apps

### DIFF
--- a/src/go/types/scenario.go
+++ b/src/go/types/scenario.go
@@ -128,6 +128,8 @@ func MergeScenariosForTopology(scenario ifaces.ScenarioSpec, topology string) er
 					app.SetAssetDir(fromApp.AssetDir())
 					app.SetMetadata(fromApp.Metadata())
 					app.SetHosts(fromApp.Hosts())
+					app.SetDisabled(fromApp.Disabled())
+					app.SetRunPeriodically(fromApp.RunPeriodically())
 
 					found = true
 


### PR DESCRIPTION
## Description
`MergeScenariosForTopology` copied `assetDir`, `metadata`, and `hosts` from the included scenario's app but not `disabled` or `runPeriodically`, so those fields silently fell back to their zero values instead of the includee's.

## Related Issue
Fixes #266

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [~] ~~I have commented my code, particularly in hard-to-understand areas.~~
- [~] ~~I have made corresponding changes to the documentation.~~
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A