### PR TITLE
fix(builder): hostnames fail topology validation

### DIFF
--- a/src/go/web/public/grapheditor/js/Dialogs.js
+++ b/src/go/web/public/grapheditor/js/Dialogs.js
@@ -1638,7 +1638,7 @@ function checkValue(graph, cell, ui) {
                 var checkLabel = vertices[i].getAttribute('label');
                 var checkHostId = parseInt(vertices[i].getId());
                 if (checkLabel == hostname && checkHostId != cellId && cellId > checkHostId) {
-                    schemaVars.general.hostname = `${schemaVars.device}_device_${host_count}`;
+                    schemaVars.general.hostname = `${schemaVars.device}-device-${host_count}`;
                     // hack to prevent ifaces/vlans from piling up in cloned node
                     try {
                         delete schemaVars.network;
@@ -1646,7 +1646,7 @@ function checkValue(graph, cell, ui) {
                     catch {
                         // console.log('network object does not exist');
                     }
-                    value.setAttribute('label', `${schemaVars.device}_device_${host_count}`);
+                    value.setAttribute('label', `${schemaVars.device}-device-${host_count}`);
                     host_count++;
                 }
             }
@@ -1709,8 +1709,8 @@ function checkValue(graph, cell, ui) {
             schemaVars.type = nodeType;
 
             if (typeof schemaVars.general === 'undefined') schemaVars.general = {};
-            schemaVars.general.hostname = `${device}_device_${host_count}`; // (cell.getId());
-            value.setAttribute('label', `${device}_device_${host_count}`);
+            schemaVars.general.hostname = `${device}-device-${host_count}`; // (cell.getId());
+            value.setAttribute('label', `${device}-device-${host_count}`);
             host_count++;
 
             if (type === 'kvm') {
@@ -1723,8 +1723,8 @@ function checkValue(graph, cell, ui) {
             schemaVars.id = 0;
 
             if (device == 'switch') {
-                schemaVars.hostname = `${device}_device_${host_count}`;
-                value.setAttribute('label', `${device}_device_${host_count}`);
+                schemaVars.hostname = `${device}-device-${host_count}`;
+                value.setAttribute('label', `${device}-device-${host_count}`);
                 schemaVars.name = searchNextVlan(vlanid).toString();
                 host_count++;
             } else {
@@ -3821,12 +3821,12 @@ var EditMiniConfigDialog = function(editorUi,vertices,edges)
                 } 
                 else{
                     config += `##Config for a ${schemaVars.device} device #${count}\n`;
-                    name = `${schemaVars.device}_device_${count}`
+                    name = `${schemaVars.device}-device-${count}`
                 }
             }
             catch {
                 config += `##Config for a ${schemaVars.device} device #${count}\n`;
-                name = `${schemaVars.device}_device_${count}`
+                name = `${schemaVars.device}-device-${count}`
             }
             value.setAttribute('label', name);
             graph.getModel().setValue(cell, value);
@@ -4592,7 +4592,7 @@ var ImportJSONDialog = function(graph, ui) {
                     obj.geometry = {width: 80, height: 80};
                     obj.value = {};
                     obj.value.schemaVars = JSON.stringify(node);
-                    obj.value.label = node.general.hostname || device + '_device_' + host_count;
+                    obj.value.label = node.general.hostname || device + '-device-' + host_count;
                     host_count++;
                     const xmlNode = enc.encode(obj.value);
                     var layer;

--- a/src/go/web/public/grapheditor/utils/schemas/container_schema.json
+++ b/src/go/web/public/grapheditor/utils/schemas/container_schema.json
@@ -39,7 +39,8 @@
           "examples": [
             "power-provider"
           ],
-          "pattern": "^[\\w-]+$"
+          "maxLength": 63,
+          "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$"
         },
         "description": {
           "$id": "#/nodes/properties/general/properties/description",

--- a/src/go/web/public/grapheditor/utils/schemas/kvm_schema.json
+++ b/src/go/web/public/grapheditor/utils/schemas/kvm_schema.json
@@ -88,7 +88,8 @@
           "examples": [
             "ADServer"
           ],
-          "pattern": "^[\\w-]+$"
+          "maxLength": 63,
+          "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$"
         },
         "description": {
           "$id": "#/nodes/properties/general/properties/description",

--- a/src/go/web/public/grapheditor/utils/schemas/node_schema.json
+++ b/src/go/web/public/grapheditor/utils/schemas/node_schema.json
@@ -79,7 +79,8 @@
           "examples": [
             "ADServer"
           ],
-          "pattern": "^[\\w-]+$"
+          "maxLength": 63,
+          "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$"
         },
         "description": {
           "$id": "#/nodes/properties/general/properties/description",

--- a/src/go/web/public/grapheditor/utils/schemas/schema.json
+++ b/src/go/web/public/grapheditor/utils/schemas/schema.json
@@ -113,7 +113,8 @@
                 "examples": [
                   "power-provider"
                 ],
-                "pattern": "^[\\w-]+$"
+                "maxLength": 63,
+                "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$"
               },
               "description": {
                 "$id": "#/properties/nodes/items/properties/general/properties/description",

--- a/src/go/web/public/grapheditor/utils/schemas/topo_schema.json
+++ b/src/go/web/public/grapheditor/utils/schemas/topo_schema.json
@@ -128,7 +128,8 @@
               "examples": [
                 "ADServer"
               ],
-              "pattern": "^[\\w-]+$"
+              "maxLength": 63,
+              "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$"
             },
             "description": {
               "$id": "#/nodes/properties/general/properties/description",
@@ -1080,7 +1081,8 @@
               "examples": [
                 "ADServer"
               ],
-              "pattern": "^[\\w-]+$"
+              "maxLength": 63,
+              "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$"
             },
             "description": {
               "$id": "#/nodes/properties/general/properties/description",


### PR DESCRIPTION
## fix(builder): hostnames fail topology validation
Builder saves fail with a validation error since 65f8e83, which restricted `minimega_node` hostnames to valid DNS labels (`^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$`, max 63 chars). The builder was never updated.

Changes:
- default node names use hyphens (`server-device-0`) in `Dialogs.js`
- the builder schemas' `minimega`-node hostname fields now carry the same pattern and `maxLength` as the server schema, so invalid hostnames are flagged while editing instead of at save
- external-node hostnames stay unrestricted, matching the server schema

## Related Issue
Reported by @GhostofGoes while testing #320 (reproducible on `main` with the Vue 2 UI, hence the standalone fix)

## Type of Change
- [x] Bugfix

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
🤖 Generated with [Claude Code](https://claude.com/claude-code)