### PR TITLE
fix(experiment): avoid cleanup race when stopping during delayed VM start

### DIFF
--- a/src/go/api/experiment/experiment.go
+++ b/src/go/api/experiment/experiment.go
@@ -816,6 +816,14 @@ func Start(ctx context.Context, opts ...StartOption) error {
 				if err != nil {
 					o.errChan <- fmt.Errorf("handling delayed VMs: %w", err)
 
+					// If the context was canceled, the experiment is already being
+					// stopped elsewhere (e.g. via the web UI, which cancels this
+					// context before calling Stop). Calling Stop again here would
+					// race with that in-progress stop and its cleanup, so skip it.
+					if errors.Is(ctx.Err(), context.Canceled) {
+						return
+					}
+
 					err = Stop(exp.Spec.ExperimentName())
 					if err != nil {
 						o.errChan <- fmt.Errorf("stopping experiment: %w", err)
@@ -1245,6 +1253,16 @@ func handleDelayedVMs(
 	}
 
 	if errs != nil {
+		// If the context was canceled, the experiment is already being (or is
+		// about to be) stopped elsewhere (e.g. a user requested the experiment
+		// be stopped while delayed VMs were still pending). That in-progress
+		// stop already owns tearing down the namespace, so clearing it here too
+		// would race with it and can delete resources (such as taps created by
+		// the tap app) out from under that cleanup.
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return errs //nolint:wrapcheck // returning multierror
+		}
+
 		err2 := mm.ClearNamespace(ns)
 		if err2 != nil {
 			errs = multierror.Append(errs, fmt.Errorf("killing experiment VMs: %w", err2))

--- a/src/go/api/experiment/handle_delayed_vms_test.go
+++ b/src/go/api/experiment/handle_delayed_vms_test.go
@@ -1,0 +1,112 @@
+//nolint:testpackage // testing internals
+package experiment
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+
+	"phenix/util/mm"
+)
+
+// countingMM is a test double for mm.MM that only tracks calls to
+// ClearNamespace. Embedding the (nil) mm.MM interface means any other method
+// call will panic, which is fine since these tests never exercise them.
+type countingMM struct {
+	mm.MM
+
+	mu                  sync.Mutex
+	clearNamespaceCalls int
+}
+
+func (m *countingMM) ClearNamespace(string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.clearNamespaceCalls++
+
+	return nil
+}
+
+func (m *countingMM) calls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.clearNamespaceCalls
+}
+
+// TestHandleDelayedVMsSkipsClearNamespaceOnContextCancellation verifies the
+// fix for the race where stopping an experiment (which cancels the start
+// context) while delayed VMs were still pending would cause
+// handleDelayedVMs to call mm.ClearNamespace itself. That raced with the
+// namespace teardown already being performed by the in-progress Stop call,
+// which could delete resources (e.g. taps created by the tap app) out from
+// under that cleanup. When the context is canceled, handleDelayedVMs should
+// return the error without touching the namespace.
+func TestHandleDelayedVMsSkipsClearNamespaceOnContextCancellation(t *testing.T) {
+	fake := new(countingMM)
+
+	original := mm.DefaultMM
+	t.Cleanup(func() { mm.DefaultMM = original }) //nolint:reassign // restore test double
+
+	mm.DefaultMM = fake //nolint:reassign // install test double
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Use a delay long enough that, were the context-cancellation check not
+	// hit first, the test would hang rather than silently pass.
+	delays := map[string]time.Duration{"host01": time.Minute}
+
+	err := handleDelayedVMs(ctx, "test-ns", delays, nil)
+	if err == nil {
+		t.Fatal("expected an error when the context is canceled")
+	}
+
+	merr, ok := err.(*multierror.Error) //nolint:errorlint // need access to wrapped Errors slice
+	if !ok {
+		t.Fatalf("expected *multierror.Error, got %T", err)
+	}
+
+	var foundCanceled bool
+
+	for _, e := range merr.Errors {
+		if errors.Is(e, context.Canceled) {
+			foundCanceled = true
+
+			break
+		}
+	}
+
+	if !foundCanceled {
+		t.Fatalf("expected context.Canceled among returned errors, got: %v", merr.Errors)
+	}
+
+	if calls := fake.calls(); calls != 0 {
+		t.Fatalf("expected ClearNamespace not to be called on context cancellation, called %d time(s)", calls)
+	}
+}
+
+// TestHandleDelayedVMsNoDelaysOrC2sReturnsNilWithoutClearingNamespace is a
+// sanity check that the early-return path for experiments with no delayed
+// VMs never touches the namespace either.
+func TestHandleDelayedVMsNoDelaysOrC2sReturnsNilWithoutClearingNamespace(t *testing.T) {
+	fake := new(countingMM)
+
+	original := mm.DefaultMM
+	t.Cleanup(func() { mm.DefaultMM = original }) //nolint:reassign // restore test double
+
+	mm.DefaultMM = fake //nolint:reassign // install test double
+
+	if err := handleDelayedVMs(context.Background(), "test-ns", nil, nil); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if calls := fake.calls(); calls != 0 {
+		t.Fatalf("expected ClearNamespace not to be called, called %d time(s)", calls)
+	}
+}

--- a/src/go/app/tap.go
+++ b/src/go/app/tap.go
@@ -158,6 +158,15 @@ func (Tap) Running(ctx context.Context, exp *types.Experiment) error {
 }
 
 func (t *Tap) Cleanup(ctx context.Context, exp *types.Experiment) error {
+	if _, ok := exp.Status.AppStatus()[t.Name()]; !ok {
+		// No status was ever recorded for this app, meaning its taps were never
+		// created. This happens, for example, when the app is configured to run
+		// in the post-start stage but the experiment is stopped before delayed
+		// VMs finish starting, so post-start (and thus createTaps) never runs.
+		// There's nothing to clean up in that case.
+		return nil
+	}
+
 	var status TapAppStatus
 
 	err := exp.Status.ParseAppStatus(t.Name(), &status)

--- a/src/go/app/tap_test.go
+++ b/src/go/app/tap_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"phenix/store"
+	"phenix/types"
+)
+
+// TestTapCleanupNoopWhenStatusMissing reproduces the bug where stopping an
+// experiment before a post-start tap app has run (e.g. because the
+// experiment was stopped while waiting on delayed VMs) causes Cleanup to
+// fail with "missing status for app tap", even though the app never
+// created any taps that need to be cleaned up.
+func TestTapCleanupNoopWhenStatusMissing(t *testing.T) {
+	exp := types.NewExperiment(store.ConfigMetadata{Name: "tap-cleanup-test"})
+	exp.Spec.SetExperimentName("tap-cleanup-test")
+
+	var tapApp Tap
+
+	if err := tapApp.Cleanup(context.Background(), exp); err != nil {
+		t.Fatalf("expected no error cleaning up tap app with no recorded status, got: %v", err)
+	}
+}
+
+// TestTapCleanupDeletesRecordedTaps verifies Cleanup still parses and
+// processes status when the tap app previously recorded taps it created.
+func TestTapCleanupDeletesRecordedTaps(t *testing.T) {
+	exp := types.NewExperiment(store.ConfigMetadata{Name: "tap-cleanup-test"})
+	exp.Spec.SetExperimentName("tap-cleanup-test")
+
+	// No taps recorded, but the status entry itself exists -- this should
+	// still be treated as a legitimate (empty) status rather than "missing".
+	exp.Status.SetAppStatus("tap", TapAppStatus{Host: "compute-0"})
+
+	var tapApp Tap
+
+	if err := tapApp.Cleanup(context.Background(), exp); err != nil {
+		t.Fatalf("expected no error cleaning up tap app with empty taps, got: %v", err)
+	}
+}


### PR DESCRIPTION
# Fix cleanup race when stopping an experiment during delayed VM start

## Description
When an experiment configured with delayed VMs (time-delay or C2-gated
start, see #329) is stopped while post-start apps are still waiting for
those delayed VMs to start, the context.Context passed to
handleDelayedVMs gets canceled by the stop request. Previously this
cancellation was treated the same as any other delayed-VM failure:

- handleDelayedVMs called mm.ClearNamespace itself, and
- the Start goroutine called Stop(...) a second time

both of which raced with the Stop call already in progress (triggered
by the user's stop request), which is independently running app
Cleanup stages (e.g. the tap app deleting the taps it created in
PreStart) and then clearing the namespace. The result is a race where
the namespace/taps can be torn down out from under the in-progress
Cleanup stage, surfacing as spurious errors about tap/VM resources
that no longer exist.

This PR makes handleDelayedVMs and the Start goroutine recognize
context cancellation as "a stop is already in flight elsewhere" rather
than a fresh failure to react to, so they no longer race with the
already-owned cleanup:
- handleDelayedVMs skips its own mm.ClearNamespace call when the
  aggregated error is due to ctx being canceled.
- The Start goroutine skips its redundant Stop(...) call when
  handleDelayedVMs failed because ctx was canceled.

A unit test (handle_delayed_vms_test.go) was added that reproduces
the race directly: with a canceled context and a pending delayed VM,
it asserts mm.ClearNamespace is not invoked. It fails against the
pre-fix code and passes with the fix, including under -race.

### Update: tap app cleanup failure when post-start never ran
A related issue surfaced once the race above was fixed: if the tap app
is configured with `stage: post-start` (the default) and the
experiment is stopped before delayed VMs finish starting, `PostStart`
(and thus `createTaps`) never executes, so no status is ever recorded
for the tap app. The subsequent `Cleanup` call would unconditionally
call `ParseAppStatus`, which failed with:

```
cleaning up app experiments: applying user app tap for action cleanup: getting experiment status for tap app: missing status for app tap
```

`Cleanup` now checks `exp.Status.AppStatus()` for an entry before
parsing it, and treats a missing entry as a no-op, since there are no
taps to delete in that case.

A test (tap_test.go) reproduces this exact error message against the
pre-fix code and passes with the fix, plus a companion test asserting
`Cleanup` still processes a legitimate (even if empty) recorded status.

## Related Issue
Follow-up to #329.

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the Contributing Guide.
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
- Added src/go/api/experiment/handle_delayed_vms_test.go, following the
  existing test-double convention in src/go/app/user_test.go (swapping
  mm.DefaultMM with a struct embedding the mm.MM interface).
- Added src/go/app/tap_test.go covering the tap app Cleanup no-op fix.
- Verified via go build/go vet/go test -race for phenix/api/experiment
  and phenix/app (the only packages touched).
- Confirmed both new tests fail on the pre-fix code and pass with the fix.
- Commits squashed into a single commit for review.

Manually tested multiple combos of tap app with delayed start VMs and premature experiment stops. Confirmed that stops and cleanup occurs without error.
