### PR TITLE
fix(ui): minimega console hangs

### DIFF
--- a/src/go/web/handlers.go
+++ b/src/go/web/handlers.go
@@ -3795,7 +3795,14 @@ func CreateConsole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cmd := exec.CommandContext(r.Context(), phenix, "mm", "--attach") //nolint:gosec // Command injection via taint analysis
+	// the console must outlive this request; r.Context() is canceled as soon
+	// as the response is written, which would SIGKILL the attach process
+	cmd := exec.CommandContext(
+		context.WithoutCancel(r.Context()),
+		phenix,
+		"mm",
+		"--attach",
+	) //nolint:gosec // Command injection via taint analysis
 
 	tty, err := pty.Start(cmd)
 	if err != nil {
@@ -3815,6 +3822,20 @@ func CreateConsole(w http.ResponseWriter, r *http.Request) {
 	ptyMu.Lock()
 	ptys[pid] = tty
 	ptyMu.Unlock()
+
+	// reap the console process when it exits and drop its dead pty
+	go func() {
+		_ = cmd.Wait()
+
+		ptyMu.Lock()
+		if t, ok := ptys[pid]; ok && t == tty {
+			_ = t.Close()
+			delete(ptys, pid)
+		}
+		ptyMu.Unlock()
+
+		plog.Debug(plog.TypeSystem, "minimega console exited", "pid", pid)
+	}()
 
 	body, _ := json.Marshal(util.WithRoot("pid", pid))
 
@@ -3860,15 +3881,14 @@ func ResizeConsole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ptyMu.Lock()
-
 	tty, ok := ptys[pid]
+	ptyMu.Unlock()
+
 	if !ok {
 		http.Error(w, "pty not found", http.StatusNotFound)
 
 		return
 	}
-
-	ptyMu.Unlock()
 
 	rows, err := strconv.ParseUint(r.FormValue("rows"), 10, 16)
 	if err != nil {
@@ -3942,15 +3962,14 @@ func WsConsole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ptyMu.Lock()
-
 	tty, ok := ptys[pid]
+	ptyMu.Unlock()
+
 	if !ok {
 		http.Error(w, "pty not found", http.StatusNotFound)
 
 		return
 	}
-
-	ptyMu.Unlock()
 
 	websocket.Handler(func(ws *websocket.Conn) {
 		defer func() { _ = tty.Close() }()


### PR DESCRIPTION
## Description
The web UI's minimega console has been dead since 85f19b3: the `phenix mm --attach` process is started with the HTTP request's context, which net/http cancels as soon as the `POST /console` response is written

This PR:
- starts the console with `context.WithoutCancel(r.Context())` so it outlives the spawning request
- reaps the process when it exits and removes its dead pty from the map
- fixes a latent deadlock: `ResizeConsole` and `WsConsole` returned with `ptyMu` still locked on the "pty not found" path

## Related Issue
Reported by @GhostofGoes while testing #320 (broken on `main` with the Vue 2 UI as well, hence the standalone fix)

## Type of Change
- [x] Bugfix

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
🤖 Generated with [Claude Code](https://claude.com/claude-code)
