### PR TITLE
fix(logs): web UI logs for non-UTC hosts

### DIFF
--- a/src/go/util/plog/file.go
+++ b/src/go/util/plog/file.go
@@ -211,7 +211,7 @@ func (log *LogEntry) UnmarshalJSON(data []byte) error { //nolint:funlen // compl
 				log.Time = int64(ts)
 				log.Timestamp = time.UnixMicro(log.Time).Format(TimestampFormat)
 			} else if ts, ok := value.(string); ok {
-				t, err := time.ParseInLocation(TimestampFormat, ts, time.UTC)
+				t, err := time.ParseInLocation(TimestampFormat, ts, time.Local) //nolint:gosmopolitan // zone-less local writer
 				if err != nil {
 					t, err = time.Parse(time.RFC3339Nano, ts)
 					if err != nil {

--- a/src/go/util/plog/file_test.go
+++ b/src/go/util/plog/file_test.go
@@ -1,0 +1,28 @@
+package plog
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Catches the writer/reader timezone mismatch (only reproduces when TZ != UTC).
+func TestGetLogsReturnsRecentEntry(t *testing.T) {
+	AddFileHandler(filepath.Join(t.TempDir(), "phenix.log"), GetDefaultFileHandlerOpts())
+
+	Info(TypeSystem, "recent entry for GetLogs test")
+
+	logs, err := GetLogs(time.Now().Add(-10*time.Minute), time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatalf("GetLogs: %v", err)
+	}
+
+	for _, l := range logs {
+		if strings.Contains(l.Message, "recent entry for GetLogs test") {
+			return
+		}
+	}
+
+	t.Fatalf("entry not found in recent window (got %d entries)", len(logs))
+}


### PR DESCRIPTION
## fix(logs): web UI logs for non-UTC hosts
The Logs tab always reports "Logs shown: 0" on hosts whose local timezone is not UTC. Log files are written with zone-less local timestamps (the plog file handler formats slog's local record time), but `GetLogs` parses them with `time.ParseInLocation(..., time.UTC)`. 

One-line fix: parse with `time.Local`, the same zone the writer uses.

## Related Issue
Reported by @GhostofGoes while testing #320 (reproducible on `main` with the Vue 2 UI, hence the standalone fix)

## Type of Change
- [x] Bugfix

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
🤖 Generated with [Claude Code](https://claude.com/claude-code)