### PR TITLE
fix(windows): use case-sensitive hostname comparison

### DIFF
--- a/src/go/tmpl/templates/windows_startup.tmpl
+++ b/src/go/tmpl/templates/windows_startup.tmpl
@@ -142,8 +142,9 @@ Set-DnsClientServerAddress -InterfaceIndex $adapters[0].ifIndex -ServerAddresses
 echo 'Done configuring network interfaces'
 Start-Sleep -s 5
 
+# FIX: -c needed to ensure case-sensitive comparison of hostnames
 $host_name = hostname
-if ($host_name -eq "{{ .Node.General.Hostname }}") {
+if ($host_name -ceq "{{ .Node.General.Hostname }}") {
 {{ if .Metadata.domain_controller }}
     if (Phenix-StartupStatusIs('joined-domain')) {
         echo 'Startup script complete!'


### PR DESCRIPTION
# fix(windows): use case-sensitive hostname comparison

## Description
If a Windows VM's baked hostname differs from configured hostname only in case, then the hostname will never be configured.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A
