### PR TITLE
fix(ui): count only bootable VMs for running experiments

### DIFF
--- a/src/go/web/util/protobuf.go
+++ b/src/go/web/util/protobuf.go
@@ -16,6 +16,11 @@ func ExperimentToProtobuf(
 	status cache.Status,
 	vms []mm.VM,
 ) *proto.Experiment {
+	vmCount := len(vms)
+	if exp.Running() {
+		vmCount = 0
+	}
+
 	pb := &proto.Experiment{ //nolint:exhaustruct // partial initialization
 		Name:      exp.Spec.ExperimentName(),
 		Topology:  exp.Metadata.Annotations["topology"],
@@ -23,7 +28,7 @@ func ExperimentToProtobuf(
 		StartTime: exp.Status.StartTime(),
 		Running:   exp.Running(),
 		Status:    string(status),
-		VmCount:   uint32(len(vms)), //nolint:gosec // integer overflow conversion int -> uint32
+		VmCount:   uint32(vmCount), //nolint:gosec // integer overflow conversion int -> uint32
 	}
 
 	pb.Vms = make([]*proto.VM, len(vms))
@@ -31,6 +36,10 @@ func ExperimentToProtobuf(
 		vm := VMToProtobuf(exp.Spec.ExperimentName(), v, exp.Spec.Topology())
 
 		pb.Vms[i] = vm
+		if exp.Running() && !vm.GetDoNotBoot() && !vm.GetExternal() {
+			pb.VmCount++
+		}
+
 		if vm.GetDelayedStart() != "" {
 			pb.DelayedVms++
 		}

--- a/src/go/web/util/protobuf_test.go
+++ b/src/go/web/util/protobuf_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"testing"
+
+	"phenix/store"
+	"phenix/types"
+	v1 "phenix/types/version/v1"
+	"phenix/util/mm"
+)
+
+func TestExperimentToProtobufVMCount(t *testing.T) {
+	external := true
+	vms := []mm.VM{
+		{Name: "booted"},
+		{Name: "delayed"},
+		{Name: "disabled", DoNotBoot: true},
+		{Name: "external"},
+	}
+
+	tests := []struct {
+		name      string
+		startTime string
+		want      uint32
+	}{
+		{
+			name: "stopped experiment counts all configured VMs",
+			want: 4,
+		},
+		{
+			name:      "running experiment excludes do-not-boot and external VMs",
+			startTime: "2026-07-31T12:00:00Z",
+			want:      2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			exp := types.NewExperiment(store.ConfigMetadata{Name: "test"})
+			exp.Spec.SetExperimentName("test")
+			exp.Spec.SetTopology(&v1.TopologySpec{
+				NodesF: []*v1.Node{
+					{GeneralF: &v1.General{HostnameF: "external"}, ExternalF: &external},
+				},
+			})
+			exp.Status.SetStartTime(test.startTime)
+
+			got := ExperimentToProtobuf(*exp, "", vms).GetVmCount()
+			if got != test.want {
+				t.Fatalf("VM count = %d, want %d", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Update running experiment summary to exclude `do_not_boot` and external VMs while preserving configured counts for stopped experiments.

## Related Issue
Closes https://github.com/sandialabs/sceptre-phenix/issues/196

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Testing: started experiment with 5 VMs and 1 external (total of 6). Verified count on experiments page was 5. Shutdown experiment, marked one VM as do not boot, started again, verified count on Experiments page is 4. Verified number shows as 6 when experiment is stopped.

Aside, VMs that are marked as DNB are not displayed anywhere when an experiment is running. This behavior is present on main branch, so wasn't introduced by this change. Might be nice to have a checkbox to hide/show DNB VMs. Ditto for External nodes.