### PR TITLE
feat(soh): add host file presence checks

### DIFF
--- a/src/go/api/soh/app.go
+++ b/src/go/api/soh/app.go
@@ -220,6 +220,7 @@ func (s *SOH) runChecks(ctx context.Context, exp *types.Experiment) error {
 			"network-config":      true,
 			"reachability":        true,
 			"custom-reachability": true,
+			"files":               true,
 			"processes":           true,
 			"ports":               true,
 			"custom":              true,
@@ -408,6 +409,17 @@ func (s *SOH) runChecks(ctx context.Context, exp *types.Experiment) error {
 
 	if checks["network-config"] && (checks["reachability"] || checks["custom-reachability"]) {
 		err := s.waitForReachabilityTest(ctx, ns, checks)
+		s.writeResults(exp)
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		errs = errs || err
+	}
+
+	if checks["files"] {
+		err := s.waitForFileTest(ctx, ns)
 		s.writeResults(exp)
 
 		if ctx.Err() != nil {

--- a/src/go/api/soh/soh_test.go
+++ b/src/go/api/soh/soh_test.go
@@ -1,0 +1,80 @@
+package soh
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+func TestHostStateAllStatesIncludesFiles(t *testing.T) {
+	t.Parallel()
+
+	networking := State{Success: "network configured"}
+	file := State{Success: "file found"}
+	process := State{Success: "process running"}
+
+	state := HostState{
+		Networking: []State{networking},
+		Files:      []State{file},
+		Processes:  []State{process},
+	}
+
+	want := []State{networking, file, process}
+	if got := state.AllStates(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("AllStates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSOHMetadataDecodesHostFiles(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"hostFiles": map[string][]string{
+			"server": {"/etc/injected.conf", "/opt/data.txt"},
+		},
+	}
+
+	var metadata sohMetadata
+	if err := mapstructure.Decode(input, &metadata); err != nil {
+		t.Fatalf("decoding metadata: %v", err)
+	}
+
+	if !reflect.DeepEqual(metadata.HostFiles, input["hostFiles"]) {
+		t.Fatalf("HostFiles = %#v, want %#v", metadata.HostFiles, input["hostFiles"])
+	}
+}
+
+func TestFileCheckCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		osType string
+		path   string
+		want   string
+	}{
+		{
+			name:   "linux",
+			osType: "linux",
+			path:   "/opt/user's file",
+			want:   `stat -c present -- '/opt/user'"'"'s file'`,
+		},
+		{
+			name:   "windows",
+			osType: "windows",
+			path:   `C:\Users\O'Brien\data.txt`,
+			want:   `powershell -NoProfile -Command "if (Test-Path -LiteralPath 'C:\Users\O''Brien\data.txt' -PathType Leaf) { 'present' }"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := fileCheckCommand(test.osType, test.path); got != test.want {
+				t.Fatalf("fileCheckCommand() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/src/go/api/soh/types.go
+++ b/src/go/api/soh/types.go
@@ -52,6 +52,7 @@ type HostState struct {
 	CPULoad      string  `json:"cpuLoad"                mapstructure:"cpuLoad"                structs:"cpuLoad"`
 	Networking   []State `json:"networking,omitempty"   mapstructure:"networking,omitempty"   structs:"networking,omitempty"`
 	Reachability []State `json:"reachability,omitempty" mapstructure:"reachability,omitempty" structs:"reachability,omitempty"`
+	Files        []State `json:"files,omitempty"        mapstructure:"files,omitempty"        structs:"files,omitempty"`
 	Processes    []State `json:"processes,omitempty"    mapstructure:"processes,omitempty"    structs:"processes,omitempty"`
 	Listeners    []State `json:"listeners,omitempty"    mapstructure:"listeners,omitempty"    structs:"listeners,omitempty"`
 	CustomTests  []State `json:"customTests,omitempty"  mapstructure:"customTests,omitempty"  structs:"customTests,omitempty"`
@@ -64,13 +65,14 @@ func (h HostState) AllStates() []State {
 	all := make(
 		[]State,
 		0,
-		len(h.Networking)+len(h.Reachability)+len(h.Processes)+len(h.Listeners)+len(
+		len(h.Networking)+len(h.Reachability)+len(h.Files)+len(h.Processes)+len(h.Listeners)+len(
 			h.CustomTests,
 		),
 	)
 
 	all = append(all, h.Networking...)
 	all = append(all, h.Reachability...)
+	all = append(all, h.Files...)
 	all = append(all, h.Processes...)
 	all = append(all, h.Listeners...)
 	all = append(all, h.CustomTests...)
@@ -127,6 +129,7 @@ type sohMetadata struct {
 	AppProfileKey      string                      `mapstructure:"appMetadataProfileKey"`
 	C2Timeout          string                      `mapstructure:"c2Timeout"`
 	ExitOnError        bool                        `mapstructure:"exitOnError"`
+	HostFiles          map[string][]string         `mapstructure:"hostFiles"`
 	HostListeners      map[string][]string         `mapstructure:"hostListeners"`
 	HostProcesses      map[string][]string         `mapstructure:"hostProcesses"`
 	CustomHostTests    map[string][]customHostTest `mapstructure:"hostCustomTests"`

--- a/src/go/api/soh/util.go
+++ b/src/go/api/soh/util.go
@@ -605,6 +605,66 @@ func (s *SOH) waitForReachabilityTest(ctx context.Context, ns string, checks map
 	return wg.ErrCount > 0
 }
 
+func (s *SOH) waitForFileTest(ctx context.Context, ns string) bool {
+	var (
+		logger = plog.LoggerFromContext(ctx, plog.TypeSoh)
+		wg     = new(mm.StateGroup)
+	)
+
+	for host, files := range s.md.HostFiles {
+		if _, ok := s.c2Hosts[host]; !ok {
+			logger.Debug("skipping host per config", "host", host)
+
+			continue
+		}
+
+		for _, path := range files {
+			logger.Debug("checking for file on host", "host", host, "path", path)
+			s.fileTest(ctx, wg, ns, s.nodes[host], path)
+		}
+	}
+
+	cancel := periodicallyNotify(ctx, "waiting for file tests to complete...", notifyInterval)
+
+	wg.Wait()
+	cancel()
+
+	for _, state := range wg.States {
+		var (
+			host, _ = state.Meta["host"].(string)
+			path, _ = state.Meta["path"].(string)
+		)
+
+		st := State{ //nolint:exhaustruct // partial initialization
+			Metadata:  state.Meta,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+
+		err := state.Err
+		if err != nil {
+			if errors.Is(err, mm.ErrC2ClientNotActive) {
+				delete(s.c2Hosts, host)
+			}
+
+			st.Error = err.Error()
+
+			logger.Error("[✗] file not found on host", "host", host, "path", path)
+		} else {
+			st.Success = state.Msg
+		}
+
+		hostState, ok := s.status[host]
+		if !ok {
+			hostState = HostState{Hostname: host} //nolint:exhaustruct // partial initialization
+		}
+
+		hostState.Files = append(hostState.Files, st)
+		s.status[host] = hostState
+	}
+
+	return wg.ErrCount > 0
+}
+
 //nolint:dupl // similar to waitForPortTest
 func (s *SOH) waitForProcTest(ctx context.Context, ns string) bool {
 	var (
@@ -1335,6 +1395,58 @@ func (s SOH) procTest(
 	cmd.Expected = expected
 
 	mm.ScheduleC2ParallelCommand(ctx, cmd)
+}
+
+func (s SOH) fileTest(
+	ctx context.Context,
+	wg *mm.StateGroup,
+	ns string,
+	node ifaces.NodeSpec,
+	path string,
+) {
+	var (
+		host = node.General().Hostname()
+		meta = map[string]any{"host": host, "path": path}
+	)
+
+	retries := 5
+	expected := func(resp string) error {
+		if strings.TrimSpace(resp) != "present" {
+			if retries > 0 {
+				retries--
+
+				return mm.C2RetryError{Delay: c2RetryDelay}
+			}
+
+			return errors.New("file not found")
+		}
+
+		wg.AddSuccess("file found", meta)
+
+		return nil
+	}
+
+	cmd := s.newParallelCommand(ns, host, fileCheckCommand(node.Hardware().OSType(), path))
+	cmd.Wait = wg
+	cmd.Meta = meta
+	cmd.Expected = expected
+
+	mm.ScheduleC2ParallelCommand(ctx, cmd)
+}
+
+func fileCheckCommand(osType, path string) string {
+	if strings.EqualFold(osType, "windows") {
+		path = strings.ReplaceAll(path, "'", "''")
+
+		return fmt.Sprintf(
+			`powershell -NoProfile -Command "if (Test-Path -LiteralPath '%s' -PathType Leaf) { 'present' }"`,
+			path,
+		)
+	}
+
+	path = strings.ReplaceAll(path, "'", `'"'"'`)
+
+	return fmt.Sprintf("stat -c present -- '%s'", path)
 }
 
 func (s SOH) portTest(

--- a/src/js/src/components/StateOfHealth.vue
+++ b/src/js/src/components/StateOfHealth.vue
@@ -82,6 +82,26 @@
               </b-table>
               <br>
             </div>
+            <div v-if="detailsModal.soh.files">
+              <p class="title is-6">Files</p>
+              <b-table
+                :data="detailsModal.soh.files"
+                default-sort="timestamp">
+                <b-table-column field="timestamp" label="Timestamp" sortable v-slot="props">
+                  {{ props.row.timestamp }}
+                </b-table-column>
+                <b-table-column field="path" label="Path" sortable v-slot="props">
+                  {{ props.row.metadata.path }}
+                </b-table-column>
+                <b-table-column field="success" label="Success" sortable v-slot="props">
+                  {{ props.row.success }}
+                </b-table-column>
+                <b-table-column field="error" label="Error" sortable v-slot="props">
+                  {{ props.row.error }}
+                </b-table-column>
+              </b-table>
+              <br>
+            </div>
             <div v-if="detailsModal.soh.listeners">
               <p class="title is-6">Listeners</p>
               <b-table


### PR DESCRIPTION
# feat(soh): add host file presence checks

## Description
Add cross-platform `hostFiles` checks to `soh`, and expose results for nodes in the State of Health Graph UI.

## Related Issue

Closes #19 

Documentation: https://github.com/sandialabs/sceptre-phenix-docs/pull/51

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

Tested with a topology with a file that does exist and another that doesn't. 

```yaml
hostFiles:
  test1:
    - /etc/phenix/startup/1_hostname-start.sh  # known to exist
    - /opt/test1.txt  # definitely doesn't exist
```

### SoH UI

<img width="794" height="209" alt="image" src="https://github.com/user-attachments/assets/fa7afc80-b695-4b0c-98a3-1b4a1b2e24c4" />

### CLI

<img width="1161" height="400" alt="image" src="https://github.com/user-attachments/assets/81a1edbb-795f-458a-9027-5767c354cef4" />