### PR TITLE
fix(cli): show usage for invalid experiment arguments

### DIFF
--- a/src/go/cmd/experiment.go
+++ b/src/go/cmd/experiment.go
@@ -158,11 +158,8 @@ func newExperimentCreateCmd() *cobra.Command {
 		Short:   "Create an experiment",
 		Long:    desc,
 		Example: example,
+		Args:    argsWithUsage(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 1 {
-				return errors.New("must provide an experiment name")
-			}
-
 			var (
 				topology = MustGetString(cmd.Flags(), "topology")
 				scenario = MustGetString(cmd.Flags(), "scenario")
@@ -276,7 +273,7 @@ func newExperimentEditCmd() *cobra.Command {
 		Short:             "Edit an experiment",
 		Long:              desc,
 		ValidArgsFunction: expNameCompletion(false),
-		Args:              cobra.ExactArgs(1),
+		Args:              argsWithUsage(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				force = MustGetBool(cmd.Flags(), "force")
@@ -319,7 +316,7 @@ func newExperimentDeleteCmd() *cobra.Command {
 		Short:             "Delete an experiment",
 		Long:              desc,
 		ValidArgsFunction: expNameCompletion(true),
-		Args:              cobra.ExactArgs(1),
+		Args:              argsWithUsage(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				name        = args[0]
@@ -406,7 +403,7 @@ func newExperimentScheduleCmd() *cobra.Command {
 			}
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		},
-		Args: cobra.ExactArgs(scheduleArgs),
+		Args: argsWithUsage(cobra.ExactArgs(scheduleArgs)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := []experiment.ScheduleOption{
 				experiment.ScheduleForName(args[0]),
@@ -452,7 +449,7 @@ func newExperimentStartCmd() *cobra.Command {
 		Short:             "Start an experiment",
 		Long:              desc,
 		ValidArgsFunction: expNameCompletion(true),
-		Args:              cobra.ExactArgs(1),
+		Args:              argsWithUsage(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				name        = args[0]
@@ -577,7 +574,7 @@ func newExperimentStopCmd() *cobra.Command {
 		Short:             "Stop an experiment",
 		Long:              desc,
 		ValidArgsFunction: expNameCompletion(true),
-		Args:              cobra.ExactArgs(1),
+		Args:              argsWithUsage(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				name        = args[0]
@@ -650,7 +647,7 @@ func newExperimentRestartCmd() *cobra.Command {
 		Short:             "Restart an experiment",
 		Long:              desc,
 		ValidArgsFunction: expNameCompletion(true),
-		Args:              cobra.ExactArgs(1),
+		Args:              argsWithUsage(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				name        = args[0]
@@ -756,7 +753,7 @@ func newExperimentReconfigureCmd() *cobra.Command {
 		Short:             "Reconfigure an experiment",
 		Long:              desc,
 		ValidArgsFunction: expNameCompletion(true),
-		Args:              cobra.ExactArgs(1),
+		Args:              argsWithUsage(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				name        = args[0]
@@ -845,7 +842,7 @@ func newExperimentTriggerRunningCmd() *cobra.Command {
 			}
 			return matches, cobra.ShellCompDirectiveNoFileComp
 		},
-		Args: cobra.MinimumNArgs(1),
+		Args: argsWithUsage(cobra.MinimumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				name        = args[0]
@@ -932,7 +929,7 @@ func newExperimentScorchCmd() *cobra.Command {
 		Short:             "Start a Scorch run for experiment",
 		Long:              desc,
 		ValidArgsFunction: expNameCompletion(false),
-		Args:              cobra.MinimumNArgs(1),
+		Args:              argsWithUsage(cobra.MinimumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				name = args[0]

--- a/src/go/cmd/experiment_cmd_test.go
+++ b/src/go/cmd/experiment_cmd_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestExperimentCommandsShowUsageForMissingArguments(t *testing.T) {
+	tests := []struct {
+		name       string
+		newCommand func() *cobra.Command
+	}{
+		{name: "create", newCommand: newExperimentCreateCmd},
+		{name: "edit", newCommand: newExperimentEditCmd},
+		{name: "delete", newCommand: newExperimentDeleteCmd},
+		{name: "schedule", newCommand: newExperimentScheduleCmd},
+		{name: "start", newCommand: newExperimentStartCmd},
+		{name: "stop", newCommand: newExperimentStopCmd},
+		{name: "restart", newCommand: newExperimentRestartCmd},
+		{name: "reconfigure", newCommand: newExperimentReconfigureCmd},
+		{name: "trigger-running", newCommand: newExperimentTriggerRunningCmd},
+		{name: "scorch", newCommand: newExperimentScorchCmd},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := &cobra.Command{
+				Use:          "phenix",
+				SilenceUsage: true,
+			}
+			experimentCmd := newExperimentCmd()
+			experimentCmd.AddCommand(test.newCommand())
+			root.AddCommand(experimentCmd)
+			root.SetArgs([]string{"experiment", test.name})
+
+			var output bytes.Buffer
+			root.SetOut(&output)
+			root.SetErr(&output)
+
+			if _, err := root.ExecuteC(); err == nil {
+				t.Fatal("expected missing argument error")
+			}
+
+			want := "Usage:\n  phenix experiment " + test.name
+			if got := output.String(); !strings.Contains(got, want) {
+				t.Fatalf("expected output to contain %q, got:\n%s", want, got)
+			}
+		})
+	}
+}
+
+func TestExperimentScheduleUsageDescribesArgumentOrder(t *testing.T) {
+	cmd := newExperimentScheduleCmd()
+
+	err := cmd.ValidateArgs(nil)
+	if err == nil {
+		t.Fatal("expected missing argument error")
+	}
+
+	want := "Usage:\n  schedule <experiment name> <algorithm>"
+	if got := err.Error(); !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got:\n%s", want, got)
+	}
+}

--- a/src/go/cmd/root.go
+++ b/src/go/cmd/root.go
@@ -204,6 +204,16 @@ var rootCmd = &cobra.Command{
 	SilenceUsage: true, // don't print help when subcommands return an error
 }
 
+func argsWithUsage(validate cobra.PositionalArgs) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := validate(cmd, args); err != nil {
+			return fmt.Errorf("%w\n\n%s", err, strings.TrimSpace(cmd.UsageString()))
+		}
+
+		return nil
+	}
+}
+
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
## Description
Show command syntax when experiment sub-commands receive invalid positional arguments, while keeping runtime errors concise.

<img width="844" height="681" alt="image" src="https://github.com/user-attachments/assets/84e50a08-a2fc-4cd6-ad1a-c6326885cdcc" />


## Related Issue
Fixes https://github.com/sandialabs/sceptre-phenix/issues/52

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

As-is, it results in a separate sort of confusion by dumping all the global flags too. This will be addressed by https://github.com/sandialabs/sceptre-phenix/pull/305 once I finish that PR. Can wait until that's merged to merge this, or just merge it now.

Tested manually with a full deployment. 