### PR TITLE
fix(vrouter): preserve configured router hostnames

### DIFF
--- a/src/go/types/version/v0/node.go
+++ b/src/go/types/version/v0/node.go
@@ -479,15 +479,7 @@ func (n Node) FileDeletions() string {
 }
 
 func (n Node) RouterName() string {
-	if !strings.EqualFold(n.TypeF, "router") {
-		return n.GeneralF.HostnameF
-	}
-
-	name := strings.ToLower(n.GeneralF.HostnameF)
-	name = strings.ReplaceAll(name, ".", "-")
-	name = strings.ReplaceAll(name, "_", "-")
-
-	return name
+	return n.GeneralF.HostnameF
 }
 
 func (h Hardware) DiskConfig(snapshot string) string {

--- a/src/go/types/version/v0/node_test.go
+++ b/src/go/types/version/v0/node_test.go
@@ -1,0 +1,16 @@
+package v0
+
+import "testing"
+
+func TestNodeRouterNamePreservesHostname(t *testing.T) {
+	const hostname = "Branch-Router-01"
+
+	node := Node{
+		TypeF:    "router",
+		GeneralF: &General{HostnameF: hostname},
+	}
+
+	if got := node.RouterName(); got != hostname {
+		t.Fatalf("RouterName() = %q, want %q", got, hostname)
+	}
+}

--- a/src/go/types/version/v1/node.go
+++ b/src/go/types/version/v1/node.go
@@ -758,15 +758,7 @@ func (n Node) FileDeletions() string {
 }
 
 func (n Node) RouterName() string {
-	if !strings.EqualFold(n.TypeF, "router") {
-		return n.GeneralF.HostnameF
-	}
-
-	name := strings.ToLower(n.GeneralF.HostnameF)
-	name = strings.ReplaceAll(name, ".", "-")
-	name = strings.ReplaceAll(name, "_", "-")
-
-	return name
+	return n.GeneralF.HostnameF
 }
 
 func (h Hardware) DiskConfig(snapshot string) string {

--- a/src/go/types/version/v1/node_test.go
+++ b/src/go/types/version/v1/node_test.go
@@ -130,3 +130,16 @@ func TestNodeValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeRouterNamePreservesHostname(t *testing.T) {
+	const hostname = "Branch-Router-01"
+
+	node := Node{
+		TypeF:    "router",
+		GeneralF: &General{HostnameF: hostname},
+	}
+
+	if got := node.RouterName(); got != hostname {
+		t.Fatalf("RouterName() = %q, want %q", got, hostname)
+	}
+}


### PR DESCRIPTION
## Description
Preserve router hostname casing so guest, topology, and C2 identifiers remain consistent.

Marking as draft so questions posted in #335 can be resolved.

## Related Issue
Closes #335.

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Untested.