### PR TITLE
feat(vm-ui): show descriptions in VM details

### DIFF
--- a/src/go/api/vm/vm.go
+++ b/src/go/api/vm/vm.go
@@ -99,6 +99,7 @@ func List(expName string) ([]mm.VM, error) { //nolint:funlen // complex logic
 		vm := mm.VM{ //nolint:exhaustruct // partial initialization
 			ID:              idx,
 			Name:            node.General().Hostname(),
+			Description:     node.General().Description(),
 			Experiment:      exp.Spec.ExperimentName(),
 			CPUs:            node.Hardware().VCPU(),
 			RAM:             node.Hardware().Memory(),
@@ -203,6 +204,7 @@ func Get(expName, vmName string) (*mm.VM, error) {
 		vm = &mm.VM{ //nolint:exhaustruct // partial initialization
 			ID:              idx,
 			Name:            node.General().Hostname(),
+			Description:     node.General().Description(),
 			Experiment:      exp.Spec.ExperimentName(),
 			CPUs:            node.Hardware().VCPU(),
 			RAM:             node.Hardware().Memory(),

--- a/src/go/util/mm/types.go
+++ b/src/go/util/mm/types.go
@@ -209,6 +209,7 @@ func (v VMs) Paginate(page, size int) VMs {
 type VM struct {
 	ID              int               `json:"id"`
 	Name            string            `json:"name"`
+	Description     string            `json:"description"`
 	Type            string            `json:"type"`
 	Experiment      string            `json:"experiment"`
 	Host            string            `json:"host"`

--- a/src/go/web/proto/vm.proto
+++ b/src/go/web/proto/vm.proto
@@ -26,6 +26,7 @@ message VM {
   string delayed_start = 21 [json_name="delayed_start"];
   bool snapshot = 22 [json_name="snapshot"];
   uint32 inject_partition = 23 [json_name="inject_partition"];
+  string description = 24;
 }
 
 message VMList {

--- a/src/go/web/util/protobuf.go
+++ b/src/go/web/util/protobuf.go
@@ -95,6 +95,7 @@ func ExperimentToProtobuf(
 func VMToProtobuf(exp string, vm mm.VM, topology ifaces.TopologySpec) *proto.VM {
 	v := &proto.VM{ //nolint:exhaustruct // partial initialization
 		Name:            vm.Name,
+		Description:     vm.Description,
 		Host:            vm.Host,
 		Ipv4:            vm.IPv4,
 		Cpus:            uint32(vm.CPUs), //nolint:gosec // integer overflow conversion int -> uint32

--- a/src/js/src/components/RunningExperiment.vue
+++ b/src/js/src/components/RunningExperiment.vue
@@ -7,6 +7,7 @@
         </header>
         <section class="modal-card-body">
           <p>Host: {{ expModal.vm.host }}</p>
+          <p>Description: {{ expModal.vm.description || 'unknown' }}</p>
           <p>IPv4: {{ expModal.vm.ipv4 | stringify }}</p>
           <p>CPU(s): {{ expModal.vm.cpus }}</p>
           <p>Memory: {{ expModal.vm.ram | ram }}</p>
@@ -1784,6 +1785,10 @@
           return
         }
 
+        this.expModal.vm       = vm;
+        this.expModal.fullName = this.experiment.name + '/' + vm.name;
+        this.expModal.active   = true;
+
         try {
           const [details, snapshots, forwards] = await Promise.all([
             this.fetchVMDetails(vm),
@@ -1809,9 +1814,6 @@
               this.expModal.forwards.push(l);
             }
           }
-
-          this.expModal.fullName = this.experiment.name + '/' + vm.name;
-          this.expModal.active   = true;
         } catch (err) {
           this.errorNotification(err);
         }

--- a/src/js/src/components/StoppedExperiment.vue
+++ b/src/js/src/components/StoppedExperiment.vue
@@ -7,6 +7,7 @@
         </header>
         <section class="modal-card-body">
           <p>Host: {{ expModal.vm.host }}</p>
+          <p>Description: {{ expModal.vm.description || 'unknown' }}</p>
           <p>IPv4: {{ expModal.vm.ipv4 | stringify }}</p>
           <p>CPU(s): {{ expModal.vm.cpus }}</p>
           <p>Memory: {{ expModal.vm.ram | ram }}</p>


### PR DESCRIPTION
## Description
Expose topology node descriptions through the VM API and display them in running and stopped VM detail modals in the phenix UI.

Also, the running modal now opens immediately while snapshots and forwards load. This reduces lag when clicking on a VM to open it's modal. Unfortunately, this appears to have a side-effect of sometimes another VM's info will be briefly shown. IMO, a more responsive UI is preferable.

### Example of a VM description in the UI

<img width="530" height="73" alt="image" src="https://github.com/user-attachments/assets/06183db6-410f-4b6b-8c56-1649a7f5bca1" />

### In the YAML

```yaml
description: |
  This is a VyOS router that routes between SW1 and SW2 VLANs.
  It also has Internet connectivity via the MGMT interface.
```

## Related Issue
N/A

## Type of Change
- [x] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Validated by running a experiment with detailed VM descriptions, and clicking on VM info pages in the UI.
