### PR TITLE
fix(ui): preserve route during auth bootstrap

### DIFF
--- a/src/js/src/router.js
+++ b/src/js/src/router.js
@@ -98,7 +98,7 @@ router.beforeEach( async ( to, from, next ) => {
         }
       }
 
-      store.commit( 'LOGIN', { loginResponse, 'remember': false } );
+      store.commit( 'LOGIN', { loginResponse, 'remember': false, 'navigate': false } );
     }
 
     next();

--- a/src/js/src/store.js
+++ b/src/js/src/store.js
@@ -20,7 +20,7 @@ export default new Vuex.Store({
   },
 
   mutations: {
-    'LOGIN' ( state, { loginResponse, remember } ) {
+    'LOGIN' ( state, { loginResponse, remember, navigate = true } ) {
       state.username = loginResponse.user.username;
       state.token    = loginResponse.token;
       state.role     = loginResponse.user.role;
@@ -31,6 +31,10 @@ export default new Vuex.Store({
         localStorage.setItem( 'phenix.token', state.token );
         localStorage.setItem( 'phenix.role',  JSON.stringify(state.role) );
         localStorage.setItem( 'phenix.auth',  state.auth );
+      }
+
+      if ( !navigate ) {
+        return;
       }
 
       if ( state.role.name === "VM Viewer" ) {


### PR DESCRIPTION
## Description
Prevent disabled-auth initialization from redirecting to the home page while Vue Router is resolving a directly requested route. This preserves the current page when users refresh history-mode routes such as `/scorch`, `/configs`, or `/settings`.

## Related Issue
Closes #275.

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
~~- [ ] I have commented my code, particularly in hard-to-understand areas.~~ (No additional comments needed.)
~~- [ ] I have made corresponding changes to the documentation.~~ (No documentation changes needed.)
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

I tested with a basic container running on my Mac: `docker run -p 3000:3000 ghcr.io/ghostofgoes/sceptre-phenix/phenix:fix-issue-275-refresh-routing phenix ui` 

I recommend anyone who uses the standard phenix image test this change (e.g. if you typically use phenix via `http://localhost:3000`)

 An easy way to test is to configure phēnix to use this source image:

```text
ghcr.io/ghostofgoes/sceptre-phenix/phenix:fix-issue-275-refresh-routing
```