### PR TITLE
fix(scorch): loop node stuck grey

### DIFF
--- a/src/go/api/scorch/app.go
+++ b/src/go/api/scorch/app.go
@@ -682,6 +682,7 @@ func executor(
 	if exe.Loop != nil {
 		update := scorch.ComponentUpdate{ //nolint:exhaustruct // partial update
 			Exp:   exp,
+			Run:   options.Run,
 			Loop:  options.Loop,
 			Stage: string(ActionLoop),
 		}


### PR DESCRIPTION
## fix(scorch): loop node stuck grey
The loop-stage pipeline update in the SCORCH executor omits the run ID so the loop node's running/success/failure status is always applied to **run 0's** pipeline.

## Related Issue
report by @GhostofGoes on #320 (reproducible on `main` with the Vue 2 UI, hence the standalone fix)

## Type of Change
- [x] Bugfix

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
🤖 Generated with [Claude Code](https://claude.com/claude-code)