### PR TITLE
fix(app): propagate user app errors from running stage

### DIFF
--- a/src/go/app/app.go
+++ b/src/go/app/app.go
@@ -175,7 +175,7 @@ type App interface {
 // the given experiment for the given lifecycle phase. It returns any errors
 // encountered while applying the apps.
 //
-//nolint:cyclop,funlen,gocyclo,maintidx // complex logic
+//nolint:funlen,maintidx // complex logic
 func ApplyApps(ctx context.Context, exp *types.Experiment, opts ...Option) error {
 	var (
 		options = NewOptions(opts...)
@@ -329,39 +329,35 @@ func ApplyApps(ctx context.Context, exp *types.Experiment, opts ...Option) error
 
 				exp.Status.SetAppRunning(app.Name(), true)
 
-				err := exp.WriteToStore(true)
-				if err != nil {
+				// storeErr is local to issues here
+				storeErr := exp.WriteToStore(true)
+				if storeErr != nil {
 					notes.AddErrors(
 						ctx,
 						false,
 						fmt.Errorf(
 							"error updating store with experiment (%s): %w",
 							exp.Spec.ExperimentName(),
-							err,
+							storeErr,
 						),
 					)
 				}
 
-				if err := a.Running(ctx, exp); err != nil {
-					notes.AddErrors(
-						ctx,
-						false,
-						fmt.Errorf("running app %s: %w", app.Name(), err),
-					)
-				}
+				// Assign to the function-level err to carry out
+				err = a.Running(ctx, exp)
 
 				_ = exp.Reload() // reload experiment from store in case status was updated during run
 				exp.Status.SetAppRunning(app.Name(), false)
 
-				err = exp.WriteToStore(true)
-				if err != nil {
+				storeErr = exp.WriteToStore(true)
+				if storeErr != nil {
 					notes.AddErrors(
 						ctx,
 						false,
 						fmt.Errorf(
 							"error updating store with experiment (%s): %w",
 							exp.Spec.ExperimentName(),
-							err,
+							storeErr,
 						),
 					)
 				}

--- a/src/go/app/app_test.go
+++ b/src/go/app/app_test.go
@@ -1,0 +1,118 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"phenix/app"
+	"phenix/store"
+	"phenix/types"
+)
+
+// stubApp is a minimal user app whose running stage returns a configurable
+// error.
+type stubApp struct {
+	name string
+	err  error
+}
+
+func (a *stubApp) Init(...app.Option) error { return nil }
+
+func (a *stubApp) Name() string { return a.name }
+
+func (a *stubApp) Configure(context.Context, *types.Experiment) error { return nil }
+
+func (a *stubApp) PreStart(context.Context, *types.Experiment) error { return nil }
+
+func (a *stubApp) PostStart(context.Context, *types.Experiment) error { return nil }
+
+func (a *stubApp) Running(context.Context, *types.Experiment) error { return a.err }
+
+func (a *stubApp) Cleanup(context.Context, *types.Experiment) error { return nil }
+
+// runningStageExperiment builds a minimal experiment whose scenario contains
+// the single given app, backed by a store mock so WriteToStore/Reload calls
+// made during the running stage are absorbed.
+func runningStageExperiment(t *testing.T, appName string) *types.Experiment {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	m := store.NewMockStore(ctrl)
+	m.EXPECT().Get(gomock.Any()).Return(errors.New("store unavailable")).AnyTimes()
+
+	store.DefaultStore = m //nolint:reassign // monkey patching for test
+
+	c := store.Config{
+		Version:  "phenix.sandia.gov/v1",
+		Kind:     "Experiment",
+		Metadata: store.ConfigMetadata{Name: "running-stage-test"},
+		Spec: map[string]any{
+			"experimentName": "running-stage-test",
+			"scenario": map[string]any{
+				"apps": []map[string]any{{"name": appName}},
+			},
+		},
+	}
+
+	exp, err := types.DecodeExperimentFromConfig(c)
+	if err != nil {
+		t.Fatalf("decoding experiment from config: %v", err)
+	}
+
+	return exp
+}
+
+// TestApplyAppsRunningStageErrorPropagates is a regression test for user app
+// errors (e.g. failed SOH checks) being silently swallowed during the running
+// stage, which caused scorch and `phenix experiment trigger-running` to report
+// success even when an app failed.
+func TestApplyAppsRunningStageErrorPropagates(t *testing.T) {
+	name := "test-running-fails"
+
+	if err := app.RegisterUserApp(name, func() app.App {
+		return &stubApp{name: name, err: errors.New("checks failed")}
+	}); err != nil {
+		t.Fatalf("registering user app: %v", err)
+	}
+
+	exp := runningStageExperiment(t, name)
+
+	err := app.ApplyApps(
+		context.Background(),
+		exp,
+		app.Stage(app.ActionRunning),
+		app.FilterApp(name),
+	)
+	if err == nil {
+		t.Fatal("expected running-stage app error to propagate, got nil")
+	}
+}
+
+// TestApplyAppsRunningStageSuccess verifies a successful running stage still
+// returns nil.
+func TestApplyAppsRunningStageSuccess(t *testing.T) {
+	name := "test-running-succeeds"
+
+	if err := app.RegisterUserApp(name, func() app.App {
+		return &stubApp{name: name, err: nil}
+	}); err != nil {
+		t.Fatalf("registering user app: %v", err)
+	}
+
+	exp := runningStageExperiment(t, name)
+
+	err := app.ApplyApps(
+		context.Background(),
+		exp,
+		app.Stage(app.ActionRunning),
+		app.FilterApp(name),
+	)
+	if err != nil {
+		t.Fatalf("expected no error from successful running stage, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Description
The lint rewrite in 85f19b3 shadowed the error returned by user apps' `running` stage in `ApplyApps`, so failed SOH checks were reported as successful by scorch and the CLI. This restores error propagation and adds a regression test.

## Related Issue
N/A

## Type of Change
- [x] Bugfix
- [ ] ~~New feature~~
- [ ] ~~Documentation update~~
- [ ] ~~Other (please describe):~~

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] ~~I have made corresponding changes to the documentation.~~
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
🤖 Generated with [Claude Code](https://claude.com/claude-code)