### PR TITLE
feat(app): allow nodes to skip default apps

### DIFF
--- a/src/go/app/app.go
+++ b/src/go/app/app.go
@@ -46,8 +46,9 @@ const (
 	ActionRunning   Action = "running"
 	ActionCleanup   Action = "cleanup"
 
-	osWindows = "windows"
-	osLinux   = "linux"
+	defaultAppsAnnotation = "phenix/default-apps"
+	osWindows             = "windows"
+	osLinux               = "linux"
 )
 
 var (
@@ -135,6 +136,17 @@ func DefaultApps() []string {
 	}
 
 	return apps
+}
+
+func defaultAppsEnabled(node ifaces.NodeSpec) bool {
+	enabled, ok := node.GetAnnotation(defaultAppsAnnotation)
+	if !ok {
+		return true
+	}
+
+	value, ok := enabled.(bool)
+
+	return !ok || value
 }
 
 // App is the interface that identifies all the required functionality for a

--- a/src/go/app/default_apps_test.go
+++ b/src/go/app/default_apps_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"testing"
+
+	"phenix/store"
+	"phenix/types"
+	v1 "phenix/types/version/v1"
+)
+
+func TestDefaultAppsEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]any
+		want        bool
+	}{
+		{name: "annotation omitted", want: true},
+		{
+			name:        "explicitly enabled",
+			annotations: map[string]any{defaultAppsAnnotation: true},
+			want:        true,
+		},
+		{
+			name:        "explicitly disabled",
+			annotations: map[string]any{defaultAppsAnnotation: false},
+			want:        false,
+		},
+		{
+			name:        "invalid value preserves default",
+			annotations: map[string]any{defaultAppsAnnotation: "false"},
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &v1.Node{
+				AnnotationsF: tt.annotations,
+			}
+
+			if got := defaultAppsEnabled(node); got != tt.want {
+				t.Fatalf("defaultAppsEnabled() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartupSkipsNodeWithDefaultAppsDisabled(t *testing.T) {
+	node := &v1.Node{
+		AnnotationsF: map[string]any{defaultAppsAnnotation: false},
+		GeneralF: &v1.General{
+			HostnameF: "unmanaged-apps",
+		},
+		HardwareF: &v1.Hardware{
+			OSTypeF: "linux",
+			DrivesF: []*v1.Drive{{ImageF: "test.qc2"}},
+		},
+	}
+	exp := &types.Experiment{
+		Metadata: store.ConfigMetadata{Name: "default-apps-disabled"},
+		Spec: &v1.ExperimentSpec{
+			BaseDirF:  t.TempDir(),
+			TopologyF: &v1.TopologySpec{NodesF: []*v1.Node{node}},
+		},
+	}
+
+	if err := (Startup{}).PreStart(t.Context(), exp); err != nil {
+		t.Fatalf("PreStart() applied startup app to disabled node: %v", err)
+	}
+
+	if len(node.Injections()) != 0 {
+		t.Fatalf("PreStart() added %d injections to disabled node", len(node.Injections()))
+	}
+}
+
+// TestStartupChecksAlwaysRunForNodeWithDefaultAppsDisabled verifies that
+// checks/normalization that should always run (e.g. disk image presence),
+// regardless of the default-apps annotation, are not skipped by the
+// early bailout for disabled nodes.
+func TestStartupChecksAlwaysRunForNodeWithDefaultAppsDisabled(t *testing.T) {
+	node := &v1.Node{
+		AnnotationsF: map[string]any{defaultAppsAnnotation: false},
+		GeneralF: &v1.General{
+			HostnameF: "unmanaged-apps-no-drives",
+		},
+	}
+	exp := &types.Experiment{
+		Metadata: store.ConfigMetadata{Name: "default-apps-disabled-no-drives"},
+		Spec: &v1.ExperimentSpec{
+			BaseDirF:  t.TempDir(),
+			TopologyF: &v1.TopologySpec{NodesF: []*v1.Node{node}},
+		},
+	}
+
+	err := (Startup{}).PreStart(t.Context(), exp)
+	if err == nil {
+		t.Fatal("PreStart() did not return an error for disabled node missing drives")
+	}
+}

--- a/src/go/app/ntp.go
+++ b/src/go/app/ntp.go
@@ -122,7 +122,7 @@ func (NTP) preStartWithAppConfig(_ context.Context, exp *types.Experiment, ntpDi
 
 		for _, host := range app.Hosts() {
 			node := exp.Spec.Topology().FindNodeByName(host.Hostname())
-			if node == nil {
+			if node == nil || !defaultAppsEnabled(node) {
 				continue
 			}
 
@@ -210,6 +210,10 @@ func (NTP) preStartWithNodeLabels(_ context.Context, exp *types.Experiment, ntpD
 
 	// Configure topology nodes as NTP clients.
 	for _, node := range exp.Spec.Topology().Nodes() {
+		if !defaultAppsEnabled(node) {
+			continue
+		}
+
 		if _, ok := node.Labels()["ntp-server"]; ok {
 			// Don't configure NTP server nodes as clients.
 			continue

--- a/src/go/app/serial.go
+++ b/src/go/app/serial.go
@@ -26,7 +26,7 @@ func (Serial) Name() string {
 func (Serial) Configure(ctx context.Context, exp *types.Experiment) error {
 	// loop through nodes
 	for _, node := range exp.Spec.Topology().Nodes() {
-		if node.External() {
+		if node.External() || !defaultAppsEnabled(node) {
 			continue
 		}
 
@@ -75,7 +75,7 @@ func (Serial) Configure(ctx context.Context, exp *types.Experiment) error {
 func (Serial) PreStart(ctx context.Context, exp *types.Experiment) error {
 	// loop through nodes
 	for _, node := range exp.Spec.Topology().Nodes() {
-		if node.External() {
+		if node.External() || !defaultAppsEnabled(node) {
 			continue
 		}
 

--- a/src/go/app/startup.go
+++ b/src/go/app/startup.go
@@ -157,6 +157,13 @@ func (s Startup) PreStart(ctx context.Context, exp *types.Experiment) error {
 			continue
 		}
 
+		// Skip generating startup scripts/templates for this node if default
+		// apps are disabled, now that the checks/normalization above (which
+		// should always run) have been performed.
+		if !defaultAppsEnabled(node) {
+			continue
+		}
+
 		// Check to see if a scenario exists for this experiment and if it
 		// contains a "startup" app. If so, store it for later use
 		var startupApp ifaces.ScenarioApp
@@ -309,8 +316,10 @@ func (Startup) PostStart(ctx context.Context, exp *types.Experiment) error {
 			continue
 		}
 
-		if strings.EqualFold(node.Hardware().OSType(), "windows") {
-			// Windows 10 doesn't automatically run scripts in the startup folder
+		// Windows 10 doesn't automatically run scripts in the startup folder;
+		// only re-run it here if default apps (which set up that script) are
+		// enabled for this node.
+		if defaultAppsEnabled(node) && strings.EqualFold(node.Hardware().OSType(), "windows") {
 			if ver, ok := node.GetAnnotation("windows-version"); ok && (ver == "10" || ver == 10) {
 				_, err := mm.ExecC2Command(
 					mm.C2NS(exp.Metadata.Name),
@@ -326,6 +335,8 @@ func (Startup) PostStart(ctx context.Context, exp *types.Experiment) error {
 			}
 		}
 
+		// The autotunnel annotation is independent of default apps, so it is
+		// honored regardless of whether default apps are enabled for this node.
 		if annotation, ok := node.GetAnnotation("phenix/startup-autotunnel"); ok {
 			var tunnels []string
 

--- a/src/go/app/vrouter.go
+++ b/src/go/app/vrouter.go
@@ -151,6 +151,10 @@ func (v Vrouter) Configure(ctx context.Context, exp *types.Experiment) error {
 					continue
 				}
 
+				if !defaultAppsEnabled(node) {
+					continue
+				}
+
 				err := v.processACL(host.Metadata(), node.Network())
 				if err != nil {
 					return fmt.Errorf(
@@ -186,7 +190,7 @@ func (v *Vrouter) PreStart(ctx context.Context, exp *types.Experiment) error {
 
 	// loop through nodes
 	for _, node := range exp.Spec.Topology().Nodes() {
-		if node.External() {
+		if node.External() || !defaultAppsEnabled(node) {
 			continue
 		}
 
@@ -425,7 +429,7 @@ func (Vrouter) PostStart(ctx context.Context, exp *types.Experiment) error {
 	}
 
 	for _, node := range exp.Spec.Topology().Nodes() {
-		if node.External() {
+		if node.External() || !defaultAppsEnabled(node) {
 			continue
 		}
 


### PR DESCRIPTION
# feat(app): allow nodes to skip default apps

## Description
Add ability to skip default apps for a node using an annotation, `phenix/default-apps: false`. This applies to all lifecycle stages.

## Related Issue
Closes #156.

Documentation: https://github.com/sandialabs/sceptre-phenix-docs/pull/50

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Tested by adding the annotation to a VM, and verifying that the default apps don't run. Not perfect.

Test1, which has the annotation to disable default apps, and also has a injection (`1_example-injection.sh`) that test2 doesn't. 
Note the hostname is incorrect, and the 3 typical startup injections aren't present.
<img width="447" height="138" alt="image" src="https://github.com/user-attachments/assets/ba5930d0-826a-4ea6-be35-d50fe2877ecd" />

Test2, which doesn't have the annotation, but is otherwise almost identical to test1 in configuration:
<img width="466" height="173" alt="image" src="https://github.com/user-attachments/assets/961cbc64-f870-47fa-bfcd-b2fa7d86efd1" />

