### PR TITLE
feat(cli): expose tap and runtime details

### DIFF
--- a/src/go/app/user.go
+++ b/src/go/app/user.go
@@ -31,6 +31,19 @@ type UserApp struct {
 	options Options
 }
 
+// PopulateRuntime adds current minimega host and VM details to an experiment.
+func PopulateRuntime(exp *types.Experiment) error {
+	cluster, err := mm.GetClusterHosts(true)
+	if err != nil {
+		return fmt.Errorf("getting cluster hosts: %w", err)
+	}
+
+	exp.Hosts = cluster
+	exp.VMs = mm.GetVMInfo(mm.NS(exp.Spec.ExperimentName()))
+
+	return nil
+}
+
 func (u *UserApp) Init(opts ...Option) error {
 	u.options = NewOptions(opts...)
 
@@ -97,12 +110,9 @@ func (u UserApp) shellOut(ctx context.Context, action Action, exp *types.Experim
 		)
 	}
 
-	cluster, err := mm.GetClusterHosts(true)
-	if err != nil {
-		return fmt.Errorf("getting cluster hosts: %w", err)
+	if err := PopulateRuntime(exp); err != nil {
+		return err
 	}
-
-	exp.Hosts = cluster
 
 	data, err := json.Marshal(exp)
 	if err != nil {

--- a/src/go/app/user_test.go
+++ b/src/go/app/user_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"encoding/json"
+	"testing"
+
+	"phenix/store"
+	"phenix/types"
+	"phenix/util/mm"
+)
+
+type runtimeMM struct {
+	mm.MM
+
+	hosts mm.Hosts
+	vms   mm.VMs
+}
+
+func (m runtimeMM) GetClusterHosts(bool) (mm.Hosts, error) {
+	return m.hosts, nil
+}
+
+func (m runtimeMM) GetVMInfo(...mm.Option) mm.VMs {
+	return m.vms
+}
+
+func TestPopulateRuntimeIncludesVMTapsInExperimentJSON(t *testing.T) {
+	originalMM := mm.DefaultMM
+	t.Cleanup(func() { mm.DefaultMM = originalMM }) //nolint:reassign // restore test double
+
+	hosts := mm.Hosts{{Name: "compute-0"}}
+	vms := mm.VMs{{
+		Name: "router",
+		Host: "compute-0",
+		Taps: []string{"mega_tap101", "mega_tap102"},
+	}}
+	mm.DefaultMM = runtimeMM{hosts: hosts, vms: vms} //nolint:reassign // install test double
+
+	exp := types.NewExperiment(store.ConfigMetadata{Name: "tap-test"})
+	exp.Spec.SetExperimentName("tap-test")
+
+	if err := PopulateRuntime(exp); err != nil {
+		t.Fatalf("populating experiment runtime details: %v", err)
+	}
+
+	if len(exp.Hosts) != 1 || exp.Hosts[0].Name != hosts[0].Name {
+		t.Fatalf("unexpected runtime hosts: %#v", exp.Hosts)
+	}
+
+	if len(exp.VMs) != 1 || exp.VMs[0].Name != vms[0].Name {
+		t.Fatalf("unexpected runtime VMs: %#v", exp.VMs)
+	}
+
+	data, err := json.Marshal(exp)
+	if err != nil {
+		t.Fatalf("marshaling experiment: %v", err)
+	}
+
+	var payload struct {
+		VMs []struct {
+			Taps []string `json:"taps"`
+		} `json:"vms"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshaling experiment JSON: %v", err)
+	}
+
+	if len(payload.VMs) != 1 || len(payload.VMs[0].Taps) != 2 {
+		t.Fatalf("VM taps missing from experiment JSON: %s", data)
+	}
+}

--- a/src/go/cmd/util.go
+++ b/src/go/cmd/util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"phenix/api/experiment"
+	"phenix/app"
 	"phenix/util"
 	"phenix/web/rbac"
 )
@@ -43,6 +44,12 @@ func newUtilAppJSONCmd() *cobra.Command {
 			exp, err := experiment.Get(name)
 			if err != nil {
 				err := util.HumanizeError(err, "%s", "Unable to get the "+name+" experiment")
+
+				return err.Humanized()
+			}
+
+			if err := app.PopulateRuntime(exp); err != nil {
+				err := util.HumanizeError(err, "Unable to collect runtime experiment information")
 
 				return err.Humanized()
 			}

--- a/src/go/cmd/vm.go
+++ b/src/go/cmd/vm.go
@@ -278,7 +278,7 @@ func newVMInfoCmd() *cobra.Command {
 					return err.Humanized()
 				}
 
-				printer.PrintTableOfVMs(os.Stdout, vms...)
+				printer.PrintTableOfVMs(os.Stdout, MustGetBool(cmd.Flags(), "taps"), vms...)
 
 				return nil
 			}
@@ -292,7 +292,7 @@ func newVMInfoCmd() *cobra.Command {
 					return err.Humanized()
 				}
 
-				printer.PrintTableOfVMs(os.Stdout, vms...)
+				printer.PrintTableOfVMs(os.Stdout, MustGetBool(cmd.Flags(), "taps"), vms...)
 			case infoArgs:
 				vm, err := vm.Get(args[0], args[1])
 				if err != nil {
@@ -305,7 +305,7 @@ func newVMInfoCmd() *cobra.Command {
 					return err.Humanized()
 				}
 
-				printer.PrintTableOfVMs(os.Stdout, *vm)
+				printer.PrintTableOfVMs(os.Stdout, MustGetBool(cmd.Flags(), "taps"), *vm)
 			default:
 				return errors.New("invalid argument")
 			}
@@ -315,6 +315,7 @@ func newVMInfoCmd() *cobra.Command {
 	}
 
 	addVMLabelFlag(cmd)
+	cmd.Flags().BoolP("taps", "t", false, "Include tap interface names")
 
 	return cmd
 }

--- a/src/go/types/experiment.go
+++ b/src/go/types/experiment.go
@@ -23,6 +23,7 @@ type Experiment struct {
 
 	// used for user apps
 	Hosts mm.Hosts `json:"hosts,omitempty" yaml:"hosts,omitempty"` // cluster host details
+	VMs   mm.VMs   `json:"vms,omitempty"   yaml:"vms,omitempty"`   // VM runtime details
 }
 
 func NewExperiment(md store.ConfigMetadata) *Experiment {

--- a/src/go/util/printer/printer.go
+++ b/src/go/util/printer/printer.go
@@ -67,37 +67,38 @@ func PrintTableOfExperiments(writer io.Writer, exps ...types.Experiment) {
 }
 
 // PrintTableOfVMs writes the given VMs to the given writer as an ASCII table.
-// The table headers are set to Host, Name, Running, Disk, Interfaces, and
-// Uptime.
-func PrintTableOfVMs(writer io.Writer, vms ...mm.VM) {
+func PrintTableOfVMs(writer io.Writer, includeTaps bool, vms ...mm.VM) {
 	table := tablewriter.NewWriter(writer)
 
 	switch len(vms) {
 	case 0:
 		return
 	case 1:
-		buildSingleVMTable(table, vms[0])
+		buildSingleVMTable(table, includeTaps, vms[0])
 	default:
-		buildMultipleVMTable(table, vms...)
+		buildMultipleVMTable(table, includeTaps, vms...)
 	}
 
 	table.Render()
 }
 
-func buildMultipleVMTable(table *tablewriter.Table, vms ...mm.VM) {
-	table.SetHeader(
-		[]string{
-			"Host",
-			"Name",
-			"Running",
-			"Disk",
-			"Interfaces",
-			"Uptime",
-			"Memory",
-			"VCPUs",
-			"OS Type",
-		},
-	)
+func buildMultipleVMTable(table *tablewriter.Table, includeTaps bool, vms ...mm.VM) {
+	header := []string{
+		"Host",
+		"Name",
+		"Running",
+		"Disk",
+		"Interfaces",
+		"Uptime",
+		"Memory",
+		"VCPUs",
+		"OS Type",
+	}
+	if includeTaps {
+		header = append(header, "Taps")
+	}
+
+	table.SetHeader(header)
 	table.SetAutoWrapText(false)
 	table.SetColWidth(colWidth)
 
@@ -116,23 +117,26 @@ func buildMultipleVMTable(table *tablewriter.Table, vms ...mm.VM) {
 			uptime = (time.Duration(vm.Uptime) * time.Second).String()
 		}
 
-		table.Append(
-			[]string{
-				vm.Host,
-				vm.Name,
-				running,
-				vm.Disk,
-				strings.Join(ifaces, "\n"),
-				uptime,
-				strconv.Itoa(vm.RAM),
-				strconv.Itoa(vm.CPUs),
-				vm.OSType,
-			},
-		)
+		row := []string{
+			vm.Host,
+			vm.Name,
+			running,
+			vm.Disk,
+			strings.Join(ifaces, "\n"),
+			uptime,
+			strconv.Itoa(vm.RAM),
+			strconv.Itoa(vm.CPUs),
+			vm.OSType,
+		}
+		if includeTaps {
+			row = append(row, strings.Join(vm.Taps, ", "))
+		}
+
+		table.Append(row)
 	}
 }
 
-func buildSingleVMTable(table *tablewriter.Table, vm mm.VM) {
+func buildSingleVMTable(table *tablewriter.Table, includeTaps bool, vm mm.VM) {
 	table.SetHeader([]string{"Setting", "Value"})
 	table.SetAutoWrapText(false)
 	table.SetColWidth(colWidth)
@@ -172,6 +176,9 @@ func buildSingleVMTable(table *tablewriter.Table, vm mm.VM) {
 	table.Append([]string{"VCPUs", strconv.Itoa(vm.CPUs)})
 	table.Append([]string{"Memory", strconv.Itoa(vm.RAM)})
 	table.Append([]string{"OS Type", vm.OSType})
+	if includeTaps {
+		table.Append([]string{"Taps", strings.Join(vm.Taps, ", ")})
+	}
 	table.Append([]string{"Labels", strings.Join(labels, ", ")})
 	table.Append([]string{"Metadata", string(metadata)})
 }

--- a/src/go/util/printer/printer_test.go
+++ b/src/go/util/printer/printer_test.go
@@ -1,0 +1,37 @@
+package printer
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"phenix/util/mm"
+)
+
+func TestPrintTableOfVMsOptionallyIncludesTaps(t *testing.T) {
+	vm := mm.VM{
+		Name: "router",
+		Taps: []string{"mega_tap101", "mega_tap102"},
+	}
+
+	var output bytes.Buffer
+	PrintTableOfVMs(&output, false, vm)
+
+	if strings.Contains(output.String(), "mega_tap101") {
+		t.Fatalf("tap names included without taps option:\n%s", output.String())
+	}
+
+	output.Reset()
+	PrintTableOfVMs(&output, true, vm)
+
+	if !strings.Contains(output.String(), "mega_tap101, mega_tap102") {
+		t.Fatalf("tap names missing from single VM table:\n%s", output.String())
+	}
+
+	output.Reset()
+	PrintTableOfVMs(&output, true, vm, mm.VM{Name: "server", Taps: []string{"mega_tap103"}})
+
+	if !strings.Contains(output.String(), "mega_tap103") {
+		t.Fatalf("tap names missing from multiple VM table:\n%s", output.String())
+	}
+}


### PR DESCRIPTION
## Description

Adds tap names to `phenix vm info` with the new `-t`/`--taps` argument. By default, they are not displayed.

Also includes current VM runtime details in user-app experiment JSON.

### Example of `phenix vm info <exp> -t`

```shell
$ phenix vm info helloworld -t
+--------+-------------+---------+--------------------------+------------------------------------------+--------+--------+-------+---------+------------------------------------+
|  HOST  |    NAME     | RUNNING |           DISK           |                INTERFACES                | UPTIME | MEMORY | VCPUS | OS TYPE |                TAPS                |
+--------+-------------+---------+--------------------------+------------------------------------------+--------+--------+-------+---------+------------------------------------+
| myhost | router      | true    | /phenix/images/vyos.qc2  | ID: 0, IP: 192.168.1.1, VLAN: SW1 (101)  | 25s    |   2048 |     1 | vyos    | mega_tap14, mega_tap15, mega_tap16 |
|        |             |         |                          | ID: 1, IP: 192.168.2.1, VLAN: SW2 (102)  |        |        |       |         |                                    |
|        |             |         |                          | ID: 2, IP: 172.16.0.5, VLAN: MGMT (103)  |        |        |       |         |                                    |
| myhost | test1       | true    | /phenix/images/jammy.qc2 | ID: 0, IP: 192.168.1.10, VLAN: SW1 (101) | 24s    |   2048 |     2 | linux   | mega_tap17                         |
| myhost | test2       | true    | /phenix/images/jammy.qc2 | ID: 0, IP: 192.168.1.11, VLAN: SW1 (101) | 24s    |   2048 |     1 | linux   | mega_tap18                         |
| myhost | unlabeled   | true    | /phenix/images/jammy.qc2 | ID: 0, IP: 192.168.2.12, VLAN: SW2 (102) | 24s    |   2048 |     1 | linux   | mega_tap19                         |
| myhost | tap-example | true    | /phenix/images/jammy.qc2 | ID: 0, IP: 172.16.0.33, VLAN: MGMT (103) | 24s    |   2048 |     1 | linux   | mega_tap20                         |
|        | hil-device  | false   |                          | ID: 0, IP: 192.168.2.22, VLAN: SW2       |        |      0 |     0 | EXP     |                                    |
+--------+-------------+---------+--------------------------+------------------------------------------+--------+--------+-------+---------+------------------------------------+
```

### Example of `phenix vm info <exp> <vm> -t`

```shell
$ phenix vm info helloworld router -t
+------------+-----------------------------------------+
|  SETTING   |                  VALUE                  |
+------------+-----------------------------------------+
| Host       | myhost                                  |
| Name       | router                                  |
| Running    | true                                    |
| Disk       | /phenix/images/vyos.qc2                 |
| Interfaces | ID: 0, IP: 192.168.1.1, VLAN: SW1 (101) |
|            | ID: 1, IP: 192.168.2.1, VLAN: SW2 (102) |
|            | ID: 2, IP: 172.16.0.5, VLAN: MGMT (103) |
| Uptime     | 35s                                     |
| VCPUs      | 1                                       |
| Memory     | 2048                                    |
| OS Type    | vyos                                    |
| Taps       | mega_tap14, mega_tap15, mega_tap16      |
| Labels     | router: true                            |
| Metadata   |                                         |
+------------+-----------------------------------------+
```

## Related Issue
Closes https://github.com/sandialabs/sceptre-phenix/issues/5

## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Need to update docs, will do later