### PR TITLE
fix(ui): sort disk image dropdowns

### DIFF
--- a/src/js/src/components/RunningExperiment.vue
+++ b/src/js/src/components/RunningExperiment.vue
@@ -1613,6 +1613,8 @@
                 for ( let i = 0;  i < state.disks.length; i++ ) {
                   this.disks.push( state.disks[i].fullPath );
                 }
+
+                this.disks.sort((a, b) => this.getBaseName(a).localeCompare(this.getBaseName(b)))
               }
             );
           },  err => {

--- a/src/js/src/components/StoppedExperiment.vue
+++ b/src/js/src/components/StoppedExperiment.vue
@@ -697,7 +697,7 @@
                   this.disks.push( state.disks[i].fullPath );
                 }
 
-                this.disks.sort()
+                this.disks.sort((a, b) => this.getBaseName(a).localeCompare(this.getBaseName(b)))
               }
             );
           }, err => {


### PR DESCRIPTION
# fix(ui): sort disk image dropdowns

## Description
Sort VM disk image dropdowns alphabetically by displayed filename.

## Related Issue
Closes [#16](https://github.com/sandialabs/sceptre-phenix/issues/16).

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Tested on a node with a stopped experiment. Previously, it would put disk images with capitalized names before lowercase, now it will include same letter with different case at same location (and also should now be consistent across deployments).