### PR TITLE
fix(cmd): use default root store when sudoing to root

### DIFF
--- a/src/go/cmd/root.go
+++ b/src/go/cmd/root.go
@@ -429,9 +429,13 @@ func getCurrentUserInfo() (string, string) {
 		sudo = os.Getenv("SUDO_USER")
 	)
 
-	// Only trust `SUDO_USER` env variable if we're currently running as root and,
-	// if set, use it to lookup the actual user that ran the sudo command.
-	if u.Uid == "0" && sudo != "" {
+	// `SUDO_USER` (and `SUDO_COMMAND`) remain set in the environment even after
+	// a user has escalated to a root shell (eg. via `sudo su` or `sudo -i`), so
+	// checking `SUDO_USER` alone isn't enough to determine whether phenix was
+	// invoked directly via sudo (eg. `sudo phenix ...`) versus indirectly from
+	// a root shell that was itself started via sudo. Only trust `SUDO_USER` if
+	// `SUDO_COMMAND` indicates phenix was the command actually run via sudo.
+	if u.Uid == "0" && sudo != "" && sudoRanPhenix() {
 		u, err := user.Lookup(sudo)
 		if err != nil {
 			// fall back to sudo if we couldn't get actual user
@@ -450,6 +454,35 @@ func getCurrentUserInfo() (string, string) {
 	}
 
 	return uid, home
+}
+
+// sudoRanPhenix returns true if the `SUDO_COMMAND` env variable indicates the
+// phenix executable was the command directly invoked via sudo (eg.
+// `sudo phenix ...`). It returns false if `SUDO_COMMAND` refers to something
+// else, such as `su` or `/bin/bash`, which happens when a user obtains a root
+// shell via sudo (eg. `sudo su` or `sudo -i`) and then runs phenix from that
+// shell -- in that case `SUDO_USER` should not be used to determine the
+// config/store paths, since the command is truly being run as root.
+func sudoRanPhenix() bool {
+	cmd := os.Getenv("SUDO_COMMAND")
+	if cmd == "" {
+		return false
+	}
+
+	// `SUDO_COMMAND` may include arguments, so only consider the command name.
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return false
+	}
+
+	name := filepath.Base(fields[0])
+
+	exe, err := os.Executable()
+	if err == nil && name == filepath.Base(exe) {
+		return true
+	}
+
+	return name == "phenix"
 }
 
 // getEffectiveString returns the configuration value with the following precedence:

--- a/src/go/cmd/root_test.go
+++ b/src/go/cmd/root_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSudoRanPhenix(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("unable to determine test executable: %v", err)
+	}
+
+	exeName := filepath.Base(exe)
+
+	tests := []struct {
+		name        string
+		sudoCommand string
+		want        bool
+	}{
+		{
+			name:        "empty SUDO_COMMAND",
+			sudoCommand: "",
+			want:        false,
+		},
+		{
+			name:        "sudo ran phenix directly",
+			sudoCommand: "/usr/local/bin/phenix config list",
+			want:        true,
+		},
+		{
+			name:        "sudo ran current test binary",
+			sudoCommand: exe + " -test.run TestSudoRanPhenix",
+			want:        true,
+		},
+		{
+			name:        "sudo ran su (root shell escalation)",
+			sudoCommand: "/bin/su",
+			want:        false,
+		},
+		{
+			name:        "sudo ran su dash (root shell escalation)",
+			sudoCommand: "/bin/su -",
+			want:        false,
+		},
+		{
+			name:        "sudo ran bash",
+			sudoCommand: "/bin/bash",
+			want:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SUDO_COMMAND", tc.sudoCommand)
+
+			if got := sudoRanPhenix(); got != tc.want {
+				t.Errorf("sudoRanPhenix() with SUDO_COMMAND=%q (exe=%s) = %v, want %v", tc.sudoCommand, exeName, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# fix(cmd): use default root store when sudoing to root

## Description
Use default store for root when running as root if the root user was activated using `sudo ...`, e.g. `sudo su`.

## Related Issue
Fixes #14

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
~~- [ ] I have made corresponding changes to the documentation.~~
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Tested with a phenix binary from a built container on a Ubuntu host.
